### PR TITLE
feat: pick an install target from a list, and reset a failed provisioning run

### DIFF
--- a/middleware/migrations/0050_agent_context_memory_flag.sql
+++ b/middleware/migrations/0050_agent_context_memory_flag.sql
@@ -29,7 +29,9 @@ ALTER TABLE agents
 DO $$
 BEGIN
   IF NOT EXISTS (
-    SELECT 1 FROM pg_constraint WHERE conname = 'agents_context_memory_check'
+    SELECT 1 FROM pg_constraint
+     WHERE conname = 'agents_context_memory_check'
+       AND conrelid = 'agents'::regclass
   ) THEN
     ALTER TABLE agents
       ADD CONSTRAINT agents_context_memory_check

--- a/middleware/migrations/0052_agent_identities.sql
+++ b/middleware/migrations/0052_agent_identities.sql
@@ -62,14 +62,18 @@ CREATE TABLE IF NOT EXISTS agent_identities (
 DO $$
 BEGIN
   IF NOT EXISTS (
-    SELECT 1 FROM pg_constraint WHERE conname = 'agent_identities_accent_color_check'
+    SELECT 1 FROM pg_constraint
+     WHERE conname = 'agent_identities_accent_color_check'
+       AND conrelid = 'agent_identities'::regclass
   ) THEN
     ALTER TABLE agent_identities
       ADD CONSTRAINT agent_identities_accent_color_check
       CHECK (accent_color IS NULL OR accent_color ~ '^#[0-9A-Fa-f]{6}$');
   END IF;
   IF NOT EXISTS (
-    SELECT 1 FROM pg_constraint WHERE conname = 'agent_identities_revision_check'
+    SELECT 1 FROM pg_constraint
+     WHERE conname = 'agent_identities_revision_check'
+       AND conrelid = 'agent_identities'::regclass
   ) THEN
     ALTER TABLE agent_identities
       ADD CONSTRAINT agent_identities_revision_check

--- a/middleware/migrations/0055_agent_teams_app_object_id.sql
+++ b/middleware/migrations/0055_agent_teams_app_object_id.sql
@@ -1,0 +1,62 @@
+-- ── Agent factory: remember the Entra app's DIRECTORY OBJECT id ────────────
+-- Adds `app_object_id` to `agent_teams_identities`.
+--
+-- WHY A SECOND IDENTIFIER FOR THE SAME APPLICATION
+-- -----------------------------------------------
+-- An Entra application has two ids and they are not interchangeable:
+--
+--   * `appId` — the client id. It is what the bot authenticates with, what
+--     the Teams manifest carries as `bots[0].botId`, and it is the only one
+--     the row has stored until now (`app_id`).
+--   * `objectId` — the directory object id. It is what
+--     `DELETE /applications/{id}` and `DELETE /directory/deletedItems/{id}`
+--     address.
+--
+-- Provisioning only ever needed the first. TEARDOWN needs the second, and it
+-- needs it at a moment when it can no longer be looked up.
+--
+-- THE 30-DAY TRAP THIS COLUMN EXISTS TO CLOSE
+-- -------------------------------------------
+-- Deleting an Entra application does not remove it. It goes to the
+-- directory's recycle bin for 30 days and KEEPS RESERVING ITS `uniqueName`
+-- while it is there. omadia derives that name from the operator's bot slug
+-- (`omadia-teams-bot-<botSlug>`, see `services/teamsProvisioningJob.ts`), so
+-- a teardown that deletes without purging does not restore the starting
+-- position — it makes the operator's next attempt with the same slug collide
+-- with the corpse of the previous one. That is byte5ai/omadia#916, and it
+-- cost a slug for a month.
+--
+-- The purge needs the OBJECT id. And the moment the delete lands, the
+-- application is gone from `/applications`, so `getAppRegistration` can no
+-- longer turn the `appId` we do have into the `objectId` we need. There is
+-- exactly one window in which the pair can be observed together — before the
+-- delete — so the object id has to be written down then or it is lost.
+--
+-- Hence a persisted column rather than a lookup:
+--
+--   * it is captured when the registration is CREATED (the connector returns
+--     both ids from `createAppRegistration`), so an identity provisioned
+--     from now on is purgeable even if the process dies mid-teardown;
+--   * a reset re-captures and PERSISTS it before it deletes anything, so a
+--     row that predates this migration becomes purgeable on its way through;
+--   * and because it survives the delete, an interrupted teardown can be
+--     resumed: the second call still knows what to purge.
+--
+-- NULLABLE, WITH NO BACKFILL
+-- --------------------------
+-- Existing rows genuinely do not know their object id — it was never
+-- returned to anything that persisted it, and a migration cannot ask Graph.
+-- `NULL` is the honest value and the reset path is written for it: it
+-- resolves the id live (the application still exists at that point, so the
+-- lookup works), writes it here, and only then deletes. The one case that
+-- stays unrecoverable is a row whose application was ALREADY deleted by hand
+-- before this migration — nothing can name that tombstone any more, and the
+-- reset reports it rather than pretending.
+--
+-- Idempotent by construction (ADD COLUMN IF NOT EXISTS), because schema CI
+-- double-applies every file in this series.
+
+ALTER TABLE agent_teams_identities
+  ADD COLUMN IF NOT EXISTS app_object_id TEXT;
+
+-- rollback: ALTER TABLE agent_teams_identities DROP COLUMN app_object_id;

--- a/middleware/migrations/0056_repair_unscoped_check_constraints.sql
+++ b/middleware/migrations/0056_repair_unscoped_check_constraints.sql
@@ -1,0 +1,68 @@
+-- Repair CHECK constraints that an unscoped existence probe silently skipped
+-- (byte5ai/omadia#952).
+--
+-- 0050 and 0052 decided whether to add their CHECK constraints by asking
+-- `pg_constraint` for the constraint NAME alone:
+--
+--     IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = '…')
+--
+-- Constraint names are unique per table, not per database. Any other schema
+-- carrying a constraint of that name — a parallel test schema, a restored
+-- snapshot, a second tenant — satisfies the probe. The migration then skips
+-- creating the constraint AND REPORTS SUCCESS, leaving the column with no
+-- validation at all while every log line says the schema is up to date.
+--
+-- The probes themselves are fixed in 0050 and 0052, which covers databases
+-- created from now on. It does nothing for a database that already ran the
+-- broken version: a migration that has been applied is never applied again.
+-- Hence this one, which re-checks each constraint the correct way — scoped by
+-- `conrelid` — and adds whatever is genuinely missing.
+--
+-- On a healthy database (including this project's production, verified before
+-- writing this) all three already exist and every block below is a no-op.
+--
+-- DELIBERATELY NOT `NOT VALID`. If a row violates one of these, the ADD fails
+-- and this migration stops — which is the honest outcome, because the same
+-- data would have failed on a fresh install too. Adding the constraint as
+-- unvalidated would hide bad rows behind a constraint that looks enforced,
+-- and the point of this file is to stop exactly that kind of quiet lie.
+
+DO $$
+BEGIN
+  -- 0050: agents.context_memory
+  IF EXISTS (SELECT 1 FROM pg_class WHERE relname = 'agents' AND relkind = 'r')
+     AND NOT EXISTS (
+       SELECT 1 FROM pg_constraint
+        WHERE conname = 'agents_context_memory_check'
+          AND conrelid = 'agents'::regclass
+     ) THEN
+    ALTER TABLE agents
+      ADD CONSTRAINT agents_context_memory_check
+      CHECK (context_memory IN ('off', 'enforce', 'enforce-strict'));
+  END IF;
+
+  -- 0052: agent_identities.accent_color
+  IF EXISTS (SELECT 1 FROM pg_class WHERE relname = 'agent_identities' AND relkind = 'r')
+     AND NOT EXISTS (
+       SELECT 1 FROM pg_constraint
+        WHERE conname = 'agent_identities_accent_color_check'
+          AND conrelid = 'agent_identities'::regclass
+     ) THEN
+    ALTER TABLE agent_identities
+      ADD CONSTRAINT agent_identities_accent_color_check
+      CHECK (accent_color IS NULL OR accent_color ~ '^#[0-9A-Fa-f]{6}$');
+  END IF;
+
+  -- 0052: agent_identities.revision
+  IF EXISTS (SELECT 1 FROM pg_class WHERE relname = 'agent_identities' AND relkind = 'r')
+     AND NOT EXISTS (
+       SELECT 1 FROM pg_constraint
+        WHERE conname = 'agent_identities_revision_check'
+          AND conrelid = 'agent_identities'::regclass
+     ) THEN
+    ALTER TABLE agent_identities
+      ADD CONSTRAINT agent_identities_revision_check
+      CHECK (revision >= 1);
+  END IF;
+END
+$$;

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -51,6 +51,8 @@ import { AgentIdentityStore } from './platform/agentIdentityStore.js';
 import { AgentTeamsInstallStore } from './platform/agentTeamsInstallStore.js';
 import { TeamsProvisioningEventStore } from './platform/teamsProvisioningEventStore.js';
 import { TeamsDelegatedTokenStore } from './platform/teamsDelegatedTokenStore.js';
+import type { DelegatedTokenSet } from './platform/teamsDelegatedSignIn.js';
+import type { TeamsResetEventSink } from './services/teamsIdentityReset.js';
 import { TeamsDelegatedSignInService } from './services/teamsDelegatedSignInService.js';
 import { createOperatorTeamsSignInRouter } from './routes/operatorTeamsSignIn.js';
 import { TeamsProvisioningJobRunner } from './services/teamsProvisioningJob.js';
@@ -3457,6 +3459,7 @@ async function main(): Promise<void> {
               displayName: record.displayName,
               state: record.state as never,
               appId: record.appId,
+              appObjectId: record.appObjectId ?? null,
               tenantId: record.tenantId,
               teamsAppId: record.teamsAppId,
               teamsAppExternalId: record.teamsAppExternalId,
@@ -3475,10 +3478,27 @@ async function main(): Promise<void> {
         const eventStore = serviceRegistry.get<OperatorTeamsEventStore>(
           'teamsProvisioningEventStore',
         );
-        const withEvents: OperatorTeamsIdentityDeps =
-          eventStore === undefined
-            ? teamsDeps
-            : { ...teamsDeps, events: eventStore };
+        // The teardown writes to the SAME table the runner does, so it lands
+        // on the operator's existing timeline instead of a second screen. The
+        // WRITE side is bound separately from the read side above: this
+        // router has been a pure reader of that log since #915, and the reset
+        // is the one thing it does that an operator watches happen.
+        const eventWriter = serviceRegistry.get<TeamsResetEventSink>(
+          'teamsProvisioningEventStore',
+        );
+        // #924/#949 — withdrawing the app from the tenant catalog is
+        // delegated-only at Microsoft, exactly like uploading it. Resolved
+        // live for the same reason as the provisioner: an admin can sign in
+        // (or out) while the process runs.
+        const delegatedTokens = serviceRegistry.get<{
+          read(): Promise<DelegatedTokenSet | undefined>;
+        }>('teamsDelegatedTokenStore');
+        const withEvents: OperatorTeamsIdentityDeps = {
+          ...teamsDeps,
+          ...(eventStore === undefined ? {} : { events: eventStore }),
+          ...(eventWriter === undefined ? {} : { eventWriter }),
+          ...(delegatedTokens === undefined ? {} : { delegatedTokens }),
+        };
         if (installStore === undefined) return withEvents;
         return { ...withEvents, installs: installStore };
       },

--- a/middleware/src/platform/agentTeamsIdentityStore.ts
+++ b/middleware/src/platform/agentTeamsIdentityStore.ts
@@ -78,6 +78,19 @@ export interface AgentTeamsIdentityRecord {
    */
   readonly targetKind: TeamsTargetKind;
   readonly appId: string | null;
+  /**
+   * The Entra application's DIRECTORY OBJECT id (migration 0055) — a
+   * different identifier from {@link appId}, and the only one the
+   * recycle-bin purge accepts.
+   *
+   * `null` on rows provisioned before migration 0055 and on rows whose
+   * registration does not exist yet. See the migration on why it is stored
+   * rather than looked up: after `DELETE /applications/{id}` the application
+   * is gone from `/applications`, so the appId → objectId lookup that would
+   * have produced it no longer works — and without it the deleted app sits
+   * in the recycle bin holding this agent's `uniqueName` for 30 days.
+   */
+  readonly appObjectId: string | null;
   readonly tenantId: string | null;
   readonly teamsAppId: string | null;
   readonly teamsAppExternalId: string | null;
@@ -106,10 +119,18 @@ export interface AgentTeamsIdentityUpdate {
   readonly teamId?: string | null;
   /** Set together with {@link teamId} when a request re-targets the row. */
   readonly targetKind?: TeamsTargetKind;
-  readonly appId?: string;
-  readonly tenantId?: string;
-  readonly teamsAppId?: string;
-  readonly teamsAppExternalId?: string;
+  /**
+   * The four Azure identifiers accept `null` as well as a value: the
+   * provisioning chain only ever writes them, but a teardown
+   * (`services/teamsIdentityReset.ts`) has to CLEAR them, and a row that
+   * kept pointing at a purged app registration would send the next run
+   * looking for something that is not there any more.
+   */
+  readonly appId?: string | null;
+  readonly appObjectId?: string | null;
+  readonly tenantId?: string | null;
+  readonly teamsAppId?: string | null;
+  readonly teamsAppExternalId?: string | null;
   /** `null` clears a previous error. */
   readonly lastError?: string | null;
 }
@@ -157,7 +178,7 @@ export class AgentTeamsIdentityStateError extends Error {
 // ---------------------------------------------------------------------------
 
 const COLUMNS =
-  'agent_id, bot_slug, display_name, state, team_id, target_kind, app_id, tenant_id, teams_app_id, teams_app_external_id, last_error, created_at, updated_at';
+  'agent_id, bot_slug, display_name, state, team_id, target_kind, app_id, app_object_id, tenant_id, teams_app_id, teams_app_external_id, last_error, created_at, updated_at';
 
 interface AgentTeamsIdentityRow {
   agent_id: string;
@@ -167,6 +188,7 @@ interface AgentTeamsIdentityRow {
   team_id: string | null;
   target_kind: TeamsTargetKind;
   app_id: string | null;
+  app_object_id: string | null;
   tenant_id: string | null;
   teams_app_id: string | null;
   teams_app_external_id: string | null;
@@ -188,6 +210,7 @@ function mapRow(row: AgentTeamsIdentityRow): AgentTeamsIdentityRecord {
     teamId: row.team_id,
     targetKind: row.target_kind,
     appId: row.app_id,
+    appObjectId: row.app_object_id,
     tenantId: row.tenant_id,
     teamsAppId: row.teams_app_id,
     teamsAppExternalId: row.teams_app_external_id,
@@ -292,6 +315,7 @@ export class AgentTeamsIdentityStore {
     if (patch.teamId !== undefined) add('team_id', patch.teamId);
     if (patch.targetKind !== undefined) add('target_kind', patch.targetKind);
     if (patch.appId !== undefined) add('app_id', patch.appId);
+    if (patch.appObjectId !== undefined) add('app_object_id', patch.appObjectId);
     if (patch.tenantId !== undefined) add('tenant_id', patch.tenantId);
     if (patch.teamsAppId !== undefined) add('teams_app_id', patch.teamsAppId);
     if (patch.teamsAppExternalId !== undefined) {
@@ -326,6 +350,48 @@ export class AgentTeamsIdentityStore {
       state: 'catalog_uploaded',
       teamId: null,
       targetKind: 'team',
+      lastError: null,
+    });
+  }
+
+  /**
+   * Return the row to the position it held before anything was provisioned —
+   * the last act of a teardown (`services/teamsIdentityReset.ts`).
+   *
+   * A RESET, NOT A ROW DELETION. `bot_slug` and `display_name` are the only
+   * two fields in this row a human typed; every other one is an identifier
+   * Azure handed back. Dropping the row would throw the operator's two
+   * answers away and make them retype both to try again — and because
+   * `bot_slug` is `UNIQUE`, dropping it also silently changes what a
+   * re-create is allowed to be called. Keeping them means the retry is one
+   * button, with the same slug, which is the whole reason someone asked for
+   * this in the first place.
+   *
+   * `state` goes to `'pending'` rather than to some intermediate rank because
+   * by the time this runs the Entra app, the Azure bot and the catalog entry
+   * are all provably gone — the caller does not reach this step otherwise.
+   * That is exactly the difference from {@link clearTeamInstall}, which stops
+   * at `'catalog_uploaded'` precisely because those three still exist.
+   *
+   * The Azure identifiers are NULLed for the same reason: a row that kept a
+   * purged `app_id` would let the chain's evidence guards skip step 1 and
+   * then build a bot on an application that is not there any more.
+   *
+   * ON THE ORDER OF WRITES. This is the LAST thing a teardown does, never the
+   * first. `app_object_id` is what makes an interrupted purge resumable, so
+   * clearing it before the purge landed would destroy the only pointer to the
+   * tombstone holding this agent's `uniqueName`.
+   */
+  async resetForRetry(agentId: string): Promise<AgentTeamsIdentityRecord> {
+    return this.update(agentId, {
+      state: 'pending',
+      teamId: null,
+      targetKind: 'team',
+      appId: null,
+      appObjectId: null,
+      tenantId: null,
+      teamsAppId: null,
+      teamsAppExternalId: null,
       lastError: null,
     });
   }

--- a/middleware/src/platform/agentTeamsInstallStore.ts
+++ b/middleware/src/platform/agentTeamsInstallStore.ts
@@ -197,4 +197,34 @@ export class AgentTeamsInstallStore {
     );
     return (res.rowCount ?? 0) > 0;
   }
+
+  /**
+   * Drop EVERY binding of one agent, returning how many there were — the
+   * teardown's counterpart to {@link remove}
+   * (`services/teamsIdentityReset.ts`).
+   *
+   * Why a bulk call rather than a loop over {@link listForAgent}: the rows
+   * this table holds are the record of what omadia INSTALLED, and after a
+   * teardown has withdrawn the app from the tenant catalog none of them
+   * describes anything that still exists. Deleting them one id at a time
+   * would leave a half-emptied read model behind if the process died in the
+   * middle, and the operator screen would go on listing installs that Graph
+   * has no memory of.
+   *
+   * `0` is an ordinary answer, not an error: an identity that never reached
+   * the install step has no bindings to drop, and a teardown resumed after an
+   * interruption finds the table already empty. Both are success.
+   *
+   * NOTE the cascade this does NOT rely on. `agent_teams_installs` cascades
+   * from `agent_teams_identities`, but a teardown keeps the identity row
+   * (only its Azure identifiers are cleared), so nothing deletes these rows
+   * for us. They have to be removed explicitly, which is what this is for.
+   */
+  async removeAllForAgent(agentId: string): Promise<number> {
+    const res = await this.pool.query(
+      `DELETE FROM agent_teams_installs WHERE agent_id = $1`,
+      [agentId],
+    );
+    return res.rowCount ?? 0;
+  }
 }

--- a/middleware/src/platform/teamsProvisionerCleanup.ts
+++ b/middleware/src/platform/teamsProvisionerCleanup.ts
@@ -1,0 +1,263 @@
+/**
+ * The TEARDOWN half of `teamsProvisioner@1` — the primitives a failed
+ * provisioning run needs in order to be undone, plus the vocabulary the
+ * teardown reports itself in.
+ *
+ * WHY A TEARDOWN EXISTS AT ALL
+ * ----------------------------
+ * A run that dies in the middle leaves real objects behind: an Entra app
+ * registration, an Azure bot service, a tenant catalog entry. Until now an
+ * operator cleaned those up by hand in two Azure portals before they could
+ * try again, and the identity row kept pointing at whichever of them had
+ * survived.
+ *
+ * THE PURGE IS THE WHOLE POINT
+ * ----------------------------
+ * A deleted Entra application does not disappear. It goes to the directory's
+ * recycle bin for 30 days and — this is the part that costs a month —
+ * KEEPS RESERVING ITS `uniqueName` while it sits there. omadia derives that
+ * name from the operator's bot slug (`omadia-teams-bot-<botSlug>`), so a
+ * teardown that deletes without purging does not restore the starting
+ * position: it makes the next attempt with the same slug collide with the
+ * corpse of the previous one. That is byte5ai/omadia#916, and it burned a
+ * slug for a month.
+ *
+ * So {@link TeamsProvisionerCleanupMethods.purgeDeletedAppRegistration} is
+ * not an optimisation of the delete, it is the second half of it, and the
+ * caller is required to treat the pair as ONE operation
+ * (`services/teamsIdentityReset.ts` enforces that: it refuses to delete at
+ * all when it cannot purge).
+ *
+ * AND THE PURGE NEEDS THE OBJECT ID, NOT THE APP ID
+ * -------------------------------------------------
+ * `DELETE /applications/{objectId}` and
+ * `DELETE /directory/deletedItems/{objectId}` both address the DIRECTORY
+ * OBJECT. `appId` — the client id — is a different identifier and the
+ * deleted-items endpoint does not accept it. Once the application is in the
+ * recycle bin it is gone from `/applications`, so `getAppRegistration` can no
+ * longer resolve one identifier into the other: after the delete, the object
+ * id is either already written down or lost, and losing it means losing the
+ * slug for 30 days.
+ *
+ * There are therefore TWO independent bridges from the `appId` everyone still
+ * has to the `objectId` the purge needs, and the teardown uses whichever it
+ * can get:
+ *
+ *   * `app_object_id` (migration 0055) — written when the registration is
+ *     created and re-written before any delete, so the id is on the row
+ *     before the window where losing it hurts;
+ *   * {@link TeamsProvisionerCleanupMethods.findDeletedAppRegistration} — a
+ *     search of the recycle bin BY `appId`, which works after the delete and
+ *     therefore rescues rows that predate the column entirely.
+ *
+ * Neither alone is enough: the column cannot help a row provisioned before it
+ * existed, and the search cannot help against a connector too old to publish
+ * it. Together they leave exactly one unrecoverable case — an application
+ * deleted by hand, by someone else, before either mechanism saw it.
+ *
+ * VERSION SKEW, AS ALWAYS. Every method here is OPTIONAL on the accessor, each
+ * with its own predicate — see the module doc of
+ * `teamsProvisionerService.ts`, which re-exports everything here so consumers
+ * keep their single import site.
+ */
+
+import type { DelegatedTokenSet } from './teamsDelegatedSignIn.js';
+
+/**
+ * Outcome vocabulary shared by every teardown primitive.
+ *
+ * `'already-absent'` IS A SUCCESS, and saying so in the type is the point:
+ * a teardown is run precisely when nobody knows what still exists, so "it was
+ * not there" answers the question the caller asked. Modelling it as an error
+ * would make the second run of an interrupted reset fail on everything the
+ * first run managed to finish — which is the opposite of resumable.
+ */
+export type CleanupOutcome<Done extends string> = Done | 'already-absent';
+
+/** Input of {@link TeamsProvisionerCleanupMethods.purgeDeletedAppRegistration}. */
+export interface PurgeDeletedAppRegistrationInput {
+  /**
+   * The DIRECTORY OBJECT id of the deleted application — NOT its `appId`.
+   * See the module doc: the deleted-items endpoint knows no other name for
+   * it, and after the delete there is no way left to look it up.
+   */
+  readonly objectId: string;
+}
+
+export interface PurgeDeletedAppRegistrationResult {
+  readonly outcome: CleanupOutcome<'purged'>;
+}
+
+/** Input of {@link TeamsProvisionerCleanupMethods.findDeletedAppRegistration}. */
+export interface FindDeletedAppRegistrationInput {
+  /**
+   * The application's CLIENT id — the identifier that survives in the row
+   * (`agent_teams_identities.app_id`) and in the Teams manifest, and the only
+   * one anybody still has once the delete has landed.
+   */
+  readonly appId: string;
+}
+
+/**
+ * `found: false` is the good news: no tombstone, so the `uniqueName` is free
+ * and there is nothing left to purge. It is deliberately NOT the same answer
+ * as "we could not look" — a connector too old to search reports its absence
+ * through {@link supportsDeletedAppRegistrationLookup}, so the caller can
+ * tell "provably gone" from "no idea".
+ */
+export type FindDeletedAppRegistrationResult =
+  | { readonly found: true; readonly objectId: string }
+  | { readonly found: false };
+
+/**
+ * The purge was handed an `appId` where a DIRECTORY OBJECT id belongs
+ * (connector >= 0.8.0).
+ *
+ * Worth a typed error rather than a 404 because the two identifiers are both
+ * GUIDs: the mistake is invisible in a log line, and Graph's own answer
+ * ("Resource not found") points at the wrong problem entirely — it reads as
+ * "already purged" when in fact the tombstone is sitting right there holding
+ * the agent's `uniqueName`. THAT is the misreading this error exists to stop,
+ * and it is why nothing in this codebase may treat a 404 from the purge as
+ * proof of a clean recycle bin.
+ *
+ * The connector resolves the correct id while it is refusing, and ships it on
+ * {@link objectId} — so the recovery is one retry with the value the error
+ * itself carries, not a second search.
+ *
+ * Duck-typed on `name`, like every other connector error guard: the class
+ * identity belongs to the plugin, not to us.
+ */
+export interface DeletedObjectIdMismatchLike extends Error {
+  readonly name: 'DeletedObjectIdMismatchError';
+  /** The directory object id the call SHOULD have been given. */
+  readonly objectId?: string;
+}
+
+export function isDeletedObjectIdMismatchError(
+  err: unknown,
+): err is DeletedObjectIdMismatchLike {
+  return err instanceof Error && err.name === 'DeletedObjectIdMismatchError';
+}
+
+/** The corrected object id a {@link DeletedObjectIdMismatchLike} carries, when
+ *  it carries one. A connector that refuses without naming the right id is
+ *  still handled — the caller falls back to searching the recycle bin. */
+export function correctedObjectIdOf(err: unknown): string | undefined {
+  if (!isDeletedObjectIdMismatchError(err)) return undefined;
+  const { objectId } = err;
+  return typeof objectId === 'string' && objectId !== '' ? objectId : undefined;
+}
+
+/** Input of {@link TeamsProvisionerCleanupMethods.removeFromCatalog}. */
+export interface RemoveFromCatalogInput {
+  /** Catalog id (`CatalogTeamsApp.teamsAppId`) — NOT the external id. */
+  readonly teamsAppId: string;
+  /**
+   * REQUIRED, unlike everywhere else the delegated token set appears.
+   * `DELETE /appCatalogs/teamsApps/{id}` is delegated-only at Microsoft for
+   * the same reason the upload is (#924): Application permissions are
+   * documented as "Not supported". A teardown therefore cannot remove the
+   * catalog entry of a tenant nobody has signed into, and the honest answer
+   * is to report that step as blocked rather than to try app-only and
+   * classify the 403 afterwards.
+   *
+   * NO NEW CONSENT, though: the existing delegated `AppCatalog.ReadWrite.All`
+   * already covers the delete, so a tenant that can be provisioned can also
+   * be torn down. Whoever is signed in today is enough — unlike chat
+   * enumeration, which does need a fresh sign-in
+   * (`platform/teamsTargetDirectory.ts`).
+   */
+  readonly tokens: DelegatedTokenSet;
+}
+
+export interface RemoveFromCatalogResult {
+  readonly outcome: CleanupOutcome<'removed'>;
+}
+
+/**
+ * The teardown methods, as an interface of its own so the accessor can
+ * mix it in with `Partial<…>` (same construction as
+ * `TeamsDelegatedProvisionerMethods` and `TeamsTargetDirectoryMethods`).
+ *
+ * The other two primitives a reset needs — `deleteAppRegistration` and
+ * `deleteBot` — are NOT here: they have been on the mandatory surface of
+ * `TeamsProvisionerAccessor` since the first wave, and duplicating them into
+ * an optional mixin would make two shipped methods look like they might be
+ * missing.
+ */
+export interface TeamsProvisionerCleanupMethods {
+  /** Empty the recycle bin of ONE deleted application — the half of the
+   *  delete that gives the `uniqueName` back. */
+  purgeDeletedAppRegistration(
+    input: PurgeDeletedAppRegistrationInput,
+  ): Promise<PurgeDeletedAppRegistrationResult>;
+  /**
+   * Look up a deleted application in the directory's recycle bin BY ITS
+   * CLIENT ID, and answer with the object id the purge needs.
+   *
+   * THIS IS WHAT MAKES AN INTERRUPTED TEARDOWN SURVIVABLE. Without it the
+   * only bridge from the identifier everyone still has (`appId`) to the one
+   * the purge requires (`objectId`) is `getAppRegistration` — which stops
+   * working the instant the delete lands, i.e. exactly in the window where an
+   * interruption hurts. A teardown that died between the delete and the purge
+   * could then never find its own tombstone again, and the agent's
+   * `uniqueName` stayed reserved for 30 days (byte5ai/omadia#916).
+   *
+   * With this method the recovery is mechanical: the row still carries
+   * `app_id` (the teardown clears it only after the purge is confirmed), so a
+   * second call searches, finds, and finishes.
+   */
+  findDeletedAppRegistration(
+    input: FindDeletedAppRegistrationInput,
+  ): Promise<FindDeletedAppRegistrationResult>;
+  /** Withdraw the agent's app from the tenant app catalog. */
+  removeFromCatalog(input: RemoveFromCatalogInput): Promise<RemoveFromCatalogResult>;
+}
+
+/** Method names of this half, as data — so a forwarder cannot drift from the
+ *  interface above. */
+export const CLEANUP_METHOD_NAMES = [
+  'purgeDeletedAppRegistration',
+  'findDeletedAppRegistration',
+  'removeFromCatalog',
+] as const satisfies readonly (keyof TeamsProvisionerCleanupMethods)[];
+
+/**
+ * Does the CURRENTLY INSTALLED connector publish the recycle-bin purge?
+ *
+ * THE MOST CONSEQUENTIAL GUARD IN THIS FILE. A `false` here does not degrade
+ * the teardown, it FORBIDS the app-registration step entirely: deleting
+ * without purging is strictly worse than not deleting, because it converts a
+ * reusable registration into a 30-day reservation on the operator's own slug.
+ * `services/teamsIdentityReset.ts` is where that refusal lives.
+ */
+export function supportsAppRegistrationPurge(
+  provisioner: { readonly purgeDeletedAppRegistration?: unknown } | undefined,
+): boolean {
+  return typeof provisioner?.purgeDeletedAppRegistration === 'function';
+}
+
+/**
+ * Does it publish the recycle-bin lookup?
+ *
+ * Its absence is not fatal — a stored `app_object_id` (migration 0055) covers
+ * the same ground for every identity provisioned since — but it IS the
+ * difference between "provably no tombstone" and "no way to tell". A teardown
+ * that cannot look must report an unresolvable application as a warning
+ * rather than as a clean sweep.
+ */
+export function supportsDeletedAppRegistrationLookup(
+  provisioner: { readonly findDeletedAppRegistration?: unknown } | undefined,
+): boolean {
+  return typeof provisioner?.findDeletedAppRegistration === 'function';
+}
+
+/** Does it publish catalog removal? Absent means the tenant catalog entry
+ *  stays and the reset reports that step as unsupported — an orphan, not a
+ *  blocker: the next run adopts the same `externalId`. */
+export function supportsCatalogRemoval(
+  provisioner: { readonly removeFromCatalog?: unknown } | undefined,
+): boolean {
+  return typeof provisioner?.removeFromCatalog === 'function';
+}

--- a/middleware/src/platform/teamsProvisionerService.ts
+++ b/middleware/src/platform/teamsProvisionerService.ts
@@ -61,6 +61,14 @@
 
 import { KERNEL_SERVICE_CALLER, type ServiceRegistry } from './serviceRegistry.js';
 import type { TeamsDelegatedProvisionerMethods } from './teamsDelegatedSignIn.js';
+import {
+  CLEANUP_METHOD_NAMES,
+  type TeamsProvisionerCleanupMethods,
+} from './teamsProvisionerCleanup.js';
+import {
+  TARGET_DIRECTORY_METHOD_NAMES,
+  type TeamsTargetDirectoryMethods,
+} from './teamsTargetDirectory.js';
 
 /** Service-registry key (bare, unversioned). */
 export const TEAMS_PROVISIONER_SERVICE_NAME = 'teamsProvisioner';
@@ -363,7 +371,9 @@ export interface UninstallFromTeamResult {
  * {@link supportsTeamUninstall}.
  */
 export interface TeamsProvisionerAccessor
-  extends Partial<TeamsDelegatedProvisionerMethods> {
+  extends Partial<TeamsDelegatedProvisionerMethods>,
+    Partial<TeamsTargetDirectoryMethods>,
+    Partial<TeamsProvisionerCleanupMethods> {
   readonly tenantMode: TenantMode;
   /** `true` when the ARM setup fields are configured (bot creation possible). */
   readonly canCreateBots: boolean;
@@ -507,6 +517,37 @@ export {
   type DeviceCodeStart,
   type TeamsDelegatedProvisionerMethods,
 } from './teamsDelegatedSignIn.js';
+
+/**
+ * The ENUMERATION half — "which teams and chats could this agent be installed
+ * into?". Re-exported through this choke point for the same reason as the
+ * delegated half above: consumers keep ONE import site for
+ * `teamsProvisioner@1`, while the definitions live next to the feature they
+ * belong to.
+ */
+export {
+  supportsChatListing,
+  supportsTeamListing,
+  teamsChatTargetKind,
+  type ListChatsInput,
+  type TeamsChatSummary,
+  type TeamsChatType,
+  type TeamsTargetDirectoryMethods,
+  type TeamsTeamSummary,
+} from './teamsTargetDirectory.js';
+
+/** The TEARDOWN half — the two primitives an undo needs that the mandatory
+ *  surface does not already carry. Same choke-point rule. */
+export {
+  supportsAppRegistrationPurge,
+  supportsCatalogRemoval,
+  type CleanupOutcome,
+  type PurgeDeletedAppRegistrationInput,
+  type PurgeDeletedAppRegistrationResult,
+  type RemoveFromCatalogInput,
+  type RemoveFromCatalogResult,
+  type TeamsProvisionerCleanupMethods,
+} from './teamsProvisionerCleanup.js';
 
 export function supportsTeamUninstall(
   provisioner: TeamsProvisionerAccessor | undefined,
@@ -780,12 +821,21 @@ function guardAccessor(raw: TeamsProvisionerAccessor): TeamsProvisionerAccessor 
     // `supportsDelegatedCatalogUpload` requires all six: this wrapper's job is
     // to report the raw provider's shape truthfully, and a half-shipped
     // connector must read as half-shipped rather than as absent.
-    ...forwardDelegated(raw),
+    ...forwardOptional(raw, DELEGATED_METHOD_NAMES),
+    // The enumeration half (`listTeams`/`listChats`) and the teardown half
+    // (`purgeDeletedAppRegistration`/`removeFromCatalog`), under the SAME
+    // rule as everything above it. Forwarded through the data-driven helper
+    // rather than as four more hand-written conditional spreads: the rule is
+    // identical for all of them, and a list of names cannot drift out of
+    // sync with an interface the way twelve near-identical blocks can.
+    ...forwardOptional(raw, TARGET_DIRECTORY_METHOD_NAMES),
+    ...forwardOptional(raw, CLEANUP_METHOD_NAMES),
   };
 }
 
 /**
- * Conditional forwarding of the six delegated methods.
+ * Conditional forwarding of an OPTIONAL group of methods — the six delegated
+ * ones, the two enumeration ones, the two teardown ones.
  *
  * Its own function purely to keep {@link guardAccessor} readable; the rule it
  * implements is identical — a method appears on the wrapper if and only if the
@@ -800,17 +850,18 @@ function guardAccessor(raw: TeamsProvisionerAccessor): TeamsProvisionerAccessor 
  * feature. The guarantee that it never LEAKS lives at the log/response
  * boundaries instead — `redactDelegated` in `teamsDelegatedSignIn.ts`.
  */
-function forwardDelegated(
+function forwardOptional(
   raw: TeamsProvisionerAccessor,
-): Partial<TeamsDelegatedProvisionerMethods> {
+  names: readonly (keyof TeamsProvisionerAccessor)[],
+): Partial<TeamsProvisionerAccessor> {
   const out: Record<string, unknown> = {};
-  for (const name of DELEGATED_METHOD_NAMES) {
+  for (const name of names) {
     const method = raw[name];
     if (typeof method !== 'function') continue;
     out[name] = (...args: unknown[]) =>
       (method as (...a: unknown[]) => unknown).apply(raw, args);
   }
-  return out as Partial<TeamsDelegatedProvisionerMethods>;
+  return out as Partial<TeamsProvisionerAccessor>;
 }
 
 /** The six method names of the delegated half, as data — so the forwarder

--- a/middleware/src/platform/teamsTargetDirectory.ts
+++ b/middleware/src/platform/teamsTargetDirectory.ts
@@ -1,0 +1,216 @@
+/**
+ * The ENUMERATION half of `teamsProvisioner@1` — "which teams and chats could
+ * this agent be installed into?".
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Until now an operator TYPED the install target into a free-text field. The
+ * field test that produced migration 0054 is the whole argument for this
+ * module: a 32-hex string with no prefix is a legal reading of BOTH a team's
+ * group id AND the stem of `19:<32hex>@thread.v2`, so
+ * `resolveTeamsInstallTarget` is required to refuse it as `'ambiguous'`
+ * rather than guess. That refusal is correct and it is still a dead end — the
+ * operator is holding a string they cannot disambiguate either.
+ *
+ * A LIST DISSOLVES THE AMBIGUITY INSTEAD OF REPORTING IT. Every id that comes
+ * out of {@link TeamsTargetDirectoryMethods.listTeams} is a hyphenated GUID
+ * and every id out of {@link TeamsTargetDirectoryMethods.listChats} carries
+ * its `19:…@…` suffix, so both classify unambiguously on the way back in.
+ * Picking from a list cannot produce the input that broke the field test.
+ *
+ * WHY IT IS A SEPARATE MODULE
+ * ---------------------------
+ * Same reason the delegated half lives in `teamsDelegatedSignIn.ts`: it is a
+ * coherent feature of its own, and `teamsProvisionerService.ts` is already at
+ * the size where people stop reading it. That module stays the ONE import
+ * site — it re-exports everything here — exactly as it does for the delegated
+ * methods.
+ *
+ * THE TWO HALVES ARE NOT SYMMETRIC, AND THAT IS A GRAPH FACT, NOT A CHOICE.
+ * `listTeams` is app-only and works wherever the connector is installed.
+ * `listChats` CANNOT be: Graph publishes no tenant-wide application route for
+ * chats at all — only `/users/{id}/chats`, per user — so chat enumeration is
+ * delegated-only and additionally needs {@link CHAT_LISTING_SCOPE}, which the
+ * tenant sign-in only started requesting in connector 0.8.0.
+ *
+ * A credential stored before that CANNOT pick the scope up by refreshing; an
+ * admin has to sign in once more. The connector detects this WITHOUT calling
+ * Graph and throws {@link DelegatedScopeRequiredLike} — which is why this is
+ * modelled as its own state and not as a failure: nothing is broken, one
+ * person has to click sign-in once, and then there is a list.
+ *
+ * VERSION SKEW, AS ALWAYS. Both methods are OPTIONAL on the accessor and each
+ * has its own predicate ({@link supportsTeamListing},
+ * {@link supportsChatListing}). They are detected SEPARATELY and deliberately:
+ * a single combined guard would let an ungranted chat scope hide the team
+ * list, which is the one half that always works.
+ */
+
+import type { DelegatedTokenSet } from './teamsDelegatedSignIn.js';
+
+/** One row of {@link TeamsTargetDirectoryMethods.listTeams}. */
+export interface TeamsTeamSummary {
+  /** Hyphenated AAD group id — installs through `POST /teams/{id}/installedApps`. */
+  readonly id: string;
+  readonly displayName: string;
+}
+
+/**
+ * What kind of conversation a listed chat is.
+ *
+ * Spelled the way GRAPH spells it (`oneOnOne`, not `one-on-one`) because this
+ * is a mirrored connector contract, not our own vocabulary. The translation
+ * into omadia's `TeamsTargetKind` (`'one-on-one-chat'`) happens once, in
+ * {@link teamsChatTargetKind}, so no consumer has to remember which spelling
+ * it is holding.
+ *
+ * `'meeting'` is listed because Graph returns it and dropping rows we did not
+ * name would make the list quietly incomplete; whether a meeting chat is a
+ * sensible install target is the operator's call, not this module's.
+ */
+export type TeamsChatType = 'group' | 'oneOnOne' | 'meeting';
+
+/** One row of {@link TeamsTargetDirectoryMethods.listChats}. */
+export interface TeamsChatSummary {
+  /** Full conversation id (`19:…@thread.v2` / `19:…@unq.gbl.spaces`). */
+  readonly id: string;
+  /**
+   * The chat's title, or `null` when it has none — which is the ordinary case
+   * for a 1:1 and for many ad-hoc group chats. NOT an error and not a reason
+   * to hide the row: {@link memberNames} is what labels those, and an id with
+   * no label at all still beats the free-text field this replaces.
+   */
+  readonly topic: string | null;
+  readonly chatType: TeamsChatType;
+  /**
+   * Display names of the chat's members, when the connector could resolve
+   * them. Optional because resolving them is a second Graph call per chat
+   * that the connector may skip.
+   */
+  readonly memberNames?: readonly string[];
+}
+
+/** Input of {@link TeamsTargetDirectoryMethods.listChats}. */
+export interface ListChatsInput {
+  /**
+   * The tenant's delegated token set (#949).
+   *
+   * Chat enumeration is delegated-only — there is no application route for it
+   * in Graph — so in practice the connector always needs this. It stays
+   * OPTIONAL on the type for one reason: the middleware must not be the party
+   * that decides a call is impossible. Handing over whatever token set exists
+   * and letting the connector refuse with a typed, explainable error produces
+   * a better message than a precondition invented here, and it keeps working
+   * if Microsoft ever ships the application route.
+   */
+  readonly tokens?: DelegatedTokenSet;
+}
+
+/**
+ * The two enumeration methods, as an interface of their own so the accessor
+ * can mix them in with `Partial<…>` (same construction as
+ * `TeamsDelegatedProvisionerMethods`).
+ */
+export interface TeamsTargetDirectoryMethods {
+  /**
+   * Every team of the tenant the app can see. App-only — no delegated token,
+   * no admin sign-in.
+   */
+  listTeams(): Promise<readonly TeamsTeamSummary[]>;
+  /**
+   * Every chat the connector can see for the signed-in tenant. DELEGATED
+   * ONLY, and needs {@link CHAT_LISTING_SCOPE} — see the module doc. Throws
+   * {@link DelegatedScopeRequiredLike} when the stored credential predates
+   * that scope.
+   */
+  listChats(input?: ListChatsInput): Promise<readonly TeamsChatSummary[]>;
+}
+
+/**
+ * The delegated scope chat enumeration needs, as the tenant sign-in requests
+ * it (connector >= 0.8.0).
+ *
+ * Named here rather than only inside the connector because the operator UI
+ * has to be able to SAY what the extra sign-in is for. "Sign in again"
+ * without a reason is indistinguishable from a bug.
+ */
+export const CHAT_LISTING_SCOPE = 'Chat.ReadBasic';
+
+/**
+ * The connector refused to enumerate chats because the stored credential
+ * predates {@link CHAT_LISTING_SCOPE} (connector >= 0.8.0).
+ *
+ * THROWN WITHOUT CALLING GRAPH, and that is what makes it worth its own type:
+ * the connector can tell from the token set alone, so this is a fast, certain
+ * answer rather than a classified 403. And it is NOT recoverable by a
+ * refresh — a refresh token can only renew the scopes it was issued for — so
+ * the only way out is one interactive sign-in. Treating it as a transient
+ * failure would put an operator in front of a retry button that can never
+ * work.
+ *
+ * Duck-typed on `name`, like every other connector error guard.
+ */
+export interface DelegatedScopeRequiredLike extends Error {
+  readonly name: 'DelegatedScopeRequiredError';
+  readonly reason: 'scope-missing';
+  /** The scopes the sign-in has to be repeated for, when the connector names
+   *  them. */
+  readonly missingScopes?: readonly string[];
+}
+
+export function isDelegatedScopeRequiredError(
+  err: unknown,
+): err is DelegatedScopeRequiredLike {
+  return (
+    err instanceof Error &&
+    err.name === 'DelegatedScopeRequiredError' &&
+    (err as Partial<DelegatedScopeRequiredLike>).reason === 'scope-missing'
+  );
+}
+
+/** Method names of this half, as data — so a forwarder cannot drift from the
+ *  interface above. */
+export const TARGET_DIRECTORY_METHOD_NAMES = [
+  'listTeams',
+  'listChats',
+] as const satisfies readonly (keyof TeamsTargetDirectoryMethods)[];
+
+/**
+ * Does the CURRENTLY INSTALLED connector publish team enumeration? Same shape
+ * and same reason as every other guard in `teamsProvisionerService.ts`: the
+ * contract is mirrored, not imported, so a middleware newer than its
+ * connector must ASK before it calls.
+ */
+export function supportsTeamListing(
+  provisioner: { readonly listTeams?: unknown } | undefined,
+): boolean {
+  return typeof provisioner?.listTeams === 'function';
+}
+
+/**
+ * Does it publish chat enumeration? Checked SEPARATELY from
+ * {@link supportsTeamListing} — see the module doc on why the two must not
+ * share a predicate.
+ */
+export function supportsChatListing(
+  provisioner: { readonly listChats?: unknown } | undefined,
+): boolean {
+  return typeof provisioner?.listChats === 'function';
+}
+
+/**
+ * Translate a listed chat's Graph-spelled type into the `TeamsTargetKind` the
+ * rest of omadia stores and renders.
+ *
+ * A `'meeting'` chat is addressed through the same `19:…@thread.v2` form as a
+ * group chat and installs through the same `POST /chats/{id}/installedApps`,
+ * so it maps to `'group-chat'`: the discriminator records WHICH GRAPH
+ * ENDPOINT installed the app (that is migration 0054's stated purpose), and
+ * inventing a fourth kind would have widened a CHECK constraint to record a
+ * distinction nothing branches on.
+ */
+export function teamsChatTargetKind(
+  chatType: TeamsChatType,
+): 'group-chat' | 'one-on-one-chat' {
+  return chatType === 'oneOnOne' ? 'one-on-one-chat' : 'group-chat';
+}

--- a/middleware/src/routes/operatorAgents.ts
+++ b/middleware/src/routes/operatorAgents.ts
@@ -24,6 +24,7 @@ import type { Plugin, PluginSetupField } from '../api/admin-v1.js';
 import type { PluginCatalog } from '../plugins/manifestLoader.js';
 import type { InstalledRegistry } from '../plugins/installedRegistry.js';
 import {
+  buildBotHandle,
   classifyTeamsProvisioningError,
   TEAMS_CHAT_INSTALL_MIN_CONNECTOR_VERSION,
   type TeamsProvisioningErrorDetail,
@@ -33,6 +34,15 @@ import {
   supportsTeamUninstall,
   type TeamsProvisionerAccessor,
 } from '../platform/teamsProvisionerService.js';
+import type { DelegatedTokenSet } from '../platform/teamsDelegatedSignIn.js';
+import { loadTeamsTargetDirectory } from '../services/teamsTargetDirectoryService.js';
+import {
+  resetTeamsIdentity,
+  TeamsIdentityResetNotFoundError,
+  type TeamsResetEventSink,
+  type TeamsResetIdentityRecord,
+  type TeamsResetProvisionerPort,
+} from '../services/teamsIdentityReset.js';
 import {
   projectTeamsBotConfig,
   projectTeamsBotsConfigSyncStatus,
@@ -264,6 +274,12 @@ export interface OperatorTeamsIdentityRecord {
    *  its rows mean `'team'`, the only thing they could have meant. */
   readonly targetKind?: TeamsTargetKind;
   readonly appId: string | null;
+  /** The Entra app's DIRECTORY OBJECT id (migration 0055) — what the
+   *  recycle-bin purge of a teardown needs, and what `appId` cannot stand in
+   *  for. OPTIONAL on this structural mirror for the usual reason: a store
+   *  predating the column still satisfies the port. Never surfaced in a
+   *  response; it is an internal identifier, like `appId`'s secret ref. */
+  readonly appObjectId?: string | null;
   readonly tenantId: string | null;
   readonly teamsAppId: string | null;
   readonly teamsAppExternalId: string | null;
@@ -309,6 +325,25 @@ export interface OperatorTeamsIdentityStore {
    * is no longer in.
    */
   clearTeamInstall?(agentId: string): Promise<OperatorTeamsIdentityRecord>;
+  /**
+   * Return the row to `pending` with every Azure identifier cleared, keeping
+   * the two fields a human typed (`botSlug`, `displayName`) — the last act of
+   * a teardown.
+   *
+   * Optional for the same reason as {@link clearTeamInstall}, and refused the
+   * same way: without it the reset route answers 501 rather than deleting
+   * Azure objects it could not then forget. A middleware that removed an app
+   * registration and kept a row pointing at it would send the next
+   * provisioning run building a bot on an application that is gone.
+   */
+  resetForRetry?(agentId: string): Promise<OperatorTeamsIdentityRecord>;
+  /** Persist a single field mid-teardown — today only the freshly resolved
+   *  `appObjectId`, which must reach the database BEFORE the delete that
+   *  makes it unlookupable. Optional, like every other write above. */
+  update?(
+    agentId: string,
+    patch: { readonly appObjectId?: string | null },
+  ): Promise<unknown>;
 }
 
 /** Structural subset of `TeamsProvisioningJobRunner` — enqueue is
@@ -330,6 +365,22 @@ export interface OperatorTeamsProvisioningRunner {
    *  fire-and-forget caller cannot learn about the refusal in time. See
    *  {@link assertTeamRetargetAllowed}. */
   runningTeamId(agentId: string): string | null;
+  /**
+   * Reserve this agent for an operation that is not a provisioning run, and
+   * hand back the release — or `null` when it is already busy.
+   *
+   * The reset route needs this rather than an `isRunning` check alone,
+   * because `isRunning` answers a question about the PAST instant: between
+   * reading it and starting to delete an app registration, an enqueue can
+   * arrive and start building on the very objects the teardown is removing.
+   * The lease closes that window from the one place that knows what is in
+   * flight.
+   *
+   * Optional so a stub runner (and every existing test) still satisfies the
+   * port; the route falls back to refusing on `isRunning` alone, which is the
+   * pre-teardown behaviour of every other destructive route here.
+   */
+  acquireExclusive?(agentId: string, label: string): (() => void) | null;
 }
 
 export interface OperatorTeamsIdentityDeps {
@@ -396,6 +447,29 @@ export interface OperatorTeamsIdentityDeps {
   readonly buildAppPackage?: (
     record: OperatorTeamsIdentityRecord,
   ) => Promise<Uint8Array>;
+  /**
+   * The tenant's delegated token set (#924/#949), read on demand.
+   *
+   * Two routes need it and neither can fake it: withdrawing the app from the
+   * tenant catalog is delegated-only at Microsoft, and chat enumeration may
+   * be. Optional — absent means "nobody is signed in", which both routes
+   * report as a blocked capability rather than a failure.
+   */
+  readonly delegatedTokens?: {
+    read(): Promise<DelegatedTokenSet | undefined>;
+  };
+  /**
+   * WRITE access to the provisioning progress log, so a teardown lands on the
+   * same timeline as a run (`events` above is the read side).
+   *
+   * Deliberately a second dep rather than a widening of `events`: the router
+   * has been a pure READER of that table since #915 — the job runner is its
+   * only writer — and the teardown is the first thing the router itself does
+   * that an operator watches happen. Keeping the two directions apart makes
+   * that exception visible instead of quietly granting the whole router write
+   * access to a log it does not own.
+   */
+  readonly eventWriter?: TeamsResetEventSink;
 }
 
 /**
@@ -463,6 +537,10 @@ export interface OperatorTeamsInstallStore {
     displayName: string,
   ): Promise<boolean>;
   remove(agentId: string, teamId: string): Promise<boolean>;
+  /** Drop every binding of one agent — the teardown's counterpart of
+   *  {@link remove}. Optional so a store predating it still satisfies the
+   *  port; without it the teardown leaves the read model alone and says so. */
+  removeAllForAgent?(agentId: string): Promise<number>;
 }
 
 /** One persisted binding, camelCase — see `platform/agentTeamsInstallStore.ts`. */
@@ -771,6 +849,17 @@ export const TEAMS_UNINSTALL_UNSUPPORTED_REASON =
  *  a version skew an operator can fix, so the sentence names the version. */
 export const TEAMS_CHAT_INSTALL_UNSUPPORTED_REASON =
   `the installed teamsProvisioner@1 publishes no installToChat method — upgrade @omadia/integration-microsoft365 to >= ${TEAMS_CHAT_INSTALL_MIN_CONNECTOR_VERSION}; until then an agent can only be installed into a team, not into a group chat.`;
+
+/** Minimum connector that can tear a provisioning run down without making
+ *  things worse — see `platform/teamsProvisionerCleanup.ts` on the purge. */
+export const TEAMS_RESET_MIN_CONNECTOR_VERSION = '0.8.0';
+
+/** Reason text for a mount that cannot reset. Two independent causes, one
+ *  sentence: no connector at all, or an identity store predating
+ *  `resetForRetry`. Both mean the same thing to the operator — the cleanup is
+ *  still a manual Azure-portal step. */
+export const TEAMS_RESET_UNSUPPORTED_REASON =
+  `resetting a Teams provisioning run needs teamsProvisioner@1 and an identity store that can return the row to 'pending' — upgrade @omadia/integration-microsoft365 to >= ${TEAMS_RESET_MIN_CONNECTOR_VERSION} and apply migration 0055; until then the Entra app, the Azure bot and the catalog entry have to be removed by hand.`;
 
 const STRUCTURAL_UNSUPPORTED_REASONS: Readonly<Record<string, string>> = {
   enumerate:
@@ -2248,6 +2337,50 @@ export function createOperatorAgentsRouter(
 
   /** Resolve agent + identity row for the team routes, answering the shared
    *  404s. `undefined` means a response was already sent. */
+  /**
+   * Adapt the router's identity-store port to the teardown's.
+   *
+   * They are two different shapes on purpose: the teardown needs a row it can
+   * reason about (`appObjectId` is load-bearing there and absent from most
+   * responses here) and exactly two writes, while this router's port is a
+   * read model with optional everything. The adapter is where the optionality
+   * is resolved ONCE — `resetForRetry` has already been proven present by the
+   * caller's 501 gate, and `update` degrades to a no-op because a store that
+   * cannot persist the object id simply forces the teardown down its
+   * recycle-bin-search path instead.
+   */
+  function teamsResetStore(
+    deps: OperatorTeamsIdentityDeps,
+    resetForRetry: (agentId: string) => Promise<OperatorTeamsIdentityRecord>,
+  ): {
+    getByAgentId(agentId: string): Promise<TeamsResetIdentityRecord | undefined>;
+    update(
+      agentId: string,
+      patch: { readonly appObjectId?: string | null },
+    ): Promise<unknown>;
+    resetForRetry(agentId: string): Promise<unknown>;
+  } {
+    return {
+      getByAgentId: async (agentId) => {
+        const row = await deps.store.getByAgentId(agentId);
+        if (!row) return undefined;
+        return {
+          agentId: row.agentId,
+          botSlug: row.botSlug,
+          appId: row.appId,
+          appObjectId: row.appObjectId ?? null,
+          teamsAppId: row.teamsAppId,
+        };
+      },
+      update: async (agentId, patch) => {
+        const update = deps.store.update;
+        if (typeof update !== 'function') return undefined;
+        return update.call(deps.store, agentId, patch);
+      },
+      resetForRetry: (agentId) => resetForRetry.call(deps.store, agentId),
+    };
+  }
+
   async function teamsIdentityRow(
     req: Request,
     res: Response,
@@ -2342,6 +2475,186 @@ export function createOperatorAgentsRouter(
           message:
             'The Teams app package could not be rendered — see the middleware log for the underlying error.',
         });
+      }
+    },
+  );
+
+  /**
+   * GET /:slug/teams/targets — what the operator can PICK instead of type.
+   *
+   * The field this replaces is the one that produced migration 0054's field
+   * test: a bare 32-hex id is a legal reading of both a team's group id and
+   * the stem of a chat id, `resolveTeamsInstallTarget` is therefore obliged
+   * to refuse it as ambiguous, and the operator holding it cannot
+   * disambiguate it either. Every id in this response classifies
+   * unambiguously — teams come back hyphenated, chats keep their `19:…@…`
+   * suffix — so picking from the list cannot produce that input at all.
+   *
+   * ALWAYS 200 WHEN THE AGENT EXISTS. Each half carries its own
+   * `available` flag with a machine-readable `reason`, because an enumeration
+   * is a convenience over a field the operator can still type into, and a 500
+   * from the convenience must not take the field down with it. The one thing
+   * this endpoint must never do is answer `[]` for "I could not look" — see
+   * `services/teamsTargetDirectoryService.ts`.
+   */
+  router.get('/:slug/teams/targets', async (req: Request, res: Response) => {
+    const live = svc();
+    if (!live) return unavailable(res);
+    const deps = teamsIdentity(res);
+    if (!deps) return;
+    try {
+      // Deliberately NOT `teamsIdentityRow`: an operator choosing where an
+      // agent should live may not have created its Teams identity yet, and a
+      // 404 would hide the picker exactly when it is most useful.
+      const slug = slugParam(req, res);
+      if (!slug) return;
+      const agent = await live.store.getAgentBySlug(slug);
+      if (!agent) {
+        res.status(404).json({ error: 'not_found' });
+        return;
+      }
+      const directory = await loadTeamsTargetDirectory({
+        getProvisioner: () => deps.getProvisioner?.(),
+        ...(deps.delegatedTokens ? { delegatedTokens: deps.delegatedTokens } : {}),
+      });
+      res.json({
+        ok: true,
+        agent: agent.slug,
+        provisioner_installed: deps.isProvisionerInstalled(),
+        ...directory,
+      });
+    } catch (err) {
+      badRequest(res, err);
+    }
+  });
+
+  /**
+   * POST /:slug/teams-identity/reset — undo a provisioning run.
+   *
+   * DESTRUCTIVE, AND DELIBERATELY NOT A DELETE OF ANYTHING THE OPERATOR
+   * TYPED. The Entra app registration, the Azure bot and the tenant catalog
+   * entry go; `bot_slug` and `display_name` stay, because they are the two
+   * answers a human gave and the whole point is that the retry is one button
+   * with the same slug.
+   *
+   * WHY THE ORDER AND THE PARTIAL REPORT LIVE IN THE SERVICE, NOT HERE:
+   * `services/teamsIdentityReset.ts`. This route owns three things the
+   * service must not: the connector/version gate, the exclusion against a
+   * provisioning run, and the HTTP shape.
+   *
+   * A PARTIAL TEARDOWN IS A 200. `status: 'incomplete'` with a per-step
+   * report is an ANSWER — it says which Azure objects went and which are
+   * still there — and putting it behind a non-2xx would push it into the
+   * UI's error path, where the steps get collapsed into "reset failed". That
+   * single unhelpful sentence is what this endpoint exists to replace. Only
+   * a REFUSAL (nothing attempted) is a 4xx.
+   */
+  router.post(
+    '/:slug/teams-identity/reset',
+    async (req: Request, res: Response) => {
+      const live = svc();
+      if (!live) return unavailable(res);
+      const deps = teamsIdentity(res);
+      if (!deps) return;
+      try {
+        const found = await teamsIdentityRow(req, res, live, deps);
+        if (!found) return;
+        const { agent, row } = found;
+
+        if (!deps.isProvisionerInstalled()) {
+          res.status(503).json({
+            error: 'teams_provisioner_unavailable',
+            message:
+              'teamsProvisioner@1 is not installed — install and activate the M365 connector plugin before resetting a provisioning run.',
+            agent: agent.slug,
+          });
+          return;
+        }
+        const provisioner = deps.getProvisioner?.();
+        const resetForRetry = deps.store.resetForRetry;
+        if (provisioner === undefined || typeof resetForRetry !== 'function') {
+          // Same rule as the uninstall route: never remove something we
+          // cannot then record as removed. A row still pointing at a purged
+          // app registration would send the next run building a bot on an
+          // application that is not there.
+          res.status(501).json({
+            error: 'teams_reset_unsupported',
+            message: TEAMS_RESET_UNSUPPORTED_REASON,
+            agent: agent.slug,
+          });
+          return;
+        }
+
+        // Take the agent for the duration. `isRunning` alone answers about
+        // the instant it was read; between that read and the first delete an
+        // enqueue can arrive and start building on the very objects the
+        // teardown is about to remove.
+        const acquire = deps.runner.acquireExclusive;
+        const release =
+          typeof acquire === 'function'
+            ? acquire.call(deps.runner, agent.id, 'teams_identity_reset')
+            : deps.runner.isRunning(agent.id)
+              ? null
+              : (): void => {};
+        if (release === null) {
+          res.status(409).json({
+            error: 'teams_provisioning_running',
+            message: `agent '${agent.slug}' has a provisioning run in flight — wait for it to finish before resetting.`,
+            agent: agent.slug,
+          });
+          return;
+        }
+
+        try {
+          const result = await resetTeamsIdentity(
+            {
+              store: teamsResetStore(deps, resetForRetry),
+              getProvisioner: () => provisioner as TeamsResetProvisionerPort,
+              buildBotHandle,
+              ...(typeof deps.installs?.removeAllForAgent === 'function'
+                ? {
+                    installs: {
+                      removeAllForAgent: (agentId: string): Promise<number> =>
+                        (
+                          deps.installs?.removeAllForAgent as (
+                            id: string,
+                          ) => Promise<number>
+                        )(agentId),
+                    },
+                  }
+                : {}),
+              ...(deps.delegatedTokens
+                ? { delegatedTokens: deps.delegatedTokens }
+                : {}),
+              ...(deps.eventWriter ? { events: deps.eventWriter } : {}),
+            },
+            agent.id,
+          );
+          // `agentId` is dropped rather than spread: every other route on
+          // this router identifies an agent by its SLUG, and leaking the
+          // internal id here would make this the one response an operator
+          // screen could accidentally start keying on.
+          const { agentId: _agentId, ...report } = result;
+          res.json({
+            ok: result.status === 'reset',
+            agent: agent.slug,
+            // The state the row held when the teardown started — so the
+            // response says what was torn down, not the `pending` it now is.
+            previous_state: row.state,
+            ...report,
+          });
+        } finally {
+          release();
+        }
+      } catch (err) {
+        if (err instanceof TeamsIdentityResetNotFoundError) {
+          res.status(404).json({
+            error: 'teams_identity_not_found',
+            message: err.message,
+          });
+          return;
+        }
+        badRequest(res, err);
       }
     },
   );

--- a/middleware/src/services/teamsIdentityReset.ts
+++ b/middleware/src/services/teamsIdentityReset.ts
@@ -1,0 +1,729 @@
+/**
+ * Undo a Teams provisioning run — the teardown that lets an operator try
+ * again after one died in the middle.
+ *
+ * WHAT A FAILED RUN LEAVES BEHIND
+ * ------------------------------
+ * The chain in `services/teamsProvisioningJob.ts` creates four things in
+ * order: an Entra app registration, an Azure bot service, a tenant catalog
+ * entry, and one or more installs. A run that dies at step 3 leaves the first
+ * two alive, and the identity row pointing at both. Until now the way back
+ * was two Azure portals and a `psql` session.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * THE ORDER, AND WHY IT IS THIS ORDER
+ * ─────────────────────────────────────────────────────────────────────────
+ * The teardown runs BACKWARDS along the dependency chain — catalog entry,
+ * then bot, then app registration, then the row — and the rule that produces
+ * that order is: *no step may run before a step whose failure it would make
+ * unrecoverable.* Concretely, three constraints, each of which independently
+ * forces the same sequence:
+ *
+ *  1. THE CATALOG ENTRY MUST GO FIRST, AND ITS FAILURE MUST STOP EVERYTHING.
+ *     `stableTeamsAppExternalId` derives the catalog `externalId` from the
+ *     AGENT ID alone, so it survives any reset. The chain's step 4 asks
+ *     `getCatalogApp({ externalId })` and, when it finds one, ADOPTS its
+ *     `teamsAppId` without re-uploading. So a teardown that removed the app
+ *     registration but left the catalog entry would produce the worst
+ *     available outcome: the next run creates a NEW registration with a NEW
+ *     `appId`, then adopts a catalog app whose manifest still names the OLD,
+ *     deleted one. Every step reports success and the bot never answers a
+ *     message. A visible failure is better than that, so a catalog entry that
+ *     cannot be withdrawn aborts the teardown while everything is still
+ *     intact and re-runnable.
+ *
+ *  2. THE BOT DEPENDS ON THE REGISTRATION, SO IT GOES BEFORE IT. The bot
+ *     handle is `buildBotHandle(botSlug, appId)` — deleting the registration
+ *     first would erase the only input the bot's own name is derived from,
+ *     and with it the ability to find the bot again.
+ *
+ *  3. THE APP REGISTRATION IS THE ONE IRREVERSIBLE STEP, SO IT GOES LAST.
+ *     See the delete/purge note below. Everything above it is an operation
+ *     that a second attempt can simply repeat; this one is not. Putting it at
+ *     the end means an abort at ANY earlier point leaves the world in exactly
+ *     the state it was in before the teardown started — never a worse one.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * DELETE AND PURGE ARE ONE OPERATION, NOT TWO
+ * ─────────────────────────────────────────────────────────────────────────
+ * A deleted Entra application spends 30 days in the directory's recycle bin
+ * and KEEPS RESERVING ITS `uniqueName` the whole time. omadia derives that
+ * name from the operator's bot slug, so deleting without purging does not
+ * restore the starting position — it makes the next attempt with the same
+ * slug collide with the corpse of the previous one. That is
+ * byte5ai/omadia#916; it cost a slug for a month.
+ *
+ * Two consequences are implemented here rather than documented and hoped for:
+ *
+ *   * a connector that cannot purge is NOT allowed to delete
+ *     ({@link supportsAppRegistrationPurge} gates the whole step). Refusing
+ *     leaves a reusable registration; proceeding would convert it into a
+ *     30-day reservation, which is strictly worse than doing nothing.
+ *   * the purge needs the DIRECTORY OBJECT id, and after the delete there is
+ *     no way left to look one up. So the object id is resolved and PERSISTED
+ *     (migration 0055) before the delete, which is also what makes an
+ *     interrupted teardown resumable: the retry still knows what to purge.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * IDEMPOTENT, RESUMABLE, AND WITHOUT A CURSOR
+ * ─────────────────────────────────────────────────────────────────────────
+ * There is no progress cursor and no teardown state machine, on purpose.
+ * Every primitive answers `'already-absent'` for something that is not there,
+ * and this module treats that as success — so the correct way to resume an
+ * interrupted teardown is simply to run the whole thing again. The steps that
+ * already finished report `already-absent` and cost one API call each; the
+ * one that did not gets its second attempt. A cursor would be a second source
+ * of truth about Azure, and it would be wrong every time somebody deleted
+ * something by hand.
+ *
+ * The ONE piece of state that is persisted mid-teardown is `app_object_id`,
+ * and only because the alternative is losing it forever (see above).
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * PARTIAL SUCCESS IS THE NORMAL REPORT
+ * ─────────────────────────────────────────────────────────────────────────
+ * The result carries a per-step report, not a boolean. "Reset failed" as the
+ * only signal is what makes an operator open two portals to find out what
+ * actually happened. And the identity row is cleared ONLY when every step
+ * above it is provably done: clearing `app_id` while the registration is
+ * still alive would strand it — nothing would remember it existed, and the
+ * slug would stay blocked with no way left to find out why.
+ */
+
+import type { DelegatedTokenSet } from '../platform/teamsDelegatedSignIn.js';
+import {
+  correctedObjectIdOf,
+  isDeletedObjectIdMismatchError,
+  supportsAppRegistrationPurge,
+  supportsCatalogRemoval,
+  supportsDeletedAppRegistrationLookup,
+} from '../platform/teamsProvisionerCleanup.js';
+
+// ---------------------------------------------------------------------------
+// Vocabulary
+// ---------------------------------------------------------------------------
+
+/**
+ * The teardown's steps, in execution order.
+ *
+ * They are written to the SAME progress log as a provisioning run
+ * (`agent_teams_provisioning_events`, migration 0053) so the operator watches
+ * one timeline rather than learning a second screen. That table's `step`
+ * column is deliberately not CHECK-constrained, which is what makes adding
+ * these four a code change and not a schema change.
+ */
+export const TEAMS_RESET_STEPS = [
+  'catalog_removed',
+  'bot_deleted',
+  'app_deleted',
+  'identity_reset',
+] as const;
+
+export type TeamsResetStep = (typeof TEAMS_RESET_STEPS)[number];
+
+/**
+ * The run-level step of a teardown — the counterpart of the chain's `'run'`.
+ * One `started`, exactly one terminal event, so a UI can tell "this teardown
+ * died in step 2" from "no teardown ever ran".
+ */
+export const TEAMS_RESET_RUN_STEP = 'reset';
+
+/**
+ * What happened to one step.
+ *
+ * `'already-absent'` and `'skipped'` are BOTH successes and they are kept
+ * apart because they answer different questions: `already-absent` means the
+ * thing existed as far as the row knew and Azure says it is gone (somebody
+ * else removed it, or a previous attempt did); `skipped` means the row never
+ * had the identifier at all, i.e. the run never got that far. An operator
+ * reading a timeline wants to know which.
+ *
+ * `'blocked'` is the one that is neither success nor fault: a human action is
+ * missing (a tenant sign-in) or the connector cannot do it. Nothing broke and
+ * nothing was destroyed — which is precisely why it must not be reported as
+ * `'failed'`.
+ */
+export type TeamsResetOutcome =
+  | 'removed'
+  | 'already-absent'
+  | 'skipped'
+  | 'blocked'
+  | 'failed';
+
+export interface TeamsResetStepReport {
+  readonly step: TeamsResetStep;
+  readonly outcome: TeamsResetOutcome;
+  /** Short machine-readable code the UI localizes — never prose it parses,
+   *  and never an identifier, a token or a URL (migration 0053's rule). */
+  readonly detail?: string;
+}
+
+/** Detail codes. Closed vocabulary — the web UI has a message for each. */
+export const TEAMS_RESET_DETAILS = {
+  /** The row never carried the identifier this step removes. */
+  nothingToRemove: 'nothing_to_remove',
+  /** The connector publishes no `removeFromCatalog` (< 0.8.0). */
+  catalogRemovalUnsupported: 'catalog_removal_unsupported',
+  /** `DELETE /appCatalogs/teamsApps` is delegated-only: nobody is signed in. */
+  tenantSignInRequired: 'tenant_sign_in_required',
+  /** The connector publishes no `purgeDeletedAppRegistration` (< 0.8.0).
+   *  DELETING ANYWAY IS REFUSED — see the module doc. */
+  purgeUnsupported: 'purge_unsupported',
+  /**
+   * The application is gone from `/applications`, no object id was ever
+   * stored, AND the connector cannot search the recycle bin — so there is no
+   * way left to tell a clean sweep from a tombstone still holding this
+   * agent's `uniqueName`. Reported as a success with this note, because there
+   * is genuinely no call left to make, but named rather than hidden behind a
+   * bare `already-absent`: it is the one outcome after which retrying with
+   * the same slug may still collide.
+   */
+  appAbsentUnpurgeable: 'app_absent_unpurgeable',
+  /**
+   * The application is gone AND the recycle bin was searched and is empty.
+   * The strong version of `already-absent`: the `uniqueName` is provably
+   * free, so the retry is safe.
+   */
+  appProvablyGone: 'app_provably_gone',
+  /** ARM is not configured, so no bot service can ever have been created. */
+  armNotConfigured: 'arm_not_configured',
+} as const;
+
+/** Prefixes for the failure details, mirroring the runner's convention of a
+ *  `code:` prefix in front of a message. */
+export const TEAMS_RESET_FAILURE_PREFIXES = {
+  catalog: 'catalog_removal_failed:',
+  bot: 'bot_deletion_failed:',
+  appDelete: 'app_deletion_failed:',
+  appPurge: 'app_purge_failed:',
+  identity: 'identity_reset_failed:',
+} as const;
+
+export type TeamsIdentityResetResult =
+  | {
+      /** Every step is done and the row is back at `pending`. */
+      readonly status: 'reset';
+      readonly agentId: string;
+      readonly steps: readonly TeamsResetStepReport[];
+    }
+  | {
+      /**
+       * The teardown stopped part-way. NOT a synonym for "nothing happened":
+       * the steps that ran are in {@link steps} and they really did run. The
+       * identity row is deliberately untouched, so a second call resumes.
+       */
+      readonly status: 'incomplete';
+      readonly agentId: string;
+      readonly steps: readonly TeamsResetStepReport[];
+      readonly stoppedAt: TeamsResetStep;
+      readonly detail: string;
+    };
+
+// ---------------------------------------------------------------------------
+// Ports — structural subsets, never the concrete classes
+// ---------------------------------------------------------------------------
+
+/** What the teardown needs to know about the identity it is undoing. */
+export interface TeamsResetIdentityRecord {
+  readonly agentId: string;
+  readonly botSlug: string;
+  readonly appId: string | null;
+  readonly appObjectId: string | null;
+  readonly teamsAppId: string | null;
+}
+
+export interface TeamsResetIdentityStore {
+  getByAgentId(agentId: string): Promise<TeamsResetIdentityRecord | undefined>;
+  /** Used for exactly one write before the row reset: persisting a
+   *  freshly-resolved `app_object_id`. */
+  update(
+    agentId: string,
+    patch: { readonly appObjectId?: string | null },
+  ): Promise<unknown>;
+  resetForRetry(agentId: string): Promise<unknown>;
+}
+
+/** The recorded team/chat bindings (migration 0051), when one is wired. */
+export interface TeamsResetInstallStore {
+  removeAllForAgent(agentId: string): Promise<number>;
+}
+
+/** Mirror of `DeleteBotResult` as this module consumes it. */
+export type TeamsResetDeleteBotResult =
+  | { readonly kind: 'deleted'; readonly outcome: 'deleted' | 'already-deleted' }
+  | { readonly kind: 'registration-only'; readonly reason: 'arm-not-configured' };
+
+/**
+ * The provisioner surface a teardown uses — a structural subset of
+ * `TeamsProvisionerAccessor`, exactly like `TeamsProvisionerPort` in the job
+ * runner. The two optional methods are optional HERE too, so feature
+ * detection reads the same object the call would go to.
+ */
+export interface TeamsResetProvisionerPort {
+  readonly tenantMode: 'customer' | 'home';
+  getAppRegistration(
+    appId: string,
+    tenantMode: 'customer' | 'home',
+  ): Promise<{ readonly objectId: string } | undefined>;
+  deleteAppRegistration(input: {
+    readonly appId: string;
+  }): Promise<{ readonly outcome: string }>;
+  deleteBot(botName: string): Promise<TeamsResetDeleteBotResult>;
+  purgeDeletedAppRegistration?(input: {
+    readonly objectId: string;
+  }): Promise<{ readonly outcome: string }>;
+  findDeletedAppRegistration?(input: { readonly appId: string }): Promise<
+    { readonly found: true; readonly objectId: string } | { readonly found: false }
+  >;
+  removeFromCatalog?(input: {
+    readonly teamsAppId: string;
+    readonly tokens: DelegatedTokenSet;
+  }): Promise<{ readonly outcome: string }>;
+}
+
+/**
+ * Where a teardown writes its progress notes — the SAME sink and the same
+ * table a provisioning run writes to (`agent_teams_provisioning_events`,
+ * migration 0053), so the operator watches one timeline instead of learning a
+ * second screen.
+ *
+ * Structural, and optional on the options: a mount without Postgres runs the
+ * teardown identically and simply leaves no timeline behind.
+ */
+export interface TeamsResetEventSink {
+  record(input: {
+    readonly agentId: string;
+    readonly step: string;
+    readonly status: 'started' | 'succeeded' | 'failed';
+    readonly detail?: string | null;
+  }): Promise<unknown>;
+  clearForAgent(agentId: string): Promise<unknown>;
+}
+
+export type TeamsResetEmit = (
+  step: TeamsResetStep | typeof TEAMS_RESET_RUN_STEP,
+  status: 'started' | 'succeeded' | 'failed',
+  detail?: string,
+) => Promise<void>;
+
+export interface TeamsIdentityResetOptions {
+  readonly store: TeamsResetIdentityStore;
+  readonly getProvisioner: () => TeamsResetProvisionerPort;
+  /**
+   * Injected rather than imported, to keep this module free of a cycle back
+   * into `teamsProvisioningJob.ts` — which calls INTO here. It must be the
+   * same `buildBotHandle` the chain used, or the teardown would look for a
+   * bot under a name that was never created.
+   */
+  readonly buildBotHandle: (botSlug: string, appId: string) => string;
+  readonly installs?: TeamsResetInstallStore;
+  /** The tenant sign-in the catalog removal rides on (#924/#949). */
+  readonly delegatedTokens?: { read(): Promise<DelegatedTokenSet | undefined> };
+  /** Progress log. Absent = the teardown runs identically, silently. */
+  readonly events?: TeamsResetEventSink;
+  readonly log?: (msg: string) => void;
+}
+
+/** No identity row for this agent — the caller (a route) turns it into 404. */
+export class TeamsIdentityResetNotFoundError extends Error {
+  public readonly code = 'teams_identity_not_found';
+
+  constructor(agentId: string) {
+    super(`no teams identity row for agent '${agentId}'`);
+    this.name = 'TeamsIdentityResetNotFoundError';
+  }
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * THE choke point for the teardown's progress log — the single place a sink
+ * failure is swallowed.
+ *
+ * Same policy and same reasoning as the provisioning runner's `emit`: nothing
+ * reads this log to decide anything, so a teardown that failed because its
+ * diary entry did not write would be an outage manufactured by an
+ * observability feature. Awaited rather than fire-and-forget so the timeline
+ * keeps insertion order.
+ */
+function createEmitter(
+  opts: TeamsIdentityResetOptions,
+  agentId: string,
+): TeamsResetEmit {
+  return async (step, status, detail): Promise<void> => {
+    const sink = opts.events;
+    if (!sink) return;
+    try {
+      await sink.record({
+        agentId,
+        step,
+        status,
+        ...(detail === undefined ? {} : { detail }),
+      });
+    } catch (err) {
+      opts.log?.(
+        `[teams-reset] progress event (${step}/${status}) for ${agentId} was not recorded: ${errorMessage(err)}`,
+      );
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The teardown
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the teardown for one agent. Never throws for an Azure-side failure —
+ * those are reported as steps; it throws only for a missing identity row,
+ * which is a caller error.
+ *
+ * See the module doc for the order and for why each step is allowed (or not
+ * allowed) to stop the ones after it.
+ */
+export async function resetTeamsIdentity(
+  opts: TeamsIdentityResetOptions,
+  agentId: string,
+): Promise<TeamsIdentityResetResult> {
+  const emit = createEmitter(opts, agentId);
+  const row = await opts.store.getByAgentId(agentId);
+  if (!row) throw new TeamsIdentityResetNotFoundError(agentId);
+
+  // Open a fresh timeline, exactly as a provisioning run does: the log
+  // describes ONE operation, and an operator watching a teardown is not
+  // asking about the run that failed before it. Best-effort, like every
+  // other write to this sink.
+  try {
+    await opts.events?.clearForAgent(agentId);
+  } catch (err) {
+    opts.log?.(
+      `[teams-reset] could not clear the previous progress log of ${agentId}: ${errorMessage(err)}`,
+    );
+  }
+  await emit(TEAMS_RESET_RUN_STEP, 'started');
+  const steps: TeamsResetStepReport[] = [];
+
+  /** Record a step, mirror it into the timeline, and say whether to go on. */
+  const finish = async (report: TeamsResetStepReport): Promise<boolean> => {
+    steps.push(report);
+    const ok = report.outcome !== 'failed' && report.outcome !== 'blocked';
+    await emit(report.step, ok ? 'succeeded' : 'failed', report.detail);
+    return ok;
+  };
+
+  const halt = async (
+    stoppedAt: TeamsResetStep,
+    detail: string,
+  ): Promise<TeamsIdentityResetResult> => {
+    await emit(TEAMS_RESET_RUN_STEP, 'failed', stoppedAt);
+    return { status: 'incomplete', agentId, steps, stoppedAt, detail };
+  };
+
+  const provisioner = opts.getProvisioner();
+
+  // ── Step 1 — the tenant catalog entry ───────────────────────────────────
+  await emit('catalog_removed', 'started');
+  const catalog = await removeCatalogEntry(opts, provisioner, row);
+  if (!(await finish(catalog))) {
+    return halt('catalog_removed', catalog.detail ?? 'catalog_removal_failed');
+  }
+
+  // ── Step 2 — the Azure bot service ──────────────────────────────────────
+  await emit('bot_deleted', 'started');
+  const bot = await deleteBotService(opts, provisioner, row);
+  if (!(await finish(bot))) {
+    return halt('bot_deleted', bot.detail ?? 'bot_deletion_failed');
+  }
+
+  // ── Step 3 — the Entra app registration, delete AND purge ───────────────
+  await emit('app_deleted', 'started');
+  const app = await deleteAndPurgeRegistration(opts, provisioner, row);
+  if (!(await finish(app))) {
+    return halt('app_deleted', app.detail ?? 'app_deletion_failed');
+  }
+
+  // ── Step 4 — the row and the recorded bindings ──────────────────────────
+  await emit('identity_reset', 'started');
+  try {
+    // Bindings first: they are a read model OF the row, and a row already
+    // back at `pending` while its installs still list three teams is a
+    // screen that contradicts itself. If this throws, nothing above it is
+    // undone and the retry repeats it — `DELETE` of an empty set is a no-op.
+    if (opts.installs) await opts.installs.removeAllForAgent(agentId);
+    await opts.store.resetForRetry(agentId);
+  } catch (err) {
+    const detail = `${TEAMS_RESET_FAILURE_PREFIXES.identity}${errorMessage(err)}`;
+    await finish({ step: 'identity_reset', outcome: 'failed', detail });
+    return halt('identity_reset', detail);
+  }
+  await finish({ step: 'identity_reset', outcome: 'removed' });
+
+  await emit(TEAMS_RESET_RUN_STEP, 'succeeded');
+  return { status: 'reset', agentId, steps };
+}
+
+// ---------------------------------------------------------------------------
+// Steps
+// ---------------------------------------------------------------------------
+
+async function removeCatalogEntry(
+  opts: TeamsIdentityResetOptions,
+  provisioner: TeamsResetProvisionerPort,
+  row: TeamsResetIdentityRecord,
+): Promise<TeamsResetStepReport> {
+  const step = 'catalog_removed' as const;
+  if (row.teamsAppId === null) {
+    return { step, outcome: 'skipped', detail: TEAMS_RESET_DETAILS.nothingToRemove };
+  }
+  if (!supportsCatalogRemoval(provisioner)) {
+    // BLOCKING, and this is the decision the module doc argues for at length:
+    // the `externalId` is stable, so an abandoned catalog entry is adopted by
+    // the next run and silently pairs the new bot with the old app id.
+    return {
+      step,
+      outcome: 'blocked',
+      detail: TEAMS_RESET_DETAILS.catalogRemovalUnsupported,
+    };
+  }
+  const tokens = await opts.delegatedTokens?.read();
+  if (tokens === undefined) {
+    // Not a fault: `DELETE /appCatalogs/teamsApps` is delegated-only at
+    // Microsoft, exactly like the upload (#924). Nobody has signed in yet.
+    //
+    // And nobody needs to sign in AGAIN: the delete is covered by the
+    // `AppCatalog.ReadWrite.All` the provisioning sign-in already asked for,
+    // so any tenant that could be provisioned can be torn down by whoever is
+    // signed in today. That is why this reports a plain sign-in requirement
+    // and never a re-consent — unlike chat enumeration, which does need one.
+    return {
+      step,
+      outcome: 'blocked',
+      detail: TEAMS_RESET_DETAILS.tenantSignInRequired,
+    };
+  }
+  try {
+    const res = await (
+      provisioner.removeFromCatalog as NonNullable<
+        TeamsResetProvisionerPort['removeFromCatalog']
+      >
+    ).call(provisioner, { teamsAppId: row.teamsAppId, tokens });
+    return {
+      step,
+      outcome: res.outcome === 'already-absent' ? 'already-absent' : 'removed',
+    };
+  } catch (err) {
+    return {
+      step,
+      outcome: 'failed',
+      detail: `${TEAMS_RESET_FAILURE_PREFIXES.catalog}${errorMessage(err)}`,
+    };
+  }
+}
+
+async function deleteBotService(
+  opts: TeamsIdentityResetOptions,
+  provisioner: TeamsResetProvisionerPort,
+  row: TeamsResetIdentityRecord,
+): Promise<TeamsResetStepReport> {
+  const step = 'bot_deleted' as const;
+  if (row.appId === null) {
+    // The handle is derived from the app id, so without one there is no name
+    // to delete under — and no run ever got far enough to create a bot.
+    return { step, outcome: 'skipped', detail: TEAMS_RESET_DETAILS.nothingToRemove };
+  }
+  try {
+    const res = await provisioner.deleteBot(
+      opts.buildBotHandle(row.botSlug, row.appId),
+    );
+    if (res.kind === 'registration-only') {
+      // ARM was never configured, so the chain can only ever have reached
+      // `app_registered` and no bot service exists to remove. Success.
+      return { step, outcome: 'skipped', detail: TEAMS_RESET_DETAILS.armNotConfigured };
+    }
+    return {
+      step,
+      outcome: res.outcome === 'already-deleted' ? 'already-absent' : 'removed',
+    };
+  } catch (err) {
+    return {
+      step,
+      outcome: 'failed',
+      detail: `${TEAMS_RESET_FAILURE_PREFIXES.bot}${errorMessage(err)}`,
+    };
+  }
+}
+
+/**
+ * The registration, as ONE step: resolve the object id, persist it, delete,
+ * purge.
+ *
+ * Splitting it into two reportable steps was considered and rejected — a
+ * delete that reads as a success while its purge is still owed is exactly the
+ * state that looks "done" and burns the slug for 30 days.
+ *
+ * THE OBJECT ID IS RESOLVED FROM THREE PLACES, IN THIS ORDER, AND THE ORDER
+ * IS THE RESUMABILITY STORY:
+ *
+ *   1. `app_object_id` on the row (migration 0055). Free, and always right
+ *      for an identity provisioned since the column exists.
+ *   2. `getAppRegistration(appId)` — works while the application is still
+ *      live, which is the FIRST run's normal path.
+ *   3. `findDeletedAppRegistration({ appId })` — searches the recycle bin,
+ *      and is the only one of the three that still works AFTER a delete. It
+ *      is what makes a teardown interrupted between the delete and the purge
+ *      recoverable at all, including for rows that predate the column.
+ *
+ * Whatever is learned is PERSISTED immediately, so the next attempt starts at
+ * (1) even if this one dies on the next line.
+ */
+async function deleteAndPurgeRegistration(
+  opts: TeamsIdentityResetOptions,
+  provisioner: TeamsResetProvisionerPort,
+  row: TeamsResetIdentityRecord,
+): Promise<TeamsResetStepReport> {
+  const step = 'app_deleted' as const;
+  if (row.appId === null) {
+    return { step, outcome: 'skipped', detail: TEAMS_RESET_DETAILS.nothingToRemove };
+  }
+  const appId = row.appId;
+
+  /** Ask the recycle bin. `null` = could not look; `undefined` = looked, empty. */
+  const searchRecycleBin = async (): Promise<string | null | undefined> => {
+    if (!supportsDeletedAppRegistrationLookup(provisioner)) return null;
+    const found = await (
+      provisioner.findDeletedAppRegistration as NonNullable<
+        TeamsResetProvisionerPort['findDeletedAppRegistration']
+      >
+    ).call(provisioner, { appId });
+    return found.found ? found.objectId : undefined;
+  };
+
+  const remember = async (objectId: string): Promise<void> => {
+    // Persisted the moment it is known, never held only in a local: had the
+    // process died between the delete below and a later write, the
+    // recycle-bin entry holding this agent's `uniqueName` would have become
+    // unaddressable for any connector that cannot search.
+    await opts.store.update(row.agentId, { appObjectId: objectId });
+  };
+
+  let objectId = row.appObjectId;
+  /** Did the recycle bin answer "empty" rather than "cannot look"? */
+  let provablyGone = false;
+  if (objectId === null) {
+    try {
+      const live = await provisioner.getAppRegistration(appId, provisioner.tenantMode);
+      if (live !== undefined) {
+        objectId = live.objectId;
+        await remember(objectId);
+      } else {
+        // Not live. Either somebody already deleted it (a tombstone) or it is
+        // fully gone. Only the recycle bin can tell those two apart.
+        const deletedObjectId = await searchRecycleBin();
+        if (typeof deletedObjectId === 'string') {
+          objectId = deletedObjectId;
+          await remember(objectId);
+        } else if (deletedObjectId === undefined) {
+          provablyGone = true;
+        }
+      }
+    } catch (err) {
+      return {
+        step,
+        outcome: 'failed',
+        detail: `${TEAMS_RESET_FAILURE_PREFIXES.appDelete}${errorMessage(err)}`,
+      };
+    }
+  }
+
+  if (objectId === null) {
+    // Nothing left to call: the application is not in `/applications`, and
+    // either the recycle bin is empty (`provablyGone`) or we cannot see into
+    // it. Both are reported as done; only the second carries a warning,
+    // because only the second can still be holding the slug.
+    return {
+      step,
+      outcome: 'already-absent',
+      detail: provablyGone
+        ? TEAMS_RESET_DETAILS.appProvablyGone
+        : TEAMS_RESET_DETAILS.appAbsentUnpurgeable,
+    };
+  }
+
+  if (!supportsAppRegistrationPurge(provisioner)) {
+    // THE REFUSAL. Deleting here would be actively harmful: it converts a
+    // registration this agent can still adopt into a 30-day reservation on
+    // its own `uniqueName`. Doing nothing is strictly better, so nothing is
+    // what happens — loudly.
+    return { step, outcome: 'blocked', detail: TEAMS_RESET_DETAILS.purgeUnsupported };
+  }
+
+  let deleted: { readonly outcome: string };
+  try {
+    deleted = await provisioner.deleteAppRegistration({ appId });
+  } catch (err) {
+    return {
+      step,
+      outcome: 'failed',
+      detail: `${TEAMS_RESET_FAILURE_PREFIXES.appDelete}${errorMessage(err)}`,
+    };
+  }
+
+  const purge = async (id: string): Promise<void> => {
+    await (
+      provisioner.purgeDeletedAppRegistration as NonNullable<
+        TeamsResetProvisionerPort['purgeDeletedAppRegistration']
+      >
+    ).call(provisioner, { objectId: id });
+  };
+
+  try {
+    await purge(objectId);
+  } catch (err) {
+    // ONE retry, and only for the one error a retry can fix: the connector
+    // says we handed it an `appId` where a directory object id belongs. A
+    // stored `app_object_id` can be wrong that way — an older write, a
+    // hand-edited row — and both identifiers are GUIDs, so nothing upstream
+    // would have caught it.
+    //
+    // The connector resolves the right id WHILE refusing and ships it on the
+    // error, so the retry uses that value and only falls back to searching
+    // the recycle bin when the error came without one. Every other failure is
+    // reported as it is — and note what is deliberately NOT special-cased
+    // here: a 404. Graph answers "resource not found" both for an id that was
+    // already purged and for an id of the wrong kind, so reading one as proof
+    // of a clean recycle bin is exactly the mistake
+    // `DeletedObjectIdMismatchError` exists to prevent.
+    if (!isDeletedObjectIdMismatchError(err)) {
+      return {
+        step,
+        outcome: 'failed',
+        detail: `${TEAMS_RESET_FAILURE_PREFIXES.appPurge}${errorMessage(err)}`,
+      };
+    }
+    try {
+      const corrected = correctedObjectIdOf(err) ?? (await searchRecycleBin());
+      if (typeof corrected !== 'string') throw err;
+      await remember(corrected);
+      await purge(corrected);
+    } catch (retryErr) {
+      // The dangerous half-state, and the row is deliberately left ALONE: it
+      // still carries `app_id`, which is what lets a second call search the
+      // recycle bin and finish the purge. Clearing it here would be #916 with
+      // extra steps.
+      return {
+        step,
+        outcome: 'failed',
+        detail: `${TEAMS_RESET_FAILURE_PREFIXES.appPurge}${errorMessage(retryErr)}`,
+      };
+    }
+  }
+
+  return {
+    step,
+    outcome:
+      deleted.outcome === 'already-deleted' || deleted.outcome === 'already-absent'
+        ? 'already-absent'
+        : 'removed',
+  };
+}

--- a/middleware/src/services/teamsProvisioningJob.ts
+++ b/middleware/src/services/teamsProvisioningJob.ts
@@ -116,6 +116,16 @@ export interface TeamsIdentityJobRecord {
   readonly displayName: string;
   readonly state: TeamsProvisioningState;
   readonly appId: string | null;
+  /**
+   * The Entra app's directory object id (migration 0055) — what the
+   * teardown's purge needs and `appId` cannot substitute for.
+   *
+   * OPTIONAL on this structural port, like every other additive field here
+   * (`targetKind` before it): a store or a test double that predates the
+   * column still satisfies the type, and absent means the same as `null` —
+   * the teardown re-resolves the id from Graph or from the recycle bin.
+   */
+  readonly appObjectId?: string | null;
   readonly tenantId: string | null;
   readonly teamsAppId: string | null;
   readonly teamsAppExternalId: string | null;
@@ -125,6 +135,7 @@ export interface TeamsIdentityJobRecord {
 export interface TeamsIdentityJobUpdate {
   readonly state?: TeamsProvisioningState;
   readonly appId?: string;
+  readonly appObjectId?: string | null;
   readonly tenantId?: string;
   readonly teamsAppId?: string;
   readonly teamsAppExternalId?: string;
@@ -330,7 +341,20 @@ export type TenantMode = 'customer' | 'home';
 
 export interface ProvisionerAppRegistrationResult {
   readonly appId: string;
-  readonly registration: { readonly tenantId: string };
+  readonly registration: {
+    readonly tenantId: string;
+    /**
+     * The DIRECTORY OBJECT id (migration 0055) — a different identifier from
+     * {@link appId} and the only one the recycle-bin purge accepts.
+     *
+     * Optional on the PORT although the connector contract always returns it,
+     * because every existing test double predates it and a required field
+     * would break them all for a value none of them exercises. The runner
+     * persists it when it is there and shrugs when it is not; the teardown
+     * (`services/teamsIdentityReset.ts`) can re-resolve it either way.
+     */
+    readonly objectId?: string;
+  };
 }
 
 export interface ProvisionerRegistrationOnlyOutcome {
@@ -362,7 +386,11 @@ export interface TeamsProvisionerPort {
     readonly secretDisplayName?: string;
     /** Early-persistence hook — see the runner's step 1 (byte5ai/omadia#916). */
     readonly onRegistrationCreated?: (
-      registration: { readonly appId: string; readonly tenantId: string },
+      registration: {
+        readonly appId: string;
+        readonly tenantId: string;
+        readonly objectId?: string;
+      },
       outcome: IdempotentOutcome,
     ) => void | Promise<void>;
   }): Promise<Idempotent<ProvisionerAppRegistrationResult>>;
@@ -723,12 +751,22 @@ export type ProvisioningRunResult =
       readonly detail: string;
     }
   | {
-      /** A run for the SAME agent but a DIFFERENT team is in flight — this
-       *  request was refused outright (nothing enqueued, nothing joined), so
-       *  a caller can never be handed the other team's success. */
+      /**
+       * Refused outright — nothing enqueued, nothing joined, so a caller can
+       * never be handed somebody else's outcome. Two causes:
+       *
+       *   * `'team_conflict'` — a run for the SAME agent but a DIFFERENT team
+       *     is in flight;
+       *   * `'exclusive_lease'` — a non-provisioning operation holds this
+       *     agent (today: a teardown, {@link
+       *     TeamsProvisioningJobRunner.acquireExclusive}). Provisioning into
+       *     an identity whose Azure objects are being deleted underneath it
+       *     would race the two against each other over the same app
+       *     registration.
+       */
       readonly status: 'rejected';
       readonly agentId: string;
-      readonly reason: 'team_conflict';
+      readonly reason: 'team_conflict' | 'exclusive_lease';
       readonly detail: string;
     }
   | { readonly status: 'stopped'; readonly agentId: string };
@@ -862,6 +900,22 @@ export class TeamsProvisioningJobRunner {
    *  say WHICH step it is retrying. One run per agent is guaranteed by
    *  {@link inFlight}, so an agent id is a sufficient key. */
   private readonly currentStep = new Map<string, TeamsProvisioningStep>();
+  /**
+   * Agents held by an operation that is NOT a provisioning run — today only
+   * the teardown (`services/teamsIdentityReset.ts`), reserved through
+   * {@link acquireExclusive}.
+   *
+   * Kept next to {@link inFlight} rather than inside it because the two hold
+   * different things: `inFlight` holds a promise a second caller can JOIN,
+   * and there is nothing joinable about a teardown — a caller who arrives
+   * mid-teardown must be refused, not handed its result. Sharing the map
+   * would have meant giving every entry a nullable `run` and a discriminator
+   * for the sake of one extra state.
+   *
+   * The value is a short label, so a refusal can say WHAT is holding the
+   * agent instead of only that something is.
+   */
+  private readonly leases = new Map<string, string>();
   private readonly pendingSleeps = new Set<() => void>();
   private stopped = false;
 
@@ -894,6 +948,19 @@ export class TeamsProvisioningJobRunner {
    * result (never silently handed the other team's outcome).
    */
   enqueue(request: ProvisionTeamsIdentityRequest): Promise<ProvisioningRunResult> {
+    // Checked BEFORE the in-flight lookup: a leased agent has no in-flight
+    // run to join, and falling through would refuse it with `team_conflict`,
+    // which names the wrong problem and sends the operator looking for a
+    // second team that does not exist.
+    const lease = this.leases.get(request.agentId);
+    if (lease !== undefined) {
+      return Promise.resolve({
+        status: 'rejected',
+        agentId: request.agentId,
+        reason: 'exclusive_lease',
+        detail: `'${lease}' is in progress for this agent — wait for it to finish, then run provisioning again`,
+      });
+    }
     const existing = this.inFlight.get(request.agentId);
     if (existing) {
       if (existing.teamId === request.teamId) return existing.run;
@@ -949,8 +1016,50 @@ export class TeamsProvisioningJobRunner {
    * it from the row.
    */
   isRunning(agentId: string): boolean {
+    // A held lease counts as running, and it has to: the operator screen asks
+    // this to decide whether work is happening on the agent, and a teardown
+    // deleting an app registration is emphatically work. Reporting `false`
+    // would also let the UI offer a second teardown next to the one already
+    // going.
+    if (this.leases.has(agentId)) return true;
     const entry = this.inFlight.get(agentId);
     return entry !== undefined && !entry.settled;
+  }
+
+  /**
+   * Reserve this agent for an operation that is not a provisioning run, and
+   * return the function that gives it back — or `null` when the agent is
+   * already busy.
+   *
+   * THE MUTUAL EXCLUSION IS THE POINT. A teardown deletes the Entra app the
+   * chain is mid-way through building on; running both at once means one of
+   * them is operating on objects the other is removing, and neither can
+   * report a truthful outcome. The lock lives HERE, on the runner, because
+   * the runner is the only thing that already knows what is in flight — a
+   * second lock elsewhere would be a second opinion about the same question.
+   *
+   * The release is a closure rather than a `release(agentId)` method so a
+   * caller cannot release somebody else's lease, and it is idempotent so a
+   * `finally` that runs twice is harmless.
+   */
+  acquireExclusive(agentId: string, label: string): (() => void) | null {
+    // `inFlight.has`, not `isRunning`: a run that has its verdict but is
+    // still writing its bindings and its plugin config is not something a
+    // teardown may start deleting underneath.
+    if (this.inFlight.has(agentId) || this.leases.has(agentId)) return null;
+    this.leases.set(agentId, label);
+    let released = false;
+    return (): void => {
+      if (released) return;
+      released = true;
+      this.leases.delete(agentId);
+    };
+  }
+
+  /** What is holding this agent, or `null` — so a route can name the
+   *  conflict in its refusal instead of saying "busy". */
+  exclusiveLease(agentId: string): string | null {
+    return this.leases.get(agentId) ?? null;
   }
 
   /**
@@ -1479,6 +1588,16 @@ export class TeamsProvisioningJobRunner {
           await this.store.update(agentId, {
             appId: registration.appId,
             tenantId: registration.tenantId,
+            // Written in the SAME statement as the app id, deliberately. The
+            // two are only ever observable together — after a delete the
+            // application is gone from `/applications` and no lookup turns one
+            // into the other any more — so a teardown that has one and not the
+            // other cannot empty the recycle bin, and the agent's `uniqueName`
+            // stays reserved for 30 days (#916). Two writes would have left a
+            // window where exactly that is true.
+            ...(registration.objectId === undefined
+              ? {}
+              : { appObjectId: registration.objectId }),
           });
           // The ONE boundary inside this call the connector's contract already
           // exposes, and therefore the only honest intra-step progress the
@@ -1496,6 +1615,13 @@ export class TeamsProvisioningJobRunner {
         state: 'app_registered',
         appId: result.value.appId,
         tenantId: result.value.registration.tenantId,
+        // Also here, not only in the hook above: the hook is skipped entirely
+        // when the connector ADOPTS an existing registration, which is the
+        // resume path — and a resumed identity needs its object id just as
+        // much as a fresh one.
+        ...(result.value.registration.objectId === undefined
+          ? {}
+          : { appObjectId: result.value.registration.objectId }),
         lastError: null,
       });
       await this.emit(agentId, 'app_registered', 'succeeded');

--- a/middleware/src/services/teamsTargetDirectoryService.ts
+++ b/middleware/src/services/teamsTargetDirectoryService.ts
@@ -1,0 +1,202 @@
+/**
+ * "Which teams and chats could this agent be installed into?" — answered in a
+ * shape that can say *I don't know*.
+ *
+ * THE ONE RULE THIS MODULE EXISTS TO ENFORCE
+ * ------------------------------------------
+ * An empty list and an unavailable list must never look the same. A picker
+ * that renders `[]` because the connector is too old, or because nobody has
+ * signed in, tells the operator their tenant has no teams — which is a lie,
+ * and a lie that makes them go looking in the wrong place. So every listing
+ * is a discriminated union: either `available: true` with items (`[]` then
+ * genuinely meaning "none"), or `available: false` with a REASON the UI turns
+ * into one sentence explaining what to do about it.
+ *
+ * That is also why nothing here throws. An enumeration is a convenience over
+ * a field the operator can still type into; a 500 from the convenience must
+ * not take the field down with it.
+ *
+ * TEAMS AND CHATS DEGRADE INDEPENDENTLY
+ * -------------------------------------
+ * `listTeams` is app-only and works wherever the connector is installed.
+ * `listChats` is delegated-only — Graph has no tenant-wide application route
+ * for chats — and additionally needs `Chat.ReadBasic`, which credentials
+ * stored before connector 0.8.0 do not carry and cannot obtain by refreshing.
+ * They are therefore probed separately and reported separately: a missing
+ * chat scope must not be able to hide the team list, which is the half that
+ * always works.
+ */
+
+import {
+  isDelegatedConsentRequiredError,
+  isDelegatedSignInRequiredError,
+  isDelegatedTokenExpiredError,
+  type DelegatedTokenSet,
+} from '../platform/teamsDelegatedSignIn.js';
+import {
+  isDelegatedScopeRequiredError,
+  supportsChatListing,
+  supportsTeamListing,
+  type ListChatsInput,
+  type TeamsChatSummary,
+  type TeamsTeamSummary,
+} from '../platform/teamsTargetDirectory.js';
+
+/**
+ * Why a listing is not available.
+ *
+ * Every value is a machine code the web UI has a sentence for — the router
+ * never ships prose it would have to keep in sync with a translation file.
+ */
+export type TeamsTargetListingUnavailable =
+  /** No connector plugin installed/active at all. */
+  | 'connector_unavailable'
+  /** The installed connector publishes no such method (older version). */
+  | 'connector_unsupported'
+  /** A tenant admin has to sign in before Graph will answer (#924/#949). */
+  | 'sign_in_required'
+  /**
+   * Somebody IS signed in, but with a credential issued before this listing's
+   * scope existed (`Chat.ReadBasic`, connector 0.8.0).
+   *
+   * Kept apart from `sign_in_required` because the two look identical to the
+   * code and completely different to the person: this one means "you are
+   * signed in, it still is not enough, sign in once more" — and, crucially,
+   * that a refresh will never fix it, because a refresh token only renews the
+   * scopes it was issued for. Folding it into `sign_in_required` would put an
+   * operator who is demonstrably signed in in front of a message telling them
+   * to sign in, with no explanation of why the first time did not count.
+   */
+  | 'scope_missing'
+  /** Signed in, but the tenant never granted the permission at all. */
+  | 'consent_required'
+  /** Graph answered, badly. Transient far more often than not. */
+  | 'lookup_failed';
+
+export type TeamsTargetListing<T> =
+  | { readonly available: true; readonly items: readonly T[] }
+  | {
+      readonly available: false;
+      readonly reason: TeamsTargetListingUnavailable;
+    };
+
+export interface TeamsTargetDirectory {
+  readonly teams: TeamsTargetListing<TeamsTeamSummary>;
+  readonly chats: TeamsTargetListing<TeamsChatSummary>;
+}
+
+/** The provisioner surface this service uses — structural, both methods
+ *  optional, so feature detection reads the object the call would go to. */
+export interface TeamsTargetDirectoryProvisioner {
+  listTeams?(): Promise<readonly TeamsTeamSummary[]>;
+  listChats?(input?: ListChatsInput): Promise<readonly TeamsChatSummary[]>;
+}
+
+export interface TeamsTargetDirectoryOptions {
+  /** `undefined` when the connector plugin is not installed/active. */
+  readonly getProvisioner: () => TeamsTargetDirectoryProvisioner | undefined;
+  /** The tenant sign-in, when one is wired. Absent is not an error — it only
+   *  means `listChats` is called without tokens and the connector decides. */
+  readonly delegatedTokens?: { read(): Promise<DelegatedTokenSet | undefined> };
+  readonly log?: (msg: string) => void;
+}
+
+/**
+ * Classify a thrown enumeration failure.
+ *
+ * The three delegated guards come first because they are the only ones that
+ * name a HUMAN ACTION: "sign in", "grant consent". Reporting either of those
+ * as `lookup_failed` would put an operator in front of a retry button for a
+ * condition no retry can fix.
+ */
+function classifyListingFailure(err: unknown): TeamsTargetListingUnavailable {
+  // FIRST, and deliberately: the connector raises this one WITHOUT calling
+  // Graph, from the token set alone, so it is the most certain answer
+  // available and the only one that says "the sign-in you already have is
+  // the wrong shape" rather than "there is no sign-in".
+  if (isDelegatedScopeRequiredError(err)) return 'scope_missing';
+  if (isDelegatedSignInRequiredError(err)) return 'sign_in_required';
+  if (isDelegatedTokenExpiredError(err)) return 'sign_in_required';
+  if (isDelegatedConsentRequiredError(err)) return 'consent_required';
+  return 'lookup_failed';
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Both listings, each degraded on its own.
+ *
+ * Deliberately sequential rather than `Promise.all`: these are two Graph
+ * enumerations fired from an operator screen that may be polled, and the
+ * throttling budget they share is the connector's. The latency of one extra
+ * round trip is not worth a 429 that turns BOTH halves into `lookup_failed`.
+ */
+export async function loadTeamsTargetDirectory(
+  opts: TeamsTargetDirectoryOptions,
+): Promise<TeamsTargetDirectory> {
+  const provisioner = opts.getProvisioner();
+  if (provisioner === undefined) {
+    return {
+      teams: { available: false, reason: 'connector_unavailable' },
+      chats: { available: false, reason: 'connector_unavailable' },
+    };
+  }
+  return {
+    teams: await listTeamsSafely(opts, provisioner),
+    chats: await listChatsSafely(opts, provisioner),
+  };
+}
+
+async function listTeamsSafely(
+  opts: TeamsTargetDirectoryOptions,
+  provisioner: TeamsTargetDirectoryProvisioner,
+): Promise<TeamsTargetListing<TeamsTeamSummary>> {
+  if (!supportsTeamListing(provisioner)) {
+    return { available: false, reason: 'connector_unsupported' };
+  }
+  try {
+    const items = await (
+      provisioner.listTeams as NonNullable<
+        TeamsTargetDirectoryProvisioner['listTeams']
+      >
+    ).call(provisioner);
+    return { available: true, items };
+  } catch (err) {
+    opts.log?.(`[teams-targets] listTeams failed: ${errorMessage(err)}`);
+    return { available: false, reason: classifyListingFailure(err) };
+  }
+}
+
+async function listChatsSafely(
+  opts: TeamsTargetDirectoryOptions,
+  provisioner: TeamsTargetDirectoryProvisioner,
+): Promise<TeamsTargetListing<TeamsChatSummary>> {
+  if (!supportsChatListing(provisioner)) {
+    return { available: false, reason: 'connector_unsupported' };
+  }
+  // Read the token set but do NOT gate on it, even though chat enumeration is
+  // known to be delegated-only (Graph has no tenant-wide application route
+  // for chats). The connector distinguishes "no sign-in" from "sign-in
+  // without `Chat.ReadBasic`" and only it can tell them apart; a
+  // `sign_in_required` invented here would collapse the two and tell an admin
+  // who IS signed in to sign in, with no hint that the scope is what changed.
+  let tokens: DelegatedTokenSet | undefined;
+  try {
+    tokens = await opts.delegatedTokens?.read();
+  } catch (err) {
+    opts.log?.(`[teams-targets] delegated token read failed: ${errorMessage(err)}`);
+  }
+  try {
+    const items = await (
+      provisioner.listChats as NonNullable<
+        TeamsTargetDirectoryProvisioner['listChats']
+      >
+    ).call(provisioner, tokens === undefined ? undefined : { tokens });
+    return { available: true, items };
+  } catch (err) {
+    opts.log?.(`[teams-targets] listChats failed: ${errorMessage(err)}`);
+    return { available: false, reason: classifyListingFailure(err) };
+  }
+}

--- a/middleware/test/agentTeamsIdentityStore.pg.test.ts
+++ b/middleware/test/agentTeamsIdentityStore.pg.test.ts
@@ -54,6 +54,7 @@ const MIGRATION_FILES = [
   // 0054 without it fails on a relation that does not exist.
   '0051_agent_teams_installs.sql',
   '0054_agent_teams_target_kind.sql',
+  '0055_agent_teams_app_object_id.sql',
 ] as const;
 
 const SCHEMA = `w1a_teams_ident_${String(process.pid)}`;

--- a/middleware/test/teamsIdentityReset.test.ts
+++ b/middleware/test/teamsIdentityReset.test.ts
@@ -1,0 +1,636 @@
+/**
+ * The teardown: undoing a provisioning run without making things worse.
+ *
+ * WHAT THIS SUITE IS REALLY PINNING. Every case here traces back to one
+ * question — *what is the worst state an interrupted reset can leave behind?*
+ * The answer is a deleted-but-not-purged Entra application, which keeps
+ * reserving its `uniqueName` for 30 days and makes the operator's next attempt
+ * with the same bot slug collide with the corpse of the previous one
+ * (byte5ai/omadia#916). So the suite is built around three claims:
+ *
+ *   1. the ORDER never lets an abort leave a worse state than it found —
+ *      the irreversible step is last, and the step whose failure would
+ *      silently poison the next run (the catalog entry) stops everything;
+ *   2. delete and purge are ONE operation — a connector that cannot purge is
+ *      not allowed to delete, and a purge that failed keeps the identifiers
+ *      that let a second call finish it;
+ *   3. a second call always finishes what the first started, from whatever
+ *      point it died.
+ *
+ * Self-contained doubles rather than the shared fixture: the shape of a
+ * teardown is the thing under test, so it should be readable in one file.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import {
+  resetTeamsIdentity,
+  TeamsIdentityResetNotFoundError,
+  TEAMS_RESET_DETAILS,
+  type TeamsIdentityResetOptions,
+  type TeamsResetDeleteBotResult,
+  type TeamsResetIdentityRecord,
+  type TeamsResetProvisionerPort,
+  type TeamsResetStepReport,
+} from '../src/services/teamsIdentityReset.js';
+
+// ---------------------------------------------------------------------------
+// Doubles
+// ---------------------------------------------------------------------------
+
+const OBJECT_ID = 'obj-1111';
+const APP_ID = 'app-1111';
+
+interface MemoryStore {
+  row: TeamsResetIdentityRecord | undefined;
+  readonly writes: { readonly appObjectId?: string | null }[];
+  resetCalls: number;
+  getByAgentId(agentId: string): Promise<TeamsResetIdentityRecord | undefined>;
+  update(
+    agentId: string,
+    patch: { readonly appObjectId?: string | null },
+  ): Promise<unknown>;
+  resetForRetry(agentId: string): Promise<unknown>;
+}
+
+function memoryStore(row: Partial<TeamsResetIdentityRecord>): MemoryStore {
+  const store: MemoryStore = {
+    row: {
+      agentId: 'agent-1',
+      botSlug: 'acme',
+      appId: APP_ID,
+      appObjectId: null,
+      teamsAppId: 'catalog-1',
+      ...row,
+    },
+    writes: [],
+    resetCalls: 0,
+    getByAgentId: async () => store.row,
+    update: async (_agentId, patch) => {
+      store.writes.push(patch);
+      if (store.row && patch.appObjectId !== undefined) {
+        store.row = { ...store.row, appObjectId: patch.appObjectId };
+      }
+      return undefined;
+    },
+    resetForRetry: async () => {
+      store.resetCalls += 1;
+      return undefined;
+    },
+  };
+  return store;
+}
+
+interface StubProvisioner extends TeamsResetProvisionerPort {
+  readonly calls: string[];
+}
+
+interface StubOptions {
+  readonly live?: boolean;
+  readonly deleted?: boolean;
+  readonly canPurge?: boolean;
+  readonly canFind?: boolean;
+  readonly canRemoveFromCatalog?: boolean;
+  readonly deleteBotResult?: TeamsResetDeleteBotResult;
+  readonly failOn?: 'catalog' | 'bot' | 'delete' | 'purge';
+  readonly purgeError?: Error;
+}
+
+/**
+ * A provisioner that MODELS AZURE rather than returning canned answers: it
+ * keeps whether the application is live, in the recycle bin, or gone, and the
+ * primitives move it between those. That is what lets the resumption tests
+ * assert real continuations instead of replayed scripts.
+ */
+function stubProvisioner(opts: StubOptions = {}): StubProvisioner {
+  const calls: string[] = [];
+  let live = opts.live ?? true;
+  let deleted = opts.deleted ?? false;
+
+  const base: TeamsResetProvisionerPort = {
+    tenantMode: 'customer',
+    getAppRegistration: async (appId) => {
+      calls.push(`getAppRegistration:${appId}`);
+      return live ? { objectId: OBJECT_ID } : undefined;
+    },
+    deleteAppRegistration: async ({ appId }) => {
+      calls.push(`deleteAppRegistration:${appId}`);
+      if (opts.failOn === 'delete') throw new Error('graph exploded');
+      if (!live) return { outcome: 'already-deleted' };
+      live = false;
+      deleted = true;
+      return { outcome: 'deleted' };
+    },
+    deleteBot: async (botName) => {
+      calls.push(`deleteBot:${botName}`);
+      if (opts.failOn === 'bot') throw new Error('arm exploded');
+      return opts.deleteBotResult ?? { kind: 'deleted', outcome: 'deleted' };
+    },
+  };
+
+  const purge =
+    opts.canPurge === false
+      ? {}
+      : {
+          purgeDeletedAppRegistration: async ({ objectId }: { objectId: string }) => {
+            calls.push(`purge:${objectId}`);
+            if (opts.failOn === 'purge') {
+              throw opts.purgeError ?? new Error('purge exploded');
+            }
+            deleted = false;
+            return { outcome: 'purged' };
+          },
+        };
+
+  const find =
+    opts.canFind === false
+      ? {}
+      : {
+          findDeletedAppRegistration: async ({ appId }: { appId: string }) => {
+            calls.push(`findDeleted:${appId}`);
+            return deleted
+              ? ({ found: true, objectId: OBJECT_ID } as const)
+              : ({ found: false } as const);
+          },
+        };
+
+  const catalog =
+    opts.canRemoveFromCatalog === false
+      ? {}
+      : {
+          removeFromCatalog: async ({ teamsAppId }: { teamsAppId: string }) => {
+            calls.push(`removeFromCatalog:${teamsAppId}`);
+            if (opts.failOn === 'catalog') throw new Error('catalog exploded');
+            return { outcome: 'removed' };
+          },
+        };
+
+  return { ...base, ...purge, ...find, ...catalog, calls };
+}
+
+const TOKENS = { accessToken: 'x', tenantId: 't' } as unknown as never;
+
+function options(
+  store: MemoryStore,
+  provisioner: StubProvisioner,
+  extra: Partial<TeamsIdentityResetOptions> = {},
+): TeamsIdentityResetOptions {
+  return {
+    store,
+    getProvisioner: () => provisioner,
+    buildBotHandle: (slug, appId) => `omadia-${slug}-${appId.slice(0, 8)}`,
+    delegatedTokens: { read: async () => TOKENS },
+    ...extra,
+  };
+}
+
+function outcomeOf(
+  steps: readonly TeamsResetStepReport[],
+  step: TeamsResetStepReport['step'],
+): TeamsResetStepReport | undefined {
+  return steps.find((entry) => entry.step === step);
+}
+
+// ---------------------------------------------------------------------------
+
+describe('teams identity reset — the partial states', () => {
+  it('tears down a complete provisioning in the documented order', async () => {
+    const store = memoryStore({});
+    const provisioner = stubProvisioner();
+
+    const result = await resetTeamsIdentity(options(store, provisioner), 'agent-1');
+
+    assert.equal(result.status, 'reset');
+    // THE ORDER IS THE ASSERTION. Catalog first (its failure would poison the
+    // next run), then the bot (which depends on the app id), then the
+    // registration as delete+purge, and only then the row.
+    assert.deepEqual(
+      provisioner.calls.filter((c) => !c.startsWith('getAppRegistration')),
+      [
+        'removeFromCatalog:catalog-1',
+        'deleteBot:omadia-acme-app-1111',
+        'deleteAppRegistration:app-1111',
+        `purge:${OBJECT_ID}`,
+      ],
+    );
+    assert.equal(store.resetCalls, 1);
+  });
+
+  it('reports nothing-created as four skips and still clears the row', async () => {
+    const store = memoryStore({ appId: null, teamsAppId: null });
+    const provisioner = stubProvisioner();
+
+    const result = await resetTeamsIdentity(options(store, provisioner), 'agent-1');
+
+    assert.equal(result.status, 'reset');
+    assert.deepEqual(provisioner.calls, []);
+    for (const step of ['catalog_removed', 'bot_deleted', 'app_deleted'] as const) {
+      assert.equal(outcomeOf(result.steps, step)?.outcome, 'skipped');
+      assert.equal(
+        outcomeOf(result.steps, step)?.detail,
+        TEAMS_RESET_DETAILS.nothingToRemove,
+      );
+    }
+    assert.equal(store.resetCalls, 1);
+  });
+
+  it('with only the app registration created, skips the catalog and purges', async () => {
+    const store = memoryStore({ teamsAppId: null });
+    const provisioner = stubProvisioner();
+
+    const result = await resetTeamsIdentity(options(store, provisioner), 'agent-1');
+
+    assert.equal(result.status, 'reset');
+    assert.equal(outcomeOf(result.steps, 'catalog_removed')?.outcome, 'skipped');
+    assert.ok(provisioner.calls.includes(`purge:${OBJECT_ID}`));
+  });
+
+  it('reports an already-absent bot as a success, not a failure', async () => {
+    const store = memoryStore({});
+    const provisioner = stubProvisioner({
+      deleteBotResult: { kind: 'deleted', outcome: 'already-deleted' },
+    });
+
+    const result = await resetTeamsIdentity(options(store, provisioner), 'agent-1');
+
+    assert.equal(result.status, 'reset');
+    assert.equal(outcomeOf(result.steps, 'bot_deleted')?.outcome, 'already-absent');
+  });
+});
+
+describe('teams identity reset — the purge is not optional', () => {
+  it('REFUSES to delete the app registration when it cannot purge', async () => {
+    // The single most important case in this file. Deleting without purging
+    // converts a reusable registration into a 30-day reservation on the
+    // operator's own slug — strictly worse than doing nothing.
+    const store = memoryStore({});
+    const provisioner = stubProvisioner({ canPurge: false });
+
+    const result = await resetTeamsIdentity(options(store, provisioner), 'agent-1');
+
+    assert.equal(result.status, 'incomplete');
+    assert.equal(result.status === 'incomplete' ? result.stoppedAt : null, 'app_deleted');
+    assert.equal(outcomeOf(result.steps, 'app_deleted')?.outcome, 'blocked');
+    assert.equal(
+      outcomeOf(result.steps, 'app_deleted')?.detail,
+      TEAMS_RESET_DETAILS.purgeUnsupported,
+    );
+    assert.ok(
+      !provisioner.calls.some((c) => c.startsWith('deleteAppRegistration')),
+      'the registration must not be deleted when it cannot be purged',
+    );
+    assert.equal(store.resetCalls, 0, 'the row must keep pointing at the live app');
+  });
+
+  it('passes the OBJECT id to the purge, never the app id', async () => {
+    const store = memoryStore({});
+    const provisioner = stubProvisioner();
+
+    await resetTeamsIdentity(options(store, provisioner), 'agent-1');
+
+    assert.ok(provisioner.calls.includes(`purge:${OBJECT_ID}`));
+    assert.ok(
+      !provisioner.calls.includes(`purge:${APP_ID}`),
+      'the recycle bin is addressed by object id — an app id silently 404s',
+    );
+  });
+
+  it('persists the object id BEFORE the delete makes it unlookupable', async () => {
+    const store = memoryStore({});
+    const provisioner = stubProvisioner();
+
+    await resetTeamsIdentity(options(store, provisioner), 'agent-1');
+
+    assert.deepEqual(store.writes, [{ appObjectId: OBJECT_ID }]);
+    const lookupIndex = provisioner.calls.indexOf(`getAppRegistration:${APP_ID}`);
+    const deleteIndex = provisioner.calls.indexOf(`deleteAppRegistration:${APP_ID}`);
+    assert.ok(lookupIndex >= 0 && lookupIndex < deleteIndex);
+  });
+
+  it('uses a stored object id instead of looking it up again', async () => {
+    const store = memoryStore({ appObjectId: OBJECT_ID });
+    const provisioner = stubProvisioner();
+
+    await resetTeamsIdentity(options(store, provisioner), 'agent-1');
+
+    assert.ok(!provisioner.calls.some((c) => c.startsWith('getAppRegistration')));
+    assert.ok(provisioner.calls.includes(`purge:${OBJECT_ID}`));
+  });
+});
+
+describe('teams identity reset — interruption and resumption', () => {
+  it('a purge failure keeps the identifiers a second call needs', async () => {
+    const store = memoryStore({});
+    const first = stubProvisioner({ failOn: 'purge' });
+
+    const result = await resetTeamsIdentity(options(store, first), 'agent-1');
+
+    assert.equal(result.status, 'incomplete');
+    assert.equal(outcomeOf(result.steps, 'app_deleted')?.outcome, 'failed');
+    assert.equal(store.resetCalls, 0, 'the row must not be cleared mid-purge');
+    assert.equal(
+      store.row?.appObjectId,
+      OBJECT_ID,
+      'the object id is the only pointer to the tombstone — it must survive',
+    );
+  });
+
+  it('a second call finishes a teardown that died between delete and purge', async () => {
+    // The #916 scenario, replayed. The first attempt deletes and then dies;
+    // the second must still empty the recycle bin, or the slug is burned for
+    // 30 days.
+    const store = memoryStore({});
+    const first = stubProvisioner({ failOn: 'purge' });
+    await resetTeamsIdentity(options(store, first), 'agent-1');
+
+    // A fresh connector instance whose Azure now holds a TOMBSTONE, not a
+    // live application — exactly what the second call would really find.
+    const second = stubProvisioner({ live: false, deleted: true });
+    const result = await resetTeamsIdentity(options(store, second), 'agent-1');
+
+    assert.equal(result.status, 'reset');
+    assert.ok(second.calls.includes(`purge:${OBJECT_ID}`));
+    assert.equal(
+      outcomeOf(result.steps, 'app_deleted')?.outcome,
+      'already-absent',
+      'the delete was already done; repeating it is a success, not a failure',
+    );
+    assert.equal(store.resetCalls, 1);
+  });
+
+  it('recovers the object id from the recycle bin when the row never had one', async () => {
+    // A row provisioned before migration 0055, whose application somebody
+    // already deleted. `getAppRegistration` cannot help — only the search can.
+    const store = memoryStore({ appObjectId: null });
+    const provisioner = stubProvisioner({ live: false, deleted: true });
+
+    const result = await resetTeamsIdentity(options(store, provisioner), 'agent-1');
+
+    assert.equal(result.status, 'reset');
+    assert.ok(provisioner.calls.includes(`findDeleted:${APP_ID}`));
+    assert.ok(provisioner.calls.includes(`purge:${OBJECT_ID}`));
+    assert.equal(store.row?.appObjectId, OBJECT_ID);
+  });
+
+  it('retries the purge with the id a DeletedObjectIdMismatchError carries', async () => {
+    const store = memoryStore({ appObjectId: 'stale-object-id' });
+    let attempts = 0;
+    const provisioner = stubProvisioner();
+    const purged: string[] = [];
+    (
+      provisioner as { purgeDeletedAppRegistration?: unknown }
+    ).purgeDeletedAppRegistration = async ({ objectId }: { objectId: string }) => {
+      purged.push(objectId);
+      attempts += 1;
+      if (attempts === 1) {
+        const err = Object.assign(new Error('wrong identifier'), {
+          name: 'DeletedObjectIdMismatchError',
+          objectId: OBJECT_ID,
+        });
+        throw err;
+      }
+      return { outcome: 'purged' };
+    };
+
+    const result = await resetTeamsIdentity(options(store, provisioner), 'agent-1');
+
+    assert.equal(result.status, 'reset');
+    assert.deepEqual(purged, ['stale-object-id', OBJECT_ID]);
+    assert.equal(store.row?.appObjectId, OBJECT_ID, 'the corrected id is remembered');
+  });
+
+  it('reports an unpurgeable vanished app rather than claiming a clean sweep', async () => {
+    // Gone from `/applications`, no stored object id, and a connector that
+    // cannot search. Nothing left to call — but the slug may still be
+    // reserved, so it is NAMED rather than hidden behind a bare success.
+    const store = memoryStore({ appObjectId: null });
+    const provisioner = stubProvisioner({ live: false, canFind: false });
+
+    const result = await resetTeamsIdentity(options(store, provisioner), 'agent-1');
+
+    assert.equal(result.status, 'reset');
+    assert.equal(
+      outcomeOf(result.steps, 'app_deleted')?.detail,
+      TEAMS_RESET_DETAILS.appAbsentUnpurgeable,
+    );
+  });
+
+  it('reports a provably empty recycle bin as the strong kind of absence', async () => {
+    const store = memoryStore({ appObjectId: null });
+    const provisioner = stubProvisioner({ live: false, deleted: false });
+
+    const result = await resetTeamsIdentity(options(store, provisioner), 'agent-1');
+
+    assert.equal(
+      outcomeOf(result.steps, 'app_deleted')?.detail,
+      TEAMS_RESET_DETAILS.appProvablyGone,
+    );
+  });
+});
+
+describe('teams identity reset — the catalog entry gates everything', () => {
+  it('stops before touching Azure when the catalog cannot be withdrawn', async () => {
+    // `stableTeamsAppExternalId` is derived from the agent id, so a catalog
+    // entry survives any reset — and the chain ADOPTS a found entry without
+    // re-uploading. Deleting the app registration while it stands would give
+    // the next run a new appId paired with a manifest naming the old one:
+    // every step green, bot never answers.
+    const store = memoryStore({});
+    const provisioner = stubProvisioner({ canRemoveFromCatalog: false });
+
+    const result = await resetTeamsIdentity(options(store, provisioner), 'agent-1');
+
+    assert.equal(result.status, 'incomplete');
+    assert.equal(result.status === 'incomplete' ? result.stoppedAt : null, 'catalog_removed');
+    assert.equal(
+      outcomeOf(result.steps, 'catalog_removed')?.detail,
+      TEAMS_RESET_DETAILS.catalogRemovalUnsupported,
+    );
+    assert.deepEqual(provisioner.calls, [], 'nothing may be deleted');
+    assert.equal(store.resetCalls, 0);
+  });
+
+  it('blocks — not fails — when nobody is signed in', async () => {
+    const store = memoryStore({});
+    const provisioner = stubProvisioner();
+
+    const result = await resetTeamsIdentity(
+      options(store, provisioner, { delegatedTokens: { read: async () => undefined } }),
+      'agent-1',
+    );
+
+    assert.equal(result.status, 'incomplete');
+    assert.equal(outcomeOf(result.steps, 'catalog_removed')?.outcome, 'blocked');
+    assert.equal(
+      outcomeOf(result.steps, 'catalog_removed')?.detail,
+      TEAMS_RESET_DETAILS.tenantSignInRequired,
+    );
+    assert.deepEqual(provisioner.calls, []);
+  });
+
+  it('a catalog failure leaves the app registration alone', async () => {
+    const store = memoryStore({});
+    const provisioner = stubProvisioner({ failOn: 'catalog' });
+
+    const result = await resetTeamsIdentity(options(store, provisioner), 'agent-1');
+
+    assert.equal(result.status, 'incomplete');
+    assert.ok(!provisioner.calls.some((c) => c.startsWith('deleteAppRegistration')));
+    assert.equal(store.resetCalls, 0);
+  });
+
+  it('a bot failure stops before the registration it is named after', async () => {
+    const store = memoryStore({});
+    const provisioner = stubProvisioner({ failOn: 'bot' });
+
+    const result = await resetTeamsIdentity(options(store, provisioner), 'agent-1');
+
+    assert.equal(result.status, 'incomplete');
+    assert.equal(result.status === 'incomplete' ? result.stoppedAt : null, 'bot_deleted');
+    assert.ok(!provisioner.calls.some((c) => c.startsWith('deleteAppRegistration')));
+  });
+});
+
+describe('teams identity reset — bookkeeping', () => {
+  it('drops the recorded installs together with the row', async () => {
+    const store = memoryStore({});
+    const provisioner = stubProvisioner();
+    const removed: string[] = [];
+
+    await resetTeamsIdentity(
+      options(store, provisioner, {
+        installs: {
+          removeAllForAgent: async (agentId) => {
+            removed.push(agentId);
+            return 2;
+          },
+        },
+      }),
+      'agent-1',
+    );
+
+    assert.deepEqual(removed, ['agent-1']);
+  });
+
+  it('writes one timeline, opened by a clear and closed by a verdict', async () => {
+    const store = memoryStore({});
+    const provisioner = stubProvisioner();
+    const events: string[] = [];
+    let cleared = 0;
+
+    await resetTeamsIdentity(
+      options(store, provisioner, {
+        events: {
+          record: async ({ step, status }) => {
+            events.push(`${step}/${status}`);
+            return undefined;
+          },
+          clearForAgent: async () => {
+            cleared += 1;
+            return undefined;
+          },
+        },
+      }),
+      'agent-1',
+    );
+
+    assert.equal(cleared, 1, 'a teardown describes ONE operation');
+    assert.equal(events[0], 'reset/started');
+    assert.equal(events.at(-1), 'reset/succeeded');
+    assert.ok(events.includes('app_deleted/started'));
+    assert.ok(events.includes('app_deleted/succeeded'));
+  });
+
+  it('a sink that rejects never fails the teardown', async () => {
+    const store = memoryStore({});
+    const provisioner = stubProvisioner();
+
+    const result = await resetTeamsIdentity(
+      options(store, provisioner, {
+        events: {
+          record: async () => {
+            throw new Error('postgres is down');
+          },
+          clearForAgent: async () => {
+            throw new Error('postgres is down');
+          },
+        },
+      }),
+      'agent-1',
+    );
+
+    assert.equal(result.status, 'reset');
+  });
+
+  it('throws for an agent that has no identity row', async () => {
+    const store = memoryStore({});
+    store.row = undefined;
+
+    await assert.rejects(
+      () => resetTeamsIdentity(options(store, stubProvisioner()), 'agent-1'),
+      TeamsIdentityResetNotFoundError,
+    );
+  });
+});
+
+
+describe('teams identity reset — the #916 trap, closed from both sides', () => {
+  it('finishes an interrupted purge from the app id ALONE, with no stored object id', async () => {
+    // THE CASE THAT COSTS A MONTH IF IT IS WRONG.
+    //
+    // The first attempt deletes the registration and dies before the purge.
+    // Then the object id is lost — a row that predates migration 0055, a
+    // failed write, a hand-edited row; the reason does not matter, the point
+    // is that the teardown must not DEPEND on it. All that is left is the
+    // `appId`, which the row keeps precisely because nothing clears it until
+    // the purge is confirmed.
+    //
+    // If this test goes red, a deleted-but-not-purged application keeps
+    // reserving `omadia-teams-bot-<botSlug>` for 30 days, and the operator
+    // finds out only when their retry collides with it.
+    const store = memoryStore({});
+    const first = stubProvisioner({ failOn: 'purge' });
+    const firstResult = await resetTeamsIdentity(options(store, first), 'agent-1');
+
+    assert.equal(firstResult.status, 'incomplete');
+    assert.equal(
+      store.row?.appId,
+      APP_ID,
+      'the app id is the last bridge to the tombstone — it must survive a failed purge',
+    );
+
+    // Wipe the convenience path, keeping only what the row is guaranteed to
+    // carry.
+    store.row = { ...(store.row as TeamsResetIdentityRecord), appObjectId: null };
+
+    const second = stubProvisioner({ live: false, deleted: true });
+    const result = await resetTeamsIdentity(options(store, second), 'agent-1');
+
+    assert.equal(result.status, 'reset');
+    assert.ok(
+      second.calls.includes(`findDeleted:${APP_ID}`),
+      'the recycle bin must be searched by app id',
+    );
+    assert.ok(
+      second.calls.includes(`purge:${OBJECT_ID}`),
+      'and the tombstone must actually be purged',
+    );
+    assert.equal(store.resetCalls, 1, 'only now may the row be cleared');
+  });
+
+  it('never clears the row while an Azure object it points at is still there', async () => {
+    // The invariant the test above depends on, asserted directly across every
+    // way a teardown can stop early.
+    for (const failOn of ['catalog', 'bot', 'delete', 'purge'] as const) {
+      const store = memoryStore({});
+      const result = await resetTeamsIdentity(
+        options(store, stubProvisioner({ failOn })),
+        'agent-1',
+      );
+      assert.equal(result.status, 'incomplete', `failOn=${failOn}`);
+      assert.equal(store.resetCalls, 0, `failOn=${failOn}: the row must be kept`);
+      assert.equal(store.row?.appId, APP_ID, `failOn=${failOn}: the app id must be kept`);
+    }
+  });
+});

--- a/middleware/test/teamsProvisioningEventStore.pg.test.ts
+++ b/middleware/test/teamsProvisioningEventStore.pg.test.ts
@@ -71,6 +71,7 @@ describe(
         // it runs.
         '0051_agent_teams_installs.sql',
         '0054_agent_teams_target_kind.sql',
+        '0055_agent_teams_app_object_id.sql',
       ]) {
         const sql = await readFile(resolve(MIGRATIONS_DIR, file), 'utf8');
         // Applied TWICE on purpose — the migrations README requires every

--- a/middleware/test/teamsProvisioningExclusiveLease.test.ts
+++ b/middleware/test/teamsProvisioningExclusiveLease.test.ts
@@ -1,0 +1,176 @@
+/**
+ * A teardown and a provisioning run must never overlap.
+ *
+ * WHY THIS NEEDS ITS OWN LOCK AND NOT JUST AN `isRunning` CHECK. A reset
+ * deletes the Entra app registration the chain is mid-way through building
+ * on. `isRunning` answers a question about the instant it was read; between
+ * that read and the reset's first delete, an enqueue can arrive and start
+ * creating exactly the objects the teardown is about to remove. Whichever one
+ * lands second reports an outcome that is not true.
+ *
+ * So the runner — the only thing that already knows what is in flight — hands
+ * out a lease, and the exclusion holds in BOTH directions:
+ *
+ *   * a teardown cannot start while a run is in flight;
+ *   * a run cannot start while a teardown holds the agent, and it is refused
+ *     with a reason that names the teardown rather than inventing a team
+ *     conflict that does not exist.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import type { TimerSeam } from '../src/plugins/jobScheduler.js';
+import {
+  TeamsProvisioningJobRunner,
+  type TeamsAppPackageAssets,
+  type TeamsIdentityJobRecord,
+  type TeamsProvisionerPort,
+} from '../src/services/teamsProvisioningJob.js';
+
+const IDLE_TIMERS: TimerSeam = {
+  setTimeout: (cb) => {
+    cb();
+    return 1;
+  },
+  clearTimeout() {},
+  setInterval() {
+    throw new Error('runner must not use setInterval');
+  },
+  clearInterval() {},
+};
+
+const ROW: TeamsIdentityJobRecord = {
+  agentId: 'agent-1',
+  botSlug: 'acme',
+  displayName: 'Acme',
+  state: 'pending',
+  appId: null,
+  appObjectId: null,
+  tenantId: null,
+  teamsAppId: null,
+  teamsAppExternalId: null,
+  lastError: null,
+};
+
+/** A runner whose chain never actually runs — every test here is about the
+ *  lock, not about provisioning. */
+function runner(
+  onCreate?: () => Promise<void>,
+): TeamsProvisioningJobRunner {
+  let row = ROW;
+  const provisioner: TeamsProvisionerPort = {
+    createAppRegistration: async () => {
+      await onCreate?.();
+      return {
+        outcome: 'created',
+        value: { appId: 'app-1', registration: { tenantId: 'tenant-1' } },
+      };
+    },
+    createBot: async () => ({
+      kind: 'provisioned',
+      bot: { outcome: 'created', value: { botName: 'bot' } },
+    }),
+    buildAppPackage: () => new Uint8Array([1]),
+    uploadToCatalog: async () => ({
+      outcome: 'created',
+      value: { teamsAppId: 'catalog-1' },
+    }),
+    getCatalogApp: async () => ({ found: false }),
+    installToTeam: async () => ({ outcome: 'created', value: {} }),
+  } as unknown as TeamsProvisionerPort;
+
+  return new TeamsProvisioningJobRunner({
+    store: {
+      getByAgentId: async () => row,
+      update: async (_id, patch) => {
+        row = { ...row, ...patch } as TeamsIdentityJobRecord;
+        return row;
+      },
+    },
+    getProvisioner: () => provisioner,
+    buildMessagingEndpoint: (slug) => `https://example.test/api/teams/${slug}/messages`,
+    loadPackageAssets: async () =>
+      ({
+        manifestTemplate: '{}',
+        params: {},
+        icons: { color: new Uint8Array([1]), outline: new Uint8Array([1]) },
+        externalId: 'ext-1',
+      }) as unknown as TeamsAppPackageAssets,
+    timers: IDLE_TIMERS,
+    maxAttempts: 1,
+  });
+}
+
+describe('teams provisioning — the exclusive lease', () => {
+  it('refuses a lease while a provisioning run is in flight', async () => {
+    // The run is held open inside `createAppRegistration`, so it is genuinely
+    // mid-chain when the teardown asks — not merely enqueued.
+    let releaseRun = (): void => {};
+    const held = new Promise<void>((resolve) => {
+      releaseRun = resolve;
+    });
+    const jobs = runner(() => held);
+    const run = jobs.enqueue({ agentId: 'agent-1', teamId: 'team-1' });
+
+    assert.equal(
+      jobs.acquireExclusive('agent-1', 'teams_identity_reset'),
+      null,
+      'a teardown must not start on top of a live run',
+    );
+
+    releaseRun();
+    await run;
+  });
+
+  it('refuses an enqueue while a teardown holds the agent, and says which', async () => {
+    const jobs = runner();
+    const release = jobs.acquireExclusive('agent-1', 'teams_identity_reset');
+    assert.notEqual(release, null);
+
+    const result = await jobs.enqueue({ agentId: 'agent-1', teamId: 'team-1' });
+
+    assert.equal(result.status, 'rejected');
+    assert.equal(
+      result.status === 'rejected' ? result.reason : null,
+      'exclusive_lease',
+      "not 'team_conflict' — there is no second team, and naming the wrong problem sends the operator hunting for one",
+    );
+    assert.ok(
+      result.status === 'rejected' && result.detail.includes('teams_identity_reset'),
+    );
+  });
+
+  it('reports the agent as running while a teardown holds it', () => {
+    const jobs = runner();
+    assert.equal(jobs.isRunning('agent-1'), false);
+    const release = jobs.acquireExclusive('agent-1', 'teams_identity_reset');
+    // Deleting an app registration is work, and a UI that showed the agent as
+    // idle would offer a second teardown next to the one already going.
+    assert.equal(jobs.isRunning('agent-1'), true);
+    assert.equal(jobs.exclusiveLease('agent-1'), 'teams_identity_reset');
+    release?.();
+    assert.equal(jobs.isRunning('agent-1'), false);
+    assert.equal(jobs.exclusiveLease('agent-1'), null);
+  });
+
+  it('refuses a second lease, and releases idempotently', async () => {
+    const jobs = runner();
+    const first = jobs.acquireExclusive('agent-1', 'teams_identity_reset');
+    assert.equal(jobs.acquireExclusive('agent-1', 'teams_identity_reset'), null);
+    first?.();
+    // A `finally` that runs twice must not hand the agent to somebody else.
+    first?.();
+    const second = jobs.acquireExclusive('agent-1', 'teams_identity_reset');
+    assert.notEqual(second, null);
+    second?.();
+    await Promise.resolve();
+  });
+
+  it('does not lock unrelated agents', () => {
+    const jobs = runner();
+    const release = jobs.acquireExclusive('agent-1', 'teams_identity_reset');
+    assert.notEqual(jobs.acquireExclusive('agent-2', 'teams_identity_reset'), null);
+    release?.();
+  });
+});

--- a/middleware/test/teamsTargetDirectory.test.ts
+++ b/middleware/test/teamsTargetDirectory.test.ts
@@ -1,0 +1,226 @@
+/**
+ * The target directory degrades; it never lies.
+ *
+ * THE ONE RULE UNDER TEST. An empty list and an unavailable list must not look
+ * the same. `available: true, items: []` is a claim about the tenant ("you
+ * have no teams"); `available: false` means we could not look. Collapsing the
+ * two would send an operator hunting through a Teams admin centre for teams
+ * that are right there.
+ *
+ * The second rule: the two halves degrade INDEPENDENTLY. `listTeams` is
+ * app-only and essentially always works; `listChats` is delegated-only —
+ * Graph publishes no tenant-wide application route for chats — and needs
+ * `Chat.ReadBasic`, which a credential stored before connector 0.8.0 does not
+ * carry and cannot pick up by refreshing. A missing chat scope must never be
+ * able to hide the team list.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import {
+  loadTeamsTargetDirectory,
+  type TeamsTargetDirectoryProvisioner,
+} from '../src/services/teamsTargetDirectoryService.js';
+import {
+  isDelegatedScopeRequiredError,
+  supportsChatListing,
+  supportsTeamListing,
+  teamsChatTargetKind,
+} from '../src/platform/teamsTargetDirectory.js';
+import { classifyTeamsInstallTarget } from '../src/platform/teamsInstallTarget.js';
+
+const TEAM = { id: '2f1a9c44-1f0e-4f2c-8f1a-9c441f0e4f2c', displayName: 'Acme' };
+const CHAT = {
+  id: '19:a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6@thread.v2',
+  topic: 'Support',
+  chatType: 'group' as const,
+};
+
+const TOKENS = { accessToken: 'x' } as unknown as never;
+
+function scopeError(): Error {
+  return Object.assign(new Error('Chat.ReadBasic is missing'), {
+    name: 'DelegatedScopeRequiredError',
+    reason: 'scope-missing',
+    missingScopes: ['Chat.ReadBasic'],
+  });
+}
+
+function signInError(): Error {
+  return Object.assign(new Error('sign in first'), {
+    name: 'DelegatedSignInRequiredError',
+  });
+}
+
+function directoryOf(
+  provisioner: TeamsTargetDirectoryProvisioner | undefined,
+  tokens: unknown = TOKENS,
+): ReturnType<typeof loadTeamsTargetDirectory> {
+  return loadTeamsTargetDirectory({
+    getProvisioner: () => provisioner,
+    delegatedTokens: { read: async () => tokens as never },
+  });
+}
+
+describe('teams target directory — the happy path', () => {
+  it('returns both listings when the connector can enumerate', async () => {
+    const result = await directoryOf({
+      listTeams: async () => [TEAM],
+      listChats: async () => [CHAT],
+    });
+
+    assert.deepEqual(result.teams, { available: true, items: [TEAM] });
+    assert.deepEqual(result.chats, { available: true, items: [CHAT] });
+  });
+
+  it('every listed id classifies UNAMBIGUOUSLY — the point of the whole feature', async () => {
+    // The field test behind migration 0054 was a bare 32-hex id, which reads
+    // as both a team group id and the stem of a chat id. Nothing that comes
+    // out of this endpoint can be that string.
+    const result = await directoryOf({
+      listTeams: async () => [TEAM],
+      listChats: async () => [CHAT],
+    });
+
+    assert.ok(result.teams.available && result.chats.available);
+    assert.equal(classifyTeamsInstallTarget(result.teams.items[0]!.id).kind, 'team');
+    assert.equal(classifyTeamsInstallTarget(result.chats.items[0]!.id).kind, 'group-chat');
+  });
+
+  it('passes the delegated token set to the chat listing', async () => {
+    const seen: unknown[] = [];
+    await directoryOf({
+      listTeams: async () => [],
+      listChats: async (input) => {
+        seen.push(input);
+        return [];
+      },
+    });
+
+    assert.deepEqual(seen, [{ tokens: TOKENS }]);
+  });
+
+  it('an EMPTY tenant is available with no items — not unavailable', async () => {
+    const result = await directoryOf({
+      listTeams: async () => [],
+      listChats: async () => [],
+    });
+
+    assert.deepEqual(result.teams, { available: true, items: [] });
+    assert.deepEqual(result.chats, { available: true, items: [] });
+  });
+});
+
+describe('teams target directory — degradation', () => {
+  it('reports connector_unavailable for both halves with no connector', async () => {
+    const result = await directoryOf(undefined);
+
+    assert.deepEqual(result.teams, {
+      available: false,
+      reason: 'connector_unavailable',
+    });
+    assert.deepEqual(result.chats, {
+      available: false,
+      reason: 'connector_unavailable',
+    });
+  });
+
+  it('reports connector_unsupported per method, not for the pair', async () => {
+    // An older connector may publish one and not the other; each is detected
+    // on its own so the half that works keeps working.
+    const result = await directoryOf({ listTeams: async () => [TEAM] });
+
+    assert.deepEqual(result.teams, { available: true, items: [TEAM] });
+    assert.deepEqual(result.chats, {
+      available: false,
+      reason: 'connector_unsupported',
+    });
+  });
+
+  it('a missing chat SCOPE never hides the team list', async () => {
+    // The 0.8.0 case: someone IS signed in, with a credential that predates
+    // `Chat.ReadBasic` and cannot obtain it by refreshing.
+    const result = await directoryOf({
+      listTeams: async () => [TEAM],
+      listChats: async () => {
+        throw scopeError();
+      },
+    });
+
+    assert.deepEqual(result.teams, { available: true, items: [TEAM] });
+    assert.deepEqual(result.chats, { available: false, reason: 'scope_missing' });
+  });
+
+  it('keeps scope_missing apart from sign_in_required', async () => {
+    // They look identical to the code and completely different to the person:
+    // one means "sign in", the other "you ARE signed in and it still is not
+    // enough". A retry fixes neither, but only one of them is fixed by the
+    // sign-in button the operator has already used once.
+    const missing = await directoryOf({
+      listTeams: async () => [],
+      listChats: async () => {
+        throw signInError();
+      },
+    });
+
+    assert.deepEqual(missing.chats, { available: false, reason: 'sign_in_required' });
+    assert.ok(isDelegatedScopeRequiredError(scopeError()));
+    assert.ok(!isDelegatedScopeRequiredError(signInError()));
+  });
+
+  it('never turns a thrown listing into an empty one', async () => {
+    // THE REGRESSION THIS FILE EXISTS FOR. `[]` here would tell the operator
+    // their tenant has no teams.
+    const result = await directoryOf({
+      listTeams: async () => {
+        throw new Error('graph exploded');
+      },
+      listChats: async () => {
+        throw new Error('graph exploded');
+      },
+    });
+
+    assert.equal(result.teams.available, false);
+    assert.equal(result.chats.available, false);
+    assert.equal(
+      result.teams.available === false ? result.teams.reason : null,
+      'lookup_failed',
+    );
+  });
+
+  it('does not throw when the token read itself fails', async () => {
+    const result = await loadTeamsTargetDirectory({
+      getProvisioner: () => ({
+        listTeams: async () => [TEAM],
+        listChats: async () => [CHAT],
+      }),
+      delegatedTokens: {
+        read: async () => {
+          throw new Error('vault is down');
+        },
+      },
+    });
+
+    assert.deepEqual(result.teams, { available: true, items: [TEAM] });
+  });
+});
+
+describe('teams target directory — the mirrored contract', () => {
+  it('feature detection reads the object the call would go to', () => {
+    assert.equal(supportsTeamListing(undefined), false);
+    assert.equal(supportsChatListing({}), false);
+    assert.equal(supportsTeamListing({ listTeams: async () => [] }), true);
+    assert.equal(supportsChatListing({ listChats: async () => [] }), true);
+  });
+
+  it('maps Graph chat types onto the stored target kinds', () => {
+    // A meeting chat installs through the same `POST /chats/{id}/installedApps`
+    // as a group chat, and `target_kind` records WHICH ENDPOINT installed the
+    // app — so inventing a fourth kind would widen a CHECK constraint to record
+    // a distinction nothing branches on.
+    assert.equal(teamsChatTargetKind('oneOnOne'), 'one-on-one-chat');
+    assert.equal(teamsChatTargetKind('group'), 'group-chat');
+    assert.equal(teamsChatTargetKind('meeting'), 'group-chat');
+  });
+});

--- a/web-ui/app/_lib/agents.ts
+++ b/web-ui/app/_lib/agents.ts
@@ -1175,6 +1175,180 @@ export function parseTeamsAssignmentCapabilities(
  * row yet; that is the "there is nothing to assign yet" signal, and the panel
  * treats it as an empty state rather than an error.
  */
+/**
+ * Why a target listing is not available. Mirrors
+ * `TeamsTargetListingUnavailable` in
+ * `middleware/src/services/teamsTargetDirectoryService.ts` — a closed set of
+ * machine codes, each with its own sentence in `messages/*.json`.
+ */
+export type TeamsTargetListingUnavailable =
+  | 'connector_unavailable'
+  | 'connector_unsupported'
+  | 'sign_in_required'
+  | 'scope_missing'
+  | 'consent_required'
+  | 'lookup_failed';
+
+/**
+ * A listing that can say "I don't know".
+ *
+ * THE WHOLE POINT OF THE UNION. `available: true, items: []` means the tenant
+ * genuinely has none; `available: false` means we could not look. Rendering
+ * an empty dropdown for the second case tells the operator something false
+ * about their tenant and sends them looking in the wrong place.
+ */
+export type TeamsTargetListingDto<T> =
+  | { available: true; items: readonly T[] }
+  | { available: false; reason: TeamsTargetListingUnavailable };
+
+export interface TeamsTeamOptionDto {
+  id: string;
+  displayName: string;
+}
+
+export interface TeamsChatOptionDto {
+  id: string;
+  topic: string | null;
+  chatType: 'group' | 'oneOnOne' | 'meeting';
+  memberNames?: readonly string[];
+}
+
+export interface AgentTeamsTargetsDto {
+  ok: boolean;
+  agent: string;
+  provisioner_installed: boolean;
+  teams: TeamsTargetListingDto<TeamsTeamOptionDto>;
+  chats: TeamsTargetListingDto<TeamsChatOptionDto>;
+}
+
+/**
+ * Normalise one half of the directory response.
+ *
+ * DEFENSIVE ON PURPOSE, and it degrades toward `available: false` rather than
+ * toward an empty list: an unparsable payload is precisely the case where we
+ * do NOT know what the tenant holds, and the union exists so that state has
+ * somewhere honest to go.
+ */
+function parseTargetListing<T>(
+  value: unknown,
+  parseItem: (raw: unknown) => T | null,
+): TeamsTargetListingDto<T> {
+  if (typeof value !== 'object' || value === null) {
+    return { available: false, reason: 'lookup_failed' };
+  }
+  const record = value as Record<string, unknown>;
+  if (record['available'] !== true) {
+    const reason = record['reason'];
+    return {
+      available: false,
+      reason:
+        typeof reason === 'string'
+          ? (reason as TeamsTargetListingUnavailable)
+          : 'lookup_failed',
+    };
+  }
+  const raw = record['items'];
+  if (!Array.isArray(raw)) return { available: false, reason: 'lookup_failed' };
+  const items: T[] = [];
+  for (const entry of raw) {
+    const parsed = parseItem(entry);
+    if (parsed !== null) items.push(parsed);
+  }
+  return { available: true, items };
+}
+
+function parseTeamOption(raw: unknown): TeamsTeamOptionDto | null {
+  if (typeof raw !== 'object' || raw === null) return null;
+  const r = raw as Record<string, unknown>;
+  const id = r['id'];
+  if (typeof id !== 'string' || id === '') return null;
+  const displayName = r['displayName'];
+  return {
+    id,
+    // An id with no name still beats the free-text field this replaces, so a
+    // nameless row is kept and labelled by its id rather than dropped.
+    displayName: typeof displayName === 'string' && displayName !== '' ? displayName : id,
+  };
+}
+
+const CHAT_TYPES: readonly string[] = ['group', 'oneOnOne', 'meeting'];
+
+function parseChatOption(raw: unknown): TeamsChatOptionDto | null {
+  if (typeof raw !== 'object' || raw === null) return null;
+  const r = raw as Record<string, unknown>;
+  const id = r['id'];
+  if (typeof id !== 'string' || id === '') return null;
+  const chatType = r['chatType'];
+  const topic = r['topic'];
+  const memberNames = r['memberNames'];
+  return {
+    id,
+    topic: typeof topic === 'string' && topic !== '' ? topic : null,
+    chatType: CHAT_TYPES.includes(chatType as string)
+      ? (chatType as TeamsChatOptionDto['chatType'])
+      : 'group',
+    ...(Array.isArray(memberNames)
+      ? { memberNames: memberNames.filter((n): n is string => typeof n === 'string') }
+      : {}),
+  };
+}
+
+/**
+ * `GET /v1/operator/agents/:slug/teams/targets` — what the operator can pick
+ * instead of type.
+ */
+export async function getAgentTeamsTargets(
+  slug: string,
+): Promise<AgentTeamsTargetsDto> {
+  const dto = await callJson<AgentTeamsTargetsDto>(
+    `/v1/operator/agents/${encodeURIComponent(slug)}/teams/targets`,
+  );
+  return {
+    ...dto,
+    teams: parseTargetListing(dto.teams, parseTeamOption),
+    chats: parseTargetListing(dto.chats, parseChatOption),
+  };
+}
+
+/** One step of a teardown — mirrors `TeamsResetStepReport`. */
+export interface TeamsResetStepDto {
+  step: 'catalog_removed' | 'bot_deleted' | 'app_deleted' | 'identity_reset';
+  outcome: 'removed' | 'already-absent' | 'skipped' | 'blocked' | 'failed';
+  detail?: string;
+}
+
+export interface ResetAgentTeamsIdentityResponse {
+  ok: boolean;
+  agent: string;
+  status: 'reset' | 'incomplete';
+  previous_state?: string;
+  steps: readonly TeamsResetStepDto[];
+  stoppedAt?: TeamsResetStepDto['step'];
+  detail?: string;
+}
+
+/**
+ * `POST /v1/operator/agents/:slug/teams-identity/reset` — DESTRUCTIVE.
+ *
+ * Removes the Entra app registration (delete AND recycle-bin purge), the
+ * Azure bot and the tenant catalog entry, then returns the row to `pending`
+ * keeping `bot_slug` and `display_name`.
+ *
+ * A PARTIAL TEARDOWN RESOLVES, IT DOES NOT REJECT. `status: 'incomplete'`
+ * comes back as a 200 with the per-step report, because "which of the three
+ * are still in Azure" is the answer the operator needs and an exception would
+ * collapse it into "reset failed".
+ */
+export async function resetAgentTeamsIdentity(
+  slug: string,
+): Promise<ResetAgentTeamsIdentityResponse> {
+  const dto = await callJson<ResetAgentTeamsIdentityResponse>(
+    `/v1/operator/agents/${encodeURIComponent(slug)}/teams-identity/reset`,
+    { method: 'POST' },
+  );
+  return { ...dto, steps: Array.isArray(dto.steps) ? dto.steps : [] };
+}
+
 export async function getAgentTeams(slug: string): Promise<AgentTeamsDto> {
   const dto = await callJson<AgentTeamsDto>(
     `/v1/operator/agents/${encodeURIComponent(slug)}/teams`,

--- a/web-ui/app/operator/agents/[slug]/__tests__/AgentTeamsIdentityReset.test.tsx
+++ b/web-ui/app/operator/agents/[slug]/__tests__/AgentTeamsIdentityReset.test.tsx
@@ -1,0 +1,230 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { renderWithIntl } from '../../../../_lib/test-utils';
+import type { ResetAgentTeamsIdentityResponse } from '../../../../_lib/agents';
+import { AgentTeamsIdentityReset } from '../_components/AgentTeamsIdentityReset';
+
+/**
+ * The destructive control.
+ *
+ * What is worth pinning here is not the rendering but the SAFETY and the
+ * HONESTY:
+ *
+ *  - the teardown is never one click, and the first click only reveals what
+ *    the second would destroy;
+ *  - the consequences are named one by one (app registration, bot, catalog
+ *    entry, installs) — an operator approving a deletion is entitled to the
+ *    list — and so is the reassurance that the bot slug survives, because
+ *    that is what tells them this is a retry and not a restart;
+ *  - a PARTIAL teardown renders per step. "Reset failed" as the only signal
+ *    is what sends somebody into two Azure portals to find out what is left;
+ *  - a run in flight locks the control, so nobody is invited into a 409.
+ */
+
+const { mockReset } = vi.hoisted(() => ({ mockReset: vi.fn() }));
+
+vi.mock('../../../../_lib/agents', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../_lib/agents')>()),
+  resetAgentTeamsIdentity: mockReset,
+}));
+
+function complete(): ResetAgentTeamsIdentityResponse {
+  return {
+    ok: true,
+    agent: 'sales-bot',
+    status: 'reset',
+    steps: [
+      { step: 'catalog_removed', outcome: 'removed' },
+      { step: 'bot_deleted', outcome: 'removed' },
+      { step: 'app_deleted', outcome: 'removed' },
+      { step: 'identity_reset', outcome: 'removed' },
+    ],
+  };
+}
+
+function render(props: { state?: string; running?: boolean } = {}): {
+  onDone: ReturnType<typeof vi.fn>;
+} {
+  const onDone = vi.fn();
+  renderWithIntl(
+    <AgentTeamsIdentityReset
+      slug="sales-bot"
+      state={props.state ?? 'failed'}
+      running={props.running ?? false}
+      onDone={onDone}
+    />,
+  );
+  return { onDone };
+}
+
+/** Open the panel and tick the acknowledgement — the two steps that stand
+ *  between an operator and a deletion. */
+async function arm(): Promise<void> {
+  await userEvent.click(screen.getByRole('button', { name: /zurücksetzen …|reset …/i }));
+  await userEvent.click(screen.getByRole('checkbox'));
+}
+
+beforeEach(() => {
+  mockReset.mockReset();
+  mockReset.mockResolvedValue(complete());
+});
+
+describe('AgentTeamsIdentityReset — the confirmation', () => {
+  it('does not offer a teardown for an identity that never provisioned anything', () => {
+    render({ state: 'pending' });
+
+    // A destructive control that would be a no-op only teaches operators that
+    // the scary button is harmless.
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('never resets on a single click', async () => {
+    render();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /zurücksetzen …|reset …/i }),
+    );
+
+    expect(mockReset).not.toHaveBeenCalled();
+  });
+
+  it('names every Azure object it is about to delete', async () => {
+    render();
+    await userEvent.click(
+      screen.getByRole('button', { name: /zurücksetzen …|reset …/i }),
+    );
+
+    const note = screen.getByRole('note');
+    expect(note).toHaveTextContent(/Entra/i);
+    expect(note).toHaveTextContent(/Bot/i);
+    expect(note).toHaveTextContent(/Katalog|catalog/i);
+    // And what SURVIVES — the half that makes this a retry rather than a
+    // restart from a blank form.
+    expect(note).toHaveTextContent(/Slug/i);
+  });
+
+  it('keeps the confirm button locked until the acknowledgement is ticked', async () => {
+    render();
+    await userEvent.click(
+      screen.getByRole('button', { name: /zurücksetzen …|reset …/i }),
+    );
+
+    const confirm = screen.getByRole('button', {
+      name: /endgültig zurücksetzen|reset for good/i,
+    });
+    expect(confirm).toBeDisabled();
+
+    await userEvent.click(screen.getByRole('checkbox'));
+    expect(confirm).toBeEnabled();
+  });
+
+  it('resets once armed, and asks the panel to re-read the row', async () => {
+    const { onDone } = render();
+    await arm();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /endgültig zurücksetzen|reset for good/i }),
+    );
+
+    await waitFor(() => expect(mockReset).toHaveBeenCalledWith('sales-bot'));
+    // The teardown rewrote the row underneath the panel; rendering the state
+    // it just tore down would be stale by definition.
+    expect(onDone).toHaveBeenCalled();
+  });
+
+  it('locks the control while a provisioning run is in flight', () => {
+    render({ running: true });
+
+    expect(
+      screen.getByRole('button', { name: /zurücksetzen …|reset …/i }),
+    ).toBeDisabled();
+  });
+});
+
+describe('AgentTeamsIdentityReset — the report', () => {
+  it('renders each step of a completed teardown', async () => {
+    render();
+    await arm();
+    await userEvent.click(
+      screen.getByRole('button', { name: /endgültig zurücksetzen|reset for good/i }),
+    );
+
+    const report = await screen.findByTestId('teams-reset-report');
+    expect(report.querySelectorAll('li')).toHaveLength(4);
+  });
+
+  it('shows a PARTIAL teardown per step instead of one failure line', async () => {
+    // The connector cannot purge, so the app registration was deliberately
+    // left alone — and the catalog entry really was withdrawn. Both facts
+    // have to survive into the UI, or the operator opens the Azure portal.
+    mockReset.mockResolvedValue({
+      ok: false,
+      agent: 'sales-bot',
+      status: 'incomplete',
+      stoppedAt: 'app_deleted',
+      detail: 'purge_unsupported',
+      steps: [
+        { step: 'catalog_removed', outcome: 'removed' },
+        { step: 'bot_deleted', outcome: 'already-absent' },
+        { step: 'app_deleted', outcome: 'blocked', detail: 'purge_unsupported' },
+      ],
+    } satisfies ResetAgentTeamsIdentityResponse);
+
+    render();
+    await arm();
+    await userEvent.click(
+      screen.getByRole('button', { name: /endgültig zurücksetzen|reset for good/i }),
+    );
+
+    const report = await screen.findByTestId('teams-reset-report');
+    expect(report.querySelectorAll('li')).toHaveLength(3);
+    // The blocked step explains the refusal — including WHY not deleting was
+    // the right move, which is the least obvious part of the whole feature.
+    expect(report).toHaveTextContent(/30 Tage|30 days/);
+  });
+
+  it('falls back to the raw detail for a code it has no sentence for', async () => {
+    // Failure details carry a `code:message` payload the UI cannot enumerate.
+    // Showing it raw beats showing nothing.
+    mockReset.mockResolvedValue({
+      ok: false,
+      agent: 'sales-bot',
+      status: 'incomplete',
+      stoppedAt: 'catalog_removed',
+      detail: 'catalog_removal_failed: boom',
+      steps: [
+        {
+          step: 'catalog_removed',
+          outcome: 'failed',
+          detail: 'catalog_removal_failed: boom',
+        },
+      ],
+    } satisfies ResetAgentTeamsIdentityResponse);
+
+    render();
+    await arm();
+    await userEvent.click(
+      screen.getByRole('button', { name: /endgültig zurücksetzen|reset for good/i }),
+    );
+
+    expect(await screen.findByTestId('teams-reset-report')).toHaveTextContent(
+      /catalog_removal_failed: boom/,
+    );
+  });
+
+  it('surfaces a refused teardown as an alert', async () => {
+    mockReset.mockRejectedValue(new Error('teams_provisioning_running'));
+
+    render();
+    await arm();
+    await userEvent.click(
+      screen.getByRole('button', { name: /endgültig zurücksetzen|reset for good/i }),
+    );
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      /teams_provisioning_running/,
+    );
+  });
+});

--- a/web-ui/app/operator/agents/[slug]/__tests__/TeamsTargetPicker.test.tsx
+++ b/web-ui/app/operator/agents/[slug]/__tests__/TeamsTargetPicker.test.tsx
@@ -1,0 +1,170 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { renderWithIntl } from '../../../../_lib/test-utils';
+import type { AgentTeamsTargetsDto } from '../../../../_lib/agents';
+import { TeamsTargetPicker } from '../_components/TeamsTargetPicker';
+
+/**
+ * Picking a target instead of typing one — and, more importantly, what the
+ * picker does when it CANNOT offer a list.
+ *
+ * The behaviours worth pinning are the honesty ones:
+ *
+ *  - a list that could not be produced renders a SENTENCE, never an empty
+ *    dropdown: an empty `<select>` is a claim about the tenant, and using it
+ *    for "I could not look" sends the operator hunting for teams that are
+ *    right there;
+ *  - the two halves degrade independently — a chat scope nobody consented to
+ *    must not be able to hide the team list, which is the half that works
+ *    everywhere;
+ *  - a picked id is handed up VERBATIM, so the live classification below the
+ *    picker stays the single verdict on what the target is.
+ */
+
+const TEAM = { id: '2f1a9c44-1f0e-4f2c-8f1a-9c441f0e4f2c', displayName: 'Acme Team' };
+const CHAT = {
+  id: '19:a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6@thread.v2',
+  topic: 'Support',
+  chatType: 'group' as const,
+};
+
+function dto(overrides: Partial<AgentTeamsTargetsDto> = {}): AgentTeamsTargetsDto {
+  return {
+    ok: true,
+    agent: 'sales-bot',
+    provisioner_installed: true,
+    teams: { available: true, items: [TEAM] },
+    chats: { available: true, items: [CHAT] },
+    ...overrides,
+  };
+}
+
+function render(
+  targets: AgentTeamsTargetsDto | null,
+  onSelect = vi.fn(),
+  extra: { loading?: boolean; disabled?: boolean; value?: string } = {},
+): { onSelect: ReturnType<typeof vi.fn> } {
+  renderWithIntl(
+    <TeamsTargetPicker
+      targets={targets}
+      loading={extra.loading ?? false}
+      disabled={extra.disabled ?? false}
+      value={extra.value ?? ''}
+      onSelect={onSelect}
+    />,
+  );
+  return { onSelect };
+}
+
+describe('TeamsTargetPicker — offering a choice', () => {
+  it('lists teams and chats with their names', () => {
+    render(dto());
+
+    expect(screen.getByRole('option', { name: 'Acme Team' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /Support/ })).toBeInTheDocument();
+  });
+
+  it('hands the picked id up verbatim', async () => {
+    const { onSelect } = render(dto());
+
+    await userEvent.selectOptions(
+      screen.getByRole('combobox', { name: /Team/i }),
+      TEAM.id,
+    );
+
+    // Verbatim matters: the id goes into the same field the operator could
+    // have typed into, and the live classification decides what it is. A
+    // picker that reshaped it would become a second, disagreeing classifier.
+    expect(onSelect).toHaveBeenCalledWith(TEAM.id);
+  });
+
+  it('shows no selection for an id that was typed rather than picked', () => {
+    render(dto(), vi.fn(), { value: 'something-hand-typed' });
+
+    // Never pin the first option: the select must not claim a choice the
+    // operator did not make.
+    const select = screen.getByRole('combobox', { name: /Team/i });
+    expect((select as HTMLSelectElement).value).toBe('');
+  });
+
+  it('labels a nameless chat by its members rather than dropping it', () => {
+    render(
+      dto({
+        chats: {
+          available: true,
+          items: [{ ...CHAT, topic: null, memberNames: ['Ada', 'Grace'] }],
+        },
+      }),
+    );
+
+    expect(screen.getByRole('option', { name: /Ada, Grace/ })).toBeInTheDocument();
+  });
+});
+
+describe('TeamsTargetPicker — degrading without lying', () => {
+  it('renders a reason, NOT an empty dropdown, when a listing is unavailable', async () => {
+    render(
+      dto({
+        teams: { available: false, reason: 'connector_unsupported' },
+        chats: { available: false, reason: 'connector_unsupported' },
+      }),
+    );
+
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    // Two notes, each explaining itself — the operator is told to use the
+    // field below rather than left in front of a dropdown with nothing in it.
+    expect(await screen.findAllByRole('note')).toHaveLength(2);
+  });
+
+  it('keeps the team list when only the chat scope is missing', async () => {
+    // The connector-0.8.0 case: someone is signed in with a credential that
+    // predates `Chat.ReadBasic` and cannot refresh into it.
+    render(
+      dto({ chats: { available: false, reason: 'scope_missing' } }),
+    );
+
+    expect(screen.getByRole('option', { name: 'Acme Team' })).toBeInTheDocument();
+    const notes = await screen.findAllByRole('note');
+    expect(notes).toHaveLength(1);
+    // The sentence has to name the scope, or "sign in again" is
+    // indistinguishable from a bug to someone who IS signed in.
+    expect(notes[0]).toHaveTextContent(/Chat\.ReadBasic/);
+  });
+
+  it('distinguishes an empty tenant from an unavailable listing', () => {
+    render(dto({ teams: { available: true, items: [] } }));
+
+    // No dropdown either way — but the copy is a statement about the tenant,
+    // and it must not be the same string as "we could not look".
+    expect(screen.queryByRole('combobox', { name: /Team/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('note')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing at all when there is no directory', () => {
+    const { container } = { container: document.body };
+    render(null);
+
+    // Silent by design: the text field below is fully functional, and a
+    // component announcing its own absence would be noise on every screen
+    // whose connector predates the feature.
+    expect(container.querySelector('select')).toBeNull();
+    expect(screen.queryByRole('note')).not.toBeInTheDocument();
+  });
+
+  it('says it is loading rather than showing an empty list', () => {
+    render(null, vi.fn(), { loading: true });
+
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    expect(screen.getByText(/lade|load/i)).toBeInTheDocument();
+  });
+
+  it('disables the selects while an install is in flight', () => {
+    render(dto(), vi.fn(), { disabled: true });
+
+    for (const select of screen.getAllByRole('combobox')) {
+      expect(select).toBeDisabled();
+    }
+  });
+});

--- a/web-ui/app/operator/agents/[slug]/_components/AgentTeamsIdentity.tsx
+++ b/web-ui/app/operator/agents/[slug]/_components/AgentTeamsIdentity.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useFormatter, useTranslations } from 'next-intl';
 
 import { Button } from '@/app/_components/ui/Button';
+import { AgentTeamsIdentityReset } from './AgentTeamsIdentityReset';
 import {
   agentTeamsPackageUrl,
   getAgentTeamsIdentity,
@@ -299,6 +300,10 @@ export function AgentTeamsIdentity(
         <ReadyPanel
           status={view.status}
           busy={busy}
+          slug={props.slug}
+          // The teardown rewrites the row it is looking at, so the panel has
+          // to re-read rather than keep rendering the state it tore down.
+          onReloaded={() => void load()}
           // The server has no "as recorded" re-run: `ensureForAgent` refreshes
           // the stored team from the request and the route hands `team_id`
           // straight to the runner, so an empty body is a guaranteed 400. The
@@ -318,6 +323,8 @@ function ReadyPanel(props: {
   readonly busy: boolean;
   readonly onRerun: (teamId: string) => void;
   readonly formatDate: (iso: string) => string;
+  readonly slug: string;
+  readonly onReloaded: () => void;
 }): React.ReactElement {
   const t = useTranslations('operatorAgents');
   const { status } = props;
@@ -385,6 +392,16 @@ function ReadyPanel(props: {
       <AgentTeamsProvisioningTimeline
         events={events}
         running={status.running}
+      />
+
+      {/* The way BACK. Placed under the timeline because that is where an
+          operator is looking when a run has gone wrong, and a cleanup they
+          cannot find is a cleanup they do by hand in the Azure portal. */}
+      <AgentTeamsIdentityReset
+        slug={props.slug}
+        state={status.state}
+        running={status.running}
+        onDone={props.onReloaded}
       />
 
       {detail && <LastError detail={detail} />}

--- a/web-ui/app/operator/agents/[slug]/_components/AgentTeamsIdentityReset.tsx
+++ b/web-ui/app/operator/agents/[slug]/_components/AgentTeamsIdentityReset.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+import { Button } from '@/app/_components/ui/Button';
+import {
+  resetAgentTeamsIdentity,
+  type ResetAgentTeamsIdentityResponse,
+  type TeamsResetStepDto,
+} from '@/app/_lib/agents';
+
+/**
+ * Undo a Teams provisioning run — the destructive one.
+ *
+ * WHAT IT ACTUALLY DOES, which is why the confirmation is not a formality:
+ * it deletes the agent's Entra app registration (delete AND recycle-bin
+ * purge), its Azure bot service and the tenant catalog entry, then returns
+ * the row to `pending`. `bot_slug` and `display_name` survive — they are the
+ * only two fields a human typed, and keeping them is what makes the retry one
+ * button with the same slug.
+ *
+ * THE CONFIRMATION FOLLOWS `AgentContextMemory`'s PATTERN, deliberately: an
+ * inline consequences panel plus an acknowledgement checkbox that gates the
+ * button. Not a `window.confirm`, which cannot list three things and cannot be
+ * translated, and not a modal, which this codebase does not use for in-panel
+ * actions. Two clicks minimum, and the first one only reveals what the second
+ * would destroy.
+ *
+ * THE RESULT IS A PER-STEP REPORT, NOT A VERDICT. A teardown can genuinely
+ * half-succeed — the catalog entry withdrawn, the app registration blocked
+ * behind a connector that cannot purge — and "reset failed" as the only
+ * signal is exactly what sends an operator into two Azure portals to find out
+ * what is left. So every step renders with its own outcome, including the
+ * ones that were skipped because there was nothing there.
+ */
+
+export interface AgentTeamsIdentityResetProps {
+  readonly slug: string;
+  /** The chain state the row is in — a `pending` identity has nothing to tear
+   *  down and does not get the control at all. */
+  readonly state: string;
+  /** A run in flight. The server refuses in this case regardless; the button
+   *  is disabled so the operator is not invited into a 409. */
+  readonly running: boolean;
+  readonly onDone: () => void;
+}
+
+/** Which outcomes are worth colouring as "attention". `blocked` is the loud
+ *  one: nothing broke, but a human action is missing and the teardown stopped
+ *  before it could make anything worse. */
+function outcomeTone(outcome: TeamsResetStepDto['outcome']): string {
+  if (outcome === 'failed') return 'text-[color:var(--danger)]';
+  if (outcome === 'blocked') return 'text-[color:var(--warning,var(--danger))]';
+  return 'text-[color:var(--fg-muted)]';
+}
+
+export function AgentTeamsIdentityReset({
+  slug,
+  state,
+  running,
+  onDone,
+}: AgentTeamsIdentityResetProps): React.JSX.Element | null {
+  const t = useTranslations('operatorAgents.teamsReset');
+  const [open, setOpen] = useState(false);
+  const [acknowledged, setAcknowledged] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [report, setReport] = useState<ResetAgentTeamsIdentityResponse | null>(
+    null,
+  );
+
+  // A row that never provisioned anything has nothing to remove, and offering
+  // a destructive control that would be a no-op only teaches operators that
+  // the scary button is harmless.
+  if (state === 'pending') return null;
+
+  async function run(): Promise<void> {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await resetAgentTeamsIdentity(slug);
+      setReport(res);
+      setOpen(false);
+      setAcknowledged(false);
+      onDone();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="mt-3 rounded border border-[color:var(--border)] p-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[color:var(--fg-muted)]">
+          {t('heading')}
+        </span>
+        <div className="ml-auto">
+          <Button
+            size="sm"
+            variant="ghost"
+            disabled={running || busy}
+            onClick={() => setOpen((prev) => !prev)}
+          >
+            {open ? t('cancel') : t('open')}
+          </Button>
+        </div>
+      </div>
+      <p className="mt-1 text-[11px] text-[color:var(--fg-muted)]">
+        {running ? t('runningHint') : t('hint')}
+      </p>
+
+      {open && (
+        <div
+          role="note"
+          className="mt-3 rounded border border-[color:var(--border)] bg-[color:var(--bg)] p-3 text-xs"
+        >
+          <p className="mb-2 font-medium text-[color:var(--fg-strong)]">
+            {t('confirmHeading')}
+          </p>
+          {/* Named one by one rather than as "all Azure resources". An
+              operator approving a deletion is entitled to the list. */}
+          <ul className="mb-2 flex list-disc flex-col gap-1 pl-4 text-[color:var(--fg-muted)]">
+            <li>{t('consequenceApp')}</li>
+            <li>{t('consequenceBot')}</li>
+            <li>{t('consequenceCatalog')}</li>
+            <li>{t('consequenceInstalls')}</li>
+          </ul>
+          {/* The reassuring half, and it is load-bearing: knowing the slug
+              survives is what tells the operator this is a retry, not a
+              restart from a blank form. */}
+          <p className="mb-3 text-[color:var(--fg-muted)]">{t('keepsHint')}</p>
+          <label className="mb-3 flex cursor-pointer items-start gap-2 text-[color:var(--fg-strong)]">
+            <input
+              type="checkbox"
+              className="mt-0.5"
+              checked={acknowledged}
+              disabled={busy}
+              onChange={(e) => setAcknowledged(e.target.checked)}
+            />
+            <span>{t('acknowledge')}</span>
+          </label>
+          <Button
+            size="sm"
+            variant="secondary"
+            busy={busy}
+            busyLabel={t('busy')}
+            disabled={!acknowledged || busy || running}
+            onClick={() => void run()}
+          >
+            {t('confirm')}
+          </Button>
+        </div>
+      )}
+
+      {error !== null && (
+        <p role="alert" className="mt-2 text-[11px] text-[color:var(--danger)]">
+          {error}
+        </p>
+      )}
+
+      {report !== null && (
+        <div className="mt-3 text-xs" data-testid="teams-reset-report">
+          <p
+            className={
+              report.status === 'reset'
+                ? 'font-medium text-[color:var(--fg-strong)]'
+                : 'font-medium text-[color:var(--danger)]'
+            }
+          >
+            {report.status === 'reset'
+              ? t('resultComplete')
+              : t('resultIncomplete', {
+                  step: t(`steps.${report.stoppedAt ?? 'identity_reset'}`),
+                })}
+          </p>
+          <ul className="mt-1 flex flex-col gap-0.5">
+            {report.steps.map((step) => (
+              <li key={step.step} className={outcomeTone(step.outcome)}>
+                {t('stepLine', {
+                  step: t(`steps.${step.step}`),
+                  outcome: t(`outcomes.${step.outcome}`),
+                })}
+                {step.detail !== undefined && step.detail !== '' && (
+                  <span className="ml-1 opacity-80">
+                    {t.has(`details.${step.detail}`)
+                      ? t(`details.${step.detail}`)
+                      : step.detail}
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web-ui/app/operator/agents/[slug]/_components/AgentTeamsInstalls.tsx
+++ b/web-ui/app/operator/agents/[slug]/_components/AgentTeamsInstalls.tsx
@@ -23,7 +23,10 @@ import {
   type AgentTeamsDto,
   type InstalledTeamDto,
   type TeamsAssignmentCapabilityKey,
+  getAgentTeamsTargets,
+  type AgentTeamsTargetsDto,
 } from '../../../../_lib/agents';
+import { TeamsTargetPicker } from './TeamsTargetPicker';
 import { ApiError } from '../../../../_lib/api';
 
 /**
@@ -133,6 +136,17 @@ export function AgentTeamsInstalls({
   const [result, setResult] = useState<string | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [teamId, setTeamId] = useState('');
+  /**
+   * What the operator can pick instead of type.
+   *
+   * `null` covers BOTH "not loaded yet" and "the directory endpoint failed",
+   * and deliberately so: the picker is a convenience over a field that still
+   * works, so a failure to enumerate must degrade to the field rather than to
+   * an error the operator has to dismiss. The one thing never done here is
+   * storing an empty list on failure — see `TeamsTargetPicker`.
+   */
+  const [targets, setTargets] = useState<AgentTeamsTargetsDto | null>(null);
+  const [targetsLoading, setTargetsLoading] = useState(true);
   const [confirmUninstall, setConfirmUninstall] =
     useState<InstalledTeamDto | null>(null);
 
@@ -218,6 +232,31 @@ export function AgentTeamsInstalls({
    *
    * The server re-decides regardless; this is guidance, never authority.
    */
+  // Loaded ONCE per agent, not on every poll of the panel: a tenant's teams
+  // and chats do not change while somebody fills in a form, and re-enumerating
+  // on each refresh would spend the connector's Graph throttling budget on a
+  // list nobody is looking at any more.
+  useEffect(() => {
+    let cancelled = false;
+    setTargetsLoading(true);
+    void getAgentTeamsTargets(slug)
+      .then((dto) => {
+        if (!cancelled) setTargets(dto);
+      })
+      .catch(() => {
+        // Swallowed on purpose. The text field below is fully functional
+        // without a directory, and an error banner for a failed convenience
+        // would read as though the install itself were broken.
+        if (!cancelled) setTargets(null);
+      })
+      .finally(() => {
+        if (!cancelled) setTargetsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [slug]);
+
   const target = classifyTeamsInstallTarget(teamId);
   const targetSubmittable = isSubmittableTarget(target);
 
@@ -437,6 +476,16 @@ export function AgentTeamsInstalls({
             <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[color:var(--fg-muted)]">
               {t('installHeading')}
             </div>
+            {/* PICK first, TYPE second — and both write the same state, so the
+                live classification below stays the single verdict. */}
+            <TeamsTargetPicker
+              targets={targets}
+              loading={targetsLoading}
+              disabled={!canInstall || inFlight}
+              value={teamId}
+              onSelect={setTeamId}
+            />
+
             <label className="flex flex-col gap-1 text-[11px] text-[color:var(--fg-muted)]">
               {t('fieldTarget')}
               <input

--- a/web-ui/app/operator/agents/[slug]/_components/TeamsTargetPicker.tsx
+++ b/web-ui/app/operator/agents/[slug]/_components/TeamsTargetPicker.tsx
@@ -1,0 +1,215 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import type {
+  AgentTeamsTargetsDto,
+  TeamsChatOptionDto,
+  TeamsTargetListingDto,
+  TeamsTeamOptionDto,
+} from '@/app/_lib/agents';
+
+/**
+ * Pick an install target instead of typing one.
+ *
+ * WHY THIS EXISTS. The field underneath it is the one that produced migration
+ * 0054's field test: an operator pasted a bare 32-hex id, which is a legal
+ * reading of BOTH a team's group id and the stem of a chat id, and five
+ * provisioning steps later Graph answered `404 No team found with Group Id`.
+ * Since #950 nothing guesses any more — but the operator still had to produce
+ * the string, and they had no better way to disambiguate it than the code did.
+ *
+ * A LIST DISSOLVES THE AMBIGUITY RATHER THAN REPORTING IT. Every id this
+ * component can emit is either a hyphenated GUID or carries its `19:…@…`
+ * suffix, so it classifies unambiguously the moment it lands in the field. The
+ * input that broke the field test cannot be produced from here at all.
+ *
+ * IT WRITES INTO THE EXISTING FIELD, IT DOES NOT REPLACE IT. Selecting sets
+ * the same `teamId` state the text input owns, so the live type detection
+ * below it keeps running and keeps being the thing that decides. One code
+ * path, one verdict — and the free-text field stays usable for the cases a
+ * list cannot cover.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * DEGRADATION IS THE INTERESTING HALF
+ * ─────────────────────────────────────────────────────────────────────────
+ * Teams and chats are NOT symmetric and the component refuses to pretend they
+ * are. `listTeams` is app-only and essentially always works. Chat enumeration
+ * is delegated-only — Graph publishes no tenant-wide application route for
+ * chats — and additionally needs `Chat.ReadBasic`, which a credential stored
+ * before connector 0.8.0 does not carry and cannot obtain by refreshing.
+ *
+ * So each half renders from its own `available` flag, and an unavailable half
+ * renders ONE SENTENCE saying why, never an empty dropdown. An empty
+ * `<select>` is a claim about the tenant ("you have no chats"); it must not be
+ * how "I could not look" looks. That distinction is the entire reason the DTO
+ * is a union instead of an array.
+ */
+
+export interface TeamsTargetPickerProps {
+  /** `null` while the directory is still loading, or when it failed to load
+   *  at all — both render as "the field is all you have", quietly. */
+  readonly targets: AgentTeamsTargetsDto | null;
+  readonly loading: boolean;
+  readonly disabled: boolean;
+  /** The id currently in the text field, so a picked row can render as the
+   *  selected one and a hand-typed id simply shows no selection. */
+  readonly value: string;
+  readonly onSelect: (id: string) => void;
+}
+
+/** Label for one chat row: its topic, else its members, else its id. Never
+ *  blank — a nameless chat is still a pickable one. */
+function chatLabel(
+  chat: TeamsChatOptionDto,
+  fallbackMembers: (names: readonly string[]) => string,
+): string {
+  if (chat.topic !== null) return chat.topic;
+  if (chat.memberNames !== undefined && chat.memberNames.length > 0) {
+    return fallbackMembers(chat.memberNames);
+  }
+  return chat.id;
+}
+
+export function TeamsTargetPicker({
+  targets,
+  loading,
+  disabled,
+  value,
+  onSelect,
+}: TeamsTargetPickerProps): React.JSX.Element | null {
+  const t = useTranslations('operatorAgents.teamsTargets');
+
+  if (loading) {
+    return (
+      <p className="text-[11px] text-[color:var(--fg-muted)]">{t('loading')}</p>
+    );
+  }
+  // No directory at all: say nothing and let the text field do its job. A
+  // component that announced its own absence would be noise on every screen
+  // whose connector predates the feature.
+  if (targets === null) return null;
+
+  const teams = targets.teams;
+  const chats = targets.chats;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <TargetSelect
+        label={t('teamsLabel')}
+        emptyLabel={t('teamsEmpty')}
+        placeholder={t('choose')}
+        listing={teams}
+        disabled={disabled}
+        value={value}
+        onSelect={onSelect}
+        optionsOf={(items: readonly TeamsTeamOptionDto[]) =>
+          items.map((team) => ({ id: team.id, label: team.displayName }))
+        }
+        unavailableText={(reason) =>
+          t(`unavailable.teams.${reason}`, { scope: 'Chat.ReadBasic' })
+        }
+      />
+      <TargetSelect
+        label={t('chatsLabel')}
+        emptyLabel={t('chatsEmpty')}
+        placeholder={t('choose')}
+        listing={chats}
+        disabled={disabled}
+        value={value}
+        onSelect={onSelect}
+        optionsOf={(items: readonly TeamsChatOptionDto[]) =>
+          items.map((chat) => ({
+            id: chat.id,
+            label: `${chatLabel(chat, (names) => names.join(', '))} · ${t(
+              `chatType.${chat.chatType}`,
+            )}`,
+          }))
+        }
+        unavailableText={(reason) =>
+          t(`unavailable.chats.${reason}`, { scope: 'Chat.ReadBasic' })
+        }
+      />
+    </div>
+  );
+}
+
+interface TargetSelectProps<T> {
+  readonly label: string;
+  readonly emptyLabel: string;
+  readonly placeholder: string;
+  readonly listing: TeamsTargetListingDto<T>;
+  readonly disabled: boolean;
+  readonly value: string;
+  readonly onSelect: (id: string) => void;
+  readonly optionsOf: (items: readonly T[]) => readonly {
+    id: string;
+    label: string;
+  }[];
+  readonly unavailableText: (reason: string) => string;
+}
+
+/**
+ * One half of the picker.
+ *
+ * THREE STATES, KEPT APART ON PURPOSE: a usable list, a tenant that genuinely
+ * has none (`available` with no items — an explicit sentence, still no empty
+ * dropdown), and a listing that could not be produced (one sentence naming
+ * the reason). Collapsing the last two is the bug this whole shape exists to
+ * prevent.
+ */
+function TargetSelect<T>({
+  label,
+  emptyLabel,
+  placeholder,
+  listing,
+  disabled,
+  value,
+  onSelect,
+  optionsOf,
+  unavailableText,
+}: TargetSelectProps<T>): React.JSX.Element {
+  if (!listing.available) {
+    return (
+      <p
+        role="note"
+        className="text-[11px] text-[color:var(--fg-muted)]"
+        data-testid={`target-unavailable-${label}`}
+      >
+        {unavailableText(listing.reason)}
+      </p>
+    );
+  }
+  const options = optionsOf(listing.items);
+  if (options.length === 0) {
+    return (
+      <p className="text-[11px] text-[color:var(--fg-muted)]">{emptyLabel}</p>
+    );
+  }
+  // `value` is the text field's content, which may be a hand-typed id that is
+  // in neither list. Falling back to '' then shows the placeholder rather than
+  // silently pinning the first option — the select must never claim a choice
+  // the operator did not make.
+  const selected = options.some((option) => option.id === value) ? value : '';
+  return (
+    <label className="flex flex-col gap-1 text-[11px] text-[color:var(--fg-muted)]">
+      {label}
+      <select
+        value={selected}
+        disabled={disabled}
+        aria-label={label}
+        onChange={(e) => {
+          if (e.target.value !== '') onSelect(e.target.value);
+        }}
+        className="rounded-md border border-[color:var(--border)] bg-transparent px-2 py-1 text-sm text-[color:var(--fg-strong)]"
+      >
+        <option value="">{placeholder}</option>
+        {options.map((option) => (
+          <option key={option.id} value={option.id}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -2312,6 +2312,78 @@
         "hint": "Das Provisioning lädt dieses Paket selbst in den Tenant-Katalog — ein manueller Upload pro Agent ist nicht nötig. Der Download bleibt als Rückfallebene: für Tenants, in denen programmatische Katalog-Uploads nicht erlaubt sind, oder wenn du das Manifest vorher ansehen willst. Es wird bei jeder Anfrage neu erzeugt und entspricht damit genau dem, was das Provisioning hochladen würde.",
         "download": "Teams-App-Paket (.zip) herunterladen"
       }
+    },
+    "teamsTargets": {
+      "loading": "Teams und Chats werden geladen …",
+      "choose": "Bitte auswählen",
+      "teamsLabel": "Team aus der Liste wählen",
+      "chatsLabel": "Chat aus der Liste wählen",
+      "teamsEmpty": "In diesem Tenant ist kein Team sichtbar. Nutze das Feld unten.",
+      "chatsEmpty": "In diesem Tenant ist kein Chat sichtbar. Nutze das Feld unten.",
+      "chatType": {
+        "group": "Gruppenchat",
+        "oneOnOne": "1:1-Chat",
+        "meeting": "Besprechungschat"
+      },
+      "unavailable": {
+        "teams": {
+          "connector_unavailable": "Ohne aktiven M365-Connector gibt es keine Teamliste — trage die ID unten von Hand ein.",
+          "connector_unsupported": "Der installierte Connector kann keine Teams auflisten. Nach einem Upgrade erscheint hier eine Auswahl; bis dahin trage die ID unten ein.",
+          "sign_in_required": "Für die Teamliste fehlt die Tenant-Anmeldung. Melde dich einmal an oder trage die ID unten ein.",
+          "scope_missing": "Die gespeicherte Anmeldung kennt die Berechtigung {scope} noch nicht. Eine erneute Anmeldung schaltet die Liste frei.",
+          "consent_required": "Dem Tenant fehlt die Zustimmung zum Auflisten von Teams. Bis dahin trage die ID unten ein.",
+          "lookup_failed": "Die Teamliste konnte gerade nicht geladen werden. Lade die Seite neu oder trage die ID unten ein."
+        },
+        "chats": {
+          "connector_unavailable": "Ohne aktiven M365-Connector gibt es keine Chatliste — trage die ID unten von Hand ein.",
+          "connector_unsupported": "Der installierte Connector kann keine Chats auflisten. Nach einem Upgrade erscheint hier eine Auswahl; bis dahin trage die Chat-ID unten ein.",
+          "sign_in_required": "Chats lassen sich nur mit einer Tenant-Anmeldung auflisten — Graph bietet dafür keinen App-Zugriff an. Melde dich einmal an oder trage die Chat-ID unten ein.",
+          "scope_missing": "Die gespeicherte Anmeldung kennt die Berechtigung {scope} noch nicht und kann sie nicht nachträglich erneuern. Eine einmalige neue Anmeldung schaltet die Chatliste frei; bis dahin trage die Chat-ID unten ein.",
+          "consent_required": "Dem Tenant fehlt die Zustimmung zum Auflisten von Chats. Bis dahin trage die Chat-ID unten ein.",
+          "lookup_failed": "Die Chatliste konnte gerade nicht geladen werden. Lade die Seite neu oder trage die Chat-ID unten ein."
+        }
+      }
+    },
+    "teamsReset": {
+      "heading": "Provisionierung zurücksetzen",
+      "open": "Zurücksetzen …",
+      "cancel": "Abbrechen",
+      "hint": "Räumt die in Azure angelegten Objekte ab, damit ein neuer Versuch mit demselben Slug starten kann.",
+      "runningHint": "Solange eine Provisionierung läuft, ist das Zurücksetzen gesperrt — warte, bis der Lauf fertig ist.",
+      "confirmHeading": "Das wird unwiderruflich gelöscht:",
+      "consequenceApp": "Die Entra-App-Registrierung samt Geheimnis — gelöscht und aus dem Papierkorb entfernt, damit der Name sofort wieder frei ist.",
+      "consequenceBot": "Der Azure-Bot-Dienst dieses Agenten.",
+      "consequenceCatalog": "Der Eintrag im Teams-App-Katalog des Tenants; die App verschwindet damit aus allen Teams und Chats.",
+      "consequenceInstalls": "Alle hier vermerkten Team- und Chat-Installationen.",
+      "keepsHint": "Bot-Slug und Anzeigename bleiben erhalten — ein neuer Lauf startet direkt mit denselben Angaben.",
+      "acknowledge": "Ich habe verstanden, dass diese Azure-Objekte gelöscht werden und neu angelegt werden müssen.",
+      "confirm": "Endgültig zurücksetzen",
+      "busy": "Wird zurückgesetzt …",
+      "resultComplete": "Zurückgesetzt. Der Agent kann jetzt erneut provisioniert werden.",
+      "resultIncomplete": "Abgebrochen bei „{step}“ — alles davor ist abgeräumt, der Rest steht noch. Ein erneuter Aufruf macht dort weiter.",
+      "stepLine": "{step}: {outcome}",
+      "steps": {
+        "catalog_removed": "Katalogeintrag",
+        "bot_deleted": "Azure-Bot",
+        "app_deleted": "App-Registrierung",
+        "identity_reset": "Datenbankzeile"
+      },
+      "outcomes": {
+        "removed": "entfernt",
+        "already-absent": "war schon weg",
+        "skipped": "nicht vorhanden",
+        "blocked": "blockiert",
+        "failed": "fehlgeschlagen"
+      },
+      "details": {
+        "nothing_to_remove": "Es gab dazu keinen Eintrag.",
+        "catalog_removal_unsupported": "Der installierte Connector kann den Katalogeintrag nicht entfernen. Damit wurde nichts weiter gelöscht: ein neuer Lauf würde sonst den alten Katalogeintrag übernehmen und den Bot an eine gelöschte App-ID binden.",
+        "tenant_sign_in_required": "Der Katalogeintrag lässt sich nur mit einer Tenant-Anmeldung entfernen. Melde dich an und starte das Zurücksetzen erneut — eine zusätzliche Berechtigung ist dafür nicht nötig.",
+        "purge_unsupported": "Der installierte Connector kann den Papierkorb nicht leeren. Die App-Registrierung wurde deshalb absichtlich NICHT gelöscht: sie würde ihren Namen sonst 30 Tage blockieren.",
+        "app_absent_unpurgeable": "Die App-Registrierung ist bereits weg, ließ sich aber nicht mehr im Papierkorb nachschlagen. Sie könnte den Namen noch bis zu 30 Tage belegen — wähle im Zweifel einen anderen Bot-Slug.",
+        "app_provably_gone": "Die App-Registrierung ist weg und liegt auch nicht im Papierkorb — der Name ist wieder frei.",
+        "arm_not_configured": "Ohne ARM-Konfiguration wurde nie ein Bot-Dienst angelegt."
+      }
     }
   },
   "builder": {

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -2312,6 +2312,78 @@
         "hint": "Provisioning uploads this package to the tenant catalogue itself — no manual upload per agent is needed. The download stays as a fallback: for tenants where programmatic catalogue uploads are not allowed, or when you want to inspect the manifest first. It is rendered fresh on every request, so it matches exactly what provisioning would upload.",
         "download": "Download the Teams app package (.zip)"
       }
+    },
+    "teamsTargets": {
+      "loading": "Loading teams and chats …",
+      "choose": "Please pick one",
+      "teamsLabel": "Pick a team from the list",
+      "chatsLabel": "Pick a chat from the list",
+      "teamsEmpty": "No team is visible in this tenant. Use the field below.",
+      "chatsEmpty": "No chat is visible in this tenant. Use the field below.",
+      "chatType": {
+        "group": "Group chat",
+        "oneOnOne": "One-to-one chat",
+        "meeting": "Meeting chat"
+      },
+      "unavailable": {
+        "teams": {
+          "connector_unavailable": "Without an active M365 connector there is no team list — type the id into the field below.",
+          "connector_unsupported": "The installed connector cannot list teams. A list appears here after an upgrade; until then type the id below.",
+          "sign_in_required": "The team list needs the tenant sign-in. Sign in once, or type the id below.",
+          "scope_missing": "The stored sign-in does not yet carry the {scope} permission. Signing in again unlocks the list.",
+          "consent_required": "The tenant has not consented to listing teams. Until it does, type the id below.",
+          "lookup_failed": "The team list could not be loaded just now. Reload the page, or type the id below."
+        },
+        "chats": {
+          "connector_unavailable": "Without an active M365 connector there is no chat list — type the id into the field below.",
+          "connector_unsupported": "The installed connector cannot list chats. A list appears here after an upgrade; until then type the chat id below.",
+          "sign_in_required": "Chats can only be listed with a tenant sign-in — Graph offers no app-only route for them. Sign in once, or type the chat id below.",
+          "scope_missing": "The stored sign-in does not yet carry the {scope} permission and cannot pick it up by refreshing. One fresh sign-in unlocks the chat list; until then type the chat id below.",
+          "consent_required": "The tenant has not consented to listing chats. Until it does, type the chat id below.",
+          "lookup_failed": "The chat list could not be loaded just now. Reload the page, or type the chat id below."
+        }
+      }
+    },
+    "teamsReset": {
+      "heading": "Reset provisioning",
+      "open": "Reset …",
+      "cancel": "Cancel",
+      "hint": "Clears up the objects created in Azure so a new attempt can start with the same slug.",
+      "runningHint": "While a provisioning run is in flight the reset is locked — wait for the run to finish.",
+      "confirmHeading": "This is deleted for good:",
+      "consequenceApp": "The Entra app registration and its secret — deleted and purged from the recycle bin, so the name is free again straight away.",
+      "consequenceBot": "This agent's Azure bot service.",
+      "consequenceCatalog": "The entry in the tenant's Teams app catalog; the app disappears from every team and chat with it.",
+      "consequenceInstalls": "Every team and chat install recorded here.",
+      "keepsHint": "Bot slug and display name are kept — a new run starts from the same answers.",
+      "acknowledge": "I understand these Azure objects are deleted and will have to be created again.",
+      "confirm": "Reset for good",
+      "busy": "Resetting …",
+      "resultComplete": "Reset. The agent can be provisioned again now.",
+      "resultIncomplete": "Stopped at “{step}” — everything before it is cleared, the rest is still there. Calling it again picks up from that point.",
+      "stepLine": "{step}: {outcome}",
+      "steps": {
+        "catalog_removed": "Catalog entry",
+        "bot_deleted": "Azure bot",
+        "app_deleted": "App registration",
+        "identity_reset": "Database row"
+      },
+      "outcomes": {
+        "removed": "removed",
+        "already-absent": "was already gone",
+        "skipped": "not present",
+        "blocked": "blocked",
+        "failed": "failed"
+      },
+      "details": {
+        "nothing_to_remove": "There was no entry for it.",
+        "catalog_removal_unsupported": "The installed connector cannot withdraw the catalog entry. Nothing further was deleted because of it: a new run would otherwise adopt the old catalog entry and bind the bot to a deleted app id.",
+        "tenant_sign_in_required": "The catalog entry can only be withdrawn with a tenant sign-in. Sign in and start the reset again — no extra permission is needed for it.",
+        "purge_unsupported": "The installed connector cannot empty the recycle bin. The app registration was therefore deliberately NOT deleted: it would block its own name for 30 days.",
+        "app_absent_unpurgeable": "The app registration is already gone but could no longer be looked up in the recycle bin. It may still hold the name for up to 30 days — pick a different bot slug if in doubt.",
+        "app_provably_gone": "The app registration is gone and is not in the recycle bin either — the name is free again.",
+        "arm_not_configured": "Without ARM configured, no bot service was ever created."
+      }
     }
   },
   "builder": {


### PR DESCRIPTION
Two gaps the field test exposed: an operator has to type the install target by hand, and a failed run leaves debris nobody can clear from the UI.

## Picking a target instead of typing one

`GET /:slug/teams/targets` returns a discriminated union **per half**. `available: true, items: []` means the tenant genuinely has none; `available: false, reason` means we could not look. An unavailable half renders one sentence, never an empty dropdown. Teams and chats degrade independently, so a missing chat scope cannot hide the team list.

Selecting writes into the *existing* text field rather than replacing it, so the live classification from #950 stays the single verdict on what a target is. Freetext remains available for anything the listing cannot reach.

**Chats need a fresh sign-in.** Graph has no tenant-wide application route for chats — only `/users/{id}/chats`, per user. So listing them uses the delegated token, and that token needs `Chat.ReadBasic`, which a credential stored before connector 0.8.0 cannot pick up on refresh. That is its own `scope_missing` state, not an error: telling someone who *is* signed in to sign in reads as a bug. Teams listing is unaffected and always works.

## Resetting a failed run

`catalog → bot → app registration (delete + purge) → row`, and the order is load-bearing.

**Catalog first, and a catalog that cannot be withdrawn aborts the whole teardown.** This was the finding that reshaped the sequence. `stableTeamsAppExternalId` derives the catalog `externalId` from the **agent id alone**, so it survives any reset — and chain step 4 *adopts* a found catalog entry instead of re-uploading. Tearing down the app registration while that entry still stands hands the next run a fresh `appId` paired with a manifest naming the deleted one: five green steps, and a bot that silently never answers. Nothing is destroyed unless the catalog entry can go first.

**Bot before registration**, because the bot handle is derived from `botSlug` + `appId`; deleting the registration first erases the only input its name comes from.

**Registration last**, the single irreversible step, so an abort anywhere earlier leaves the world exactly as found.

### Delete and purge are one step, never two

A deleted Entra app sits in the recycle bin and **holds its `uniqueName` for 30 days**. That is how #916 burned a slug for a month. So a connector without `purgeDeletedAppRegistration` is **refused the delete entirely** (`outcome: 'blocked'`): turning a reusable registration into a month-long reservation on the operator's own slug is strictly worse than doing nothing.

Resuming after an abort between the two is the case that had to work. Three sources for the object id, in order: the stored `app_object_id` (migration 0055), `getAppRegistration(appId)` while the app is live, and `findDeletedAppRegistration({appId})` — the only one that still works *after* the delete. Whatever is learned is persisted immediately, and the row **keeps `app_id` until the purge is confirmed**. A bare 404 is never read as proof of a clean recycle bin; on a `DeletedObjectIdMismatchError` the purge retries with the corrected id the error carries.

### The row

Reset to `pending`, not deleted, mirroring the existing `clearTeamInstall` precedent. `bot_slug` and `display_name` are the only two fields a human typed, and `bot_slug` is `UNIQUE` — dropping the row would make an operator retype both and silently change what a re-create may be called. Azure identifiers are nulled; `agent_teams_installs` rows are deleted explicitly, because the FK does not cascade while the identity row survives. The row clears only when every step above it is provably done.

The reset writes into the same progress timeline as a provisioning run, so partial teardowns are visible as steps rather than as a single "failed".

## One residual case, named rather than hidden

If the app registration is already gone from `/applications`, `app_object_id` was never stored (a row predating 0055), **and** the connector cannot search the recycle bin, there is no call left to make. The reset reports `already-absent` with detail `app_absent_unpurgeable`, and the UI says the name may still be held for up to 30 days and suggests choosing a different slug. Every other path is closed; this one is unreachable for anything provisioned since 0055 or against connector ≥ 0.8.0.

## Verification

middleware: **8054 tests, 8038 pass, 0 fail**; typecheck, `typecheck:test` (370, no regressions) and lint all clean. web-ui: **1086 pass, 0 fail** across 118 files; typecheck clean, 0 lint errors, `i18n:check` OK at 4326 keys. 41 new middleware tests, 20 new web-ui tests.

The reset tests were mutation-checked: removing the "refuse to delete without purge" guard and the halt that keeps the row on a failed app step turned **5 of 24** red.

Requires `@omadia/integration-microsoft365` **0.8.0**.

Refs #860, #916.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790617894&installation_model_id=428086&pr_number=951&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F951&signature=e28bbfa3cd8688b2cba49656594932ba5f8edc04cf0b2df5e681f582eef8809c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->