### PR TITLE
fix: start a run again after a reset, search the target lists, stop the token display lying

### DIFF
--- a/middleware/src/platform/teamsDelegatedSignIn.ts
+++ b/middleware/src/platform/teamsDelegatedSignIn.ts
@@ -386,3 +386,69 @@ export function summarizeTokenSet(tokens: DelegatedTokenSet): DelegatedTokenSumm
     ...(tokens.account ? { account: tokens.account } : {}),
   };
 }
+
+// ---------------------------------------------------------------------------
+// Expiry, and the margin in front of it
+// ---------------------------------------------------------------------------
+
+/**
+ * How long BEFORE an access token's stated expiry it should be treated as
+ * spent — five minutes.
+ *
+ * WHY A MARGIN AT ALL. Without one, the only way to discover an expired token
+ * is to spend a Graph call finding out — and that call is a catalogue upload,
+ * a multi-megabyte package that then has to be sent again. Worse, the recovery
+ * hinges on the failure coming back as a recognisable
+ * `DelegatedTokenExpiredError`; if Graph answers with something else, or a
+ * connector classifies it differently, the run fails for a reason no human
+ * needs to fix.
+ *
+ * WHY FIVE MINUTES, rather than thirty seconds or an hour. Three terms bound
+ * it:
+ *
+ *   - THE CALL IT PROTECTS. A catalogue upload takes seconds to tens of
+ *     seconds, and a token that was valid when the request left must still be
+ *     valid when Graph validates it. Under about a minute leaves that
+ *     unguarded.
+ *   - CLOCK SKEW against Microsoft. `expiresAt` comes from a token issued on
+ *     Microsoft's clock and is compared against ours. An NTP-synced host is
+ *     within seconds; a drifted container can be a couple of minutes out in
+ *     either direction. Five minutes covers the drift worth covering — a host
+ *     further out than that has a problem no margin fixes.
+ *   - THE COST OF BEING EARLY. The token lives roughly 60 minutes, so this
+ *     refreshes early only in the last ~8% of its life: one extra token
+ *     request, occasionally. An hour-wide margin would refresh on essentially
+ *     every run and turn a silent optimisation into constant rotation of the
+ *     refresh token.
+ *
+ * It is also the window MSAL uses for its own proactive refresh, so this
+ * middleware ages a token on the same schedule as the library the connector
+ * refreshes it with, rather than holding a second opinion.
+ */
+export const ACCESS_TOKEN_REFRESH_MARGIN_MS = 5 * 60 * 1000;
+
+/**
+ * Is this access token past its expiry — or close enough that it should be
+ * refreshed before being used?
+ *
+ * A margin of `0` is the plain question "has it expired", which is what the
+ * operator-facing `accessTokenStale` projection asks. The job runner asks the
+ * same question with {@link ACCESS_TOKEN_REFRESH_MARGIN_MS}. One rule, two
+ * margins — so "stale" on screen and "refresh now" in the runner can never
+ * drift into two different definitions of expiry.
+ *
+ * An UNPARSEABLE `expiresAt` answers `false`. The honest reading of "I cannot
+ * tell when this expires" is not "it has expired": treating it as spent would
+ * refresh on every single call, and the reactive path still catches a token
+ * that really is dead. Wrong in this direction costs one recoverable retry;
+ * wrong in the other costs a refresh per run, forever.
+ */
+export function isAccessTokenExpiring(
+  expiresAt: string,
+  now: Date,
+  marginMs = 0,
+): boolean {
+  const expiry = Date.parse(expiresAt);
+  if (!Number.isFinite(expiry)) return false;
+  return expiry - marginMs <= now.getTime();
+}

--- a/middleware/src/platform/teamsDelegatedTokenStore.ts
+++ b/middleware/src/platform/teamsDelegatedTokenStore.ts
@@ -36,6 +36,7 @@
  */
 
 import {
+  isAccessTokenExpiring,
   summarizeTokenSet,
   type DelegatedTokenSet,
   type DelegatedTokenSummary,
@@ -242,8 +243,11 @@ export class TeamsDelegatedTokenStore {
     const envelope = await this.readEnvelope();
     if (envelope === undefined) return SIGNED_OUT;
     const summary = summarizeTokenSet(envelope.tokens);
-    const expiry = Date.parse(summary.expiresAt);
-    const stale = Number.isFinite(expiry) && expiry <= this.now().getTime();
+    // Margin 0: this is the plain "has it expired" question. The job runner
+    // asks the SAME predicate with a refresh margin — sharing the rule is what
+    // keeps "stale" on screen and "refresh before use" in the runner from
+    // becoming two different definitions of expiry.
+    const stale = isAccessTokenExpiring(summary.expiresAt, this.now());
     return {
       signedIn: true,
       signedInAt: envelope.signedInAt,

--- a/middleware/src/services/teamsProvisioningJob.ts
+++ b/middleware/src/services/teamsProvisioningJob.ts
@@ -64,8 +64,10 @@ import {
   type TeamsProvisioningState,
 } from '../platform/agentTeamsIdentityStore.js';
 import {
+  ACCESS_TOKEN_REFRESH_MARGIN_MS,
   adminConsentUrlOf,
   delegatedStepOf,
+  isAccessTokenExpiring,
   isDelegatedConsentRequiredError,
   isDelegatedSignInRequiredError,
   isDelegatedTokenExpiredError,
@@ -839,6 +841,15 @@ export interface TeamsProvisioningJobOptions {
    * upload, i.e. exactly the pre-0.6.0 behaviour.
    */
   readonly delegatedTokens?: TeamsDelegatedTokenPort;
+  /**
+   * Wall clock, injectable. Used only to decide whether a delegated access
+   * token is close enough to its expiry to be refreshed BEFORE the call that
+   * would otherwise discover it the hard way — a decision that has to be
+   * testable without waiting an hour. Named `now` to match
+   * `platform/teamsDelegatedTokenStore.ts`, which seams the clock the same
+   * way for the same question.
+   */
+  readonly now?: () => Date;
   readonly log?: (msg: string) => void;
 }
 
@@ -873,6 +884,7 @@ export class TeamsProvisioningJobRunner {
     | undefined;
   private readonly events: TeamsProvisioningEventSink | undefined;
   private readonly delegatedTokens: TeamsDelegatedTokenPort | undefined;
+  private readonly now: () => Date;
   private readonly log: (msg: string) => void;
 
   /**
@@ -937,6 +949,7 @@ export class TeamsProvisioningJobRunner {
     this.resolveTeamName = opts.resolveTeamName;
     this.events = opts.events;
     this.delegatedTokens = opts.delegatedTokens;
+    this.now = opts.now ?? ((): Date => new Date());
     this.log = opts.log ?? ((m) => console.log(m));
   }
 
@@ -1886,6 +1899,48 @@ export class TeamsProvisioningJobRunner {
       detail: DELEGATED_UPLOAD_DETAIL,
     });
 
+    // PROACTIVE REFRESH — before the call, not after it has failed.
+    //
+    // The reactive path below still exists and still matters, but it can only
+    // ever run once the upload has already failed: a package re-sent, and a
+    // recovery that depends on the failure being classified exactly as
+    // "expired". If Graph answers with anything else, a run dies for a reason
+    // no human needs to fix. Asking the token whether it is spent costs
+    // nothing and removes that whole class of failure.
+    //
+    // A FAILURE HERE IS NOT FATAL, deliberately. If the refresh throws we
+    // carry on with the stored token: our clock may be the thing that is
+    // wrong, and a token we wrongly believed spent may work perfectly. When it
+    // does not, the upload fails exactly as it did before this block existed
+    // and the reactive path takes over — so the worst case of a proactive
+    // refresh is today's behaviour, never worse than it.
+    const refreshDelegated = provisioner.refreshDelegatedToken;
+    let current = tokens;
+    if (
+      typeof refreshDelegated === 'function' &&
+      isAccessTokenExpiring(
+        current.expiresAt,
+        this.now(),
+        ACCESS_TOKEN_REFRESH_MARGIN_MS,
+      )
+    ) {
+      try {
+        current = await refreshDelegated.call(provisioner, { tokens: current });
+        // Persisted IMMEDIATELY, for the same reason the reactive path does:
+        // a rotation the vault has not seen is a refresh token already spent,
+        // and a crash here would sign the tenant out silently.
+        await custody.write(current);
+        await this.emit(agentId, 'catalog_uploaded', 'progress', {
+          detail: DELEGATED_TOKEN_REFRESHED_DETAIL,
+        });
+      } catch (err) {
+        current = tokens;
+        this.log(
+          `[teams-provisioning] pre-emptive delegated token refresh for agent '${agentId}' failed, continuing with the stored token: ${errorMessage(err)}`,
+        );
+      }
+    }
+
     const attemptUpload = async (set: DelegatedTokenSet): Promise<string> => {
       const result = await delegatedUpload.call(provisioner, {
         packageZip,
@@ -1902,8 +1957,15 @@ export class TeamsProvisioningJobRunner {
     };
 
     try {
-      return { kind: 'uploaded', teamsAppId: await attemptUpload(tokens) };
+      return { kind: 'uploaded', teamsAppId: await attemptUpload(current) };
     } catch (err) {
+      // THE FALLBACK, and it stays a fallback rather than becoming dead code.
+      // The check above reads a clock; this reads Microsoft's actual verdict.
+      // It is what still catches a host whose clock is behind, and a token the
+      // server invalidated early — a revoked session, a password change, a
+      // Conditional Access policy — neither of which any expiry arithmetic can
+      // see coming.
+      //
       // The ONE delegated failure an operator must never be shown: an access
       // token past its expiry with a refresh token that is still good. It is
       // recovered right here — refresh, retry once — because surfacing it
@@ -1913,7 +1975,7 @@ export class TeamsProvisioningJobRunner {
       if (!isDelegatedTokenExpiredError(err) || !isRecoverableByRefresh(err)) throw err;
       const refresh = provisioner.refreshDelegatedToken;
       if (typeof refresh !== 'function') throw err;
-      const rotated = await refresh.call(provisioner, { tokens });
+      const rotated = await refresh.call(provisioner, { tokens: current });
       await custody.write(rotated);
       await this.emit(agentId, 'catalog_uploaded', 'progress', {
         detail: DELEGATED_TOKEN_REFRESHED_DETAIL,

--- a/middleware/test/teamsProvisioningDelegatedUpload.test.ts
+++ b/middleware/test/teamsProvisioningDelegatedUpload.test.ts
@@ -206,6 +206,9 @@ function makeRunner(input: {
   readonly provisioner: TeamsProvisionerPort;
   readonly custody?: FakeCustody;
   readonly store?: FakeStore;
+  /** Seamed so "is this token nearly spent?" is testable without waiting an
+   *  hour. Absent = the real clock, i.e. production behaviour. */
+  readonly now?: () => Date;
 }): RunnerParts {
   const store = input.store ?? new FakeStore();
   const events = new RecordingEvents();
@@ -220,6 +223,7 @@ function makeRunner(input: {
     timers: immediateTimers(),
     maxAttempts: 2,
     baseRetryDelayMs: 0,
+    ...(input.now ? { now: input.now } : {}),
     log: () => undefined,
   });
   return {
@@ -590,5 +594,180 @@ describe('#924 a refreshable expiry never reaches the operator', () => {
       classifyTeamsProvisioningError(parts.store.row.lastError ?? '').code,
       'delegated_token_expired',
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Refreshing BEFORE the call, not after it failed
+// ---------------------------------------------------------------------------
+
+/**
+ * The reactive path works, but it can only run once an upload has already
+ * failed: a package re-sent, and a recovery that hinges on the failure being
+ * classified exactly as "expired". If Graph answers with anything else — or a
+ * connector labels it differently — a run dies for a reason no human needs to
+ * fix. Reading the clock before the call removes that whole class of failure.
+ *
+ * What is pinned here is the SHAPE of the guarantee, not the margin's value:
+ * a token well inside its life is left alone, one inside the margin is
+ * refreshed first, a rotation is persisted immediately, the reactive path
+ * survives as the fallback it is — and a failing pre-emptive refresh is never
+ * worse than not having tried.
+ */
+describe('#924 the runner refreshes before it spends a token', () => {
+  const NOW = new Date('2026-08-28T12:00:00.000Z');
+  const at = (ms: number): string => new Date(NOW.getTime() + ms).toISOString();
+
+  function delegatedSeeing(
+    seen: DelegatedTokenSet[],
+  ): NonNullable<TeamsProvisionerPort['uploadToCatalogDelegated']> {
+    return (input: { tokens: DelegatedTokenSet }) => {
+      seen.push(input.tokens);
+      return Promise.resolve({
+        app: { value: { teamsAppId: 'teams-app-delegated' } },
+        tokens: input.tokens,
+        refreshed: false,
+      });
+    };
+  }
+
+  it('leaves a token that is comfortably alive alone', async () => {
+    const refreshes: number[] = [];
+    const parts = makeRunner({
+      now: () => NOW,
+      custody: new FakeCustody(tokens({ expiresAt: at(30 * 60_000) })),
+      provisioner: provisioner({
+        delegated: delegatedSeeing([]),
+        refresh: () => {
+          refreshes.push(1);
+          return Promise.resolve(tokens());
+        },
+      }),
+    });
+    const result = await parts.run();
+
+    assert.equal(result.status, 'installed');
+    // Half an hour of life left. Refreshing here would spend a rotation of the
+    // refresh token on every single run, which is the cost that decides the
+    // margin's size.
+    assert.deepEqual(refreshes, []);
+    assert.equal(parts.custody.writes.length, 0);
+  });
+
+  it('refreshes a token inside the margin and uploads with the NEW one', async () => {
+    const seen: DelegatedTokenSet[] = [];
+    const rotated = tokens({ accessToken: 'at-fresh', expiresAt: at(60 * 60_000) });
+    const parts = makeRunner({
+      now: () => NOW,
+      // Two minutes left: not expired, so nothing would have failed — and
+      // that is exactly the window the reactive path cannot see.
+      custody: new FakeCustody(tokens({ expiresAt: at(2 * 60_000) })),
+      provisioner: provisioner({
+        delegated: delegatedSeeing(seen),
+        refresh: () => Promise.resolve(rotated),
+      }),
+    });
+    const result = await parts.run();
+
+    assert.equal(result.status, 'installed');
+    // The upload must ride on the refreshed set, or the refresh was pointless.
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0]?.accessToken, 'at-fresh');
+    // Persisted BEFORE the upload: a rotation the vault never saw is a refresh
+    // token already spent, and a crash here would sign the tenant out silently.
+    assert.equal(parts.custody.writes.length, 1);
+    assert.equal(parts.custody.writes[0]?.accessToken, 'at-fresh');
+    assert.ok(
+      parts.events.written.some((e) => e.detail === DELEGATED_TOKEN_REFRESHED_DETAIL),
+    );
+  });
+
+  it('refreshes a token that is already past its expiry', async () => {
+    const seen: DelegatedTokenSet[] = [];
+    const parts = makeRunner({
+      now: () => NOW,
+      custody: new FakeCustody(tokens({ expiresAt: at(-60_000) })),
+      provisioner: provisioner({
+        delegated: delegatedSeeing(seen),
+        refresh: () => Promise.resolve(tokens({ accessToken: 'at-fresh' })),
+      }),
+    });
+
+    assert.equal((await parts.run()).status, 'installed');
+    assert.equal(seen[0]?.accessToken, 'at-fresh');
+  });
+
+  it('carries on with the stored token when the pre-emptive refresh fails', async () => {
+    const seen: DelegatedTokenSet[] = [];
+    const parts = makeRunner({
+      now: () => NOW,
+      custody: new FakeCustody(tokens({ expiresAt: at(-60_000) })),
+      provisioner: provisioner({
+        delegated: delegatedSeeing(seen),
+        refresh: () => Promise.reject(new Error('token endpoint unreachable')),
+      }),
+    });
+    const result = await parts.run();
+
+    // OUR clock may be the thing that is wrong. A token we wrongly believed
+    // spent can work perfectly — and when it does not, the reactive path
+    // below takes over. The worst case of trying is today's behaviour.
+    assert.equal(result.status, 'installed');
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0]?.accessToken, 'at');
+    assert.equal(parts.custody.writes.length, 0);
+  });
+
+  it('keeps the REACTIVE path for a token the server killed early', async () => {
+    // Valid by the clock, dead at Microsoft — a revoked session, a password
+    // change, a Conditional Access policy. No expiry arithmetic sees this
+    // coming, which is why the fallback is not dead code.
+    const seen: DelegatedTokenSet[] = [];
+    let firstCall = true;
+    const parts = makeRunner({
+      now: () => NOW,
+      custody: new FakeCustody(tokens({ expiresAt: at(45 * 60_000) })),
+      provisioner: provisioner({
+        delegated: (input) => {
+          if (firstCall) {
+            firstCall = false;
+            return Promise.reject(
+              connectorError('DelegatedTokenExpiredError', {
+                reason: 'access-token-expired',
+                recoverableByRefresh: true,
+              }),
+            );
+          }
+          seen.push(input.tokens);
+          return Promise.resolve({
+            app: { value: { teamsAppId: 'teams-app-delegated' } },
+            tokens: input.tokens,
+            refreshed: false,
+          });
+        },
+        refresh: () => Promise.resolve(tokens({ accessToken: 'at-recovered' })),
+      }),
+    });
+    const result = await parts.run();
+
+    assert.equal(result.status, 'installed');
+    assert.equal(seen[0]?.accessToken, 'at-recovered');
+    assert.equal(parts.custody.writes.length, 1);
+    assert.equal(parts.custody.writes[0]?.accessToken, 'at-recovered');
+  });
+
+  it('does not try to refresh against a connector that cannot', async () => {
+    // Pre-0.6.0: no `refreshDelegatedToken`. Feature-detected, never called
+    // blind — an expired token there still needs a human, as it always did.
+    const seen: DelegatedTokenSet[] = [];
+    const parts = makeRunner({
+      now: () => NOW,
+      custody: new FakeCustody(tokens({ expiresAt: at(-60_000) })),
+      provisioner: provisioner({ delegated: delegatedSeeing(seen) }),
+    });
+
+    assert.equal((await parts.run()).status, 'installed');
+    assert.equal(seen[0]?.accessToken, 'at');
+    assert.equal(parts.custody.writes.length, 0);
   });
 });

--- a/web-ui/app/_components/ui/SearchableSelect.tsx
+++ b/web-ui/app/_components/ui/SearchableSelect.tsx
@@ -1,0 +1,239 @@
+'use client';
+
+import { useId, useMemo, useState } from 'react';
+
+/**
+ * A single-choice list you can type into — the ARIA 1.2 combobox pattern.
+ *
+ * WHY IT EXISTS. A native `<select>` is the right control until the list gets
+ * long: the byte5 tenant alone publishes thirty teams, and a chat whose topic
+ * is unset renders as a `19:…` stem, so the alphabetical wall an operator has
+ * to scroll is exactly the part they cannot read. Typing to filter is the only
+ * affordance that scales with the tenant.
+ *
+ * WHY NOT `<datalist>`, which this repo already uses in `GuidedControls` and
+ * `ConditionBuilder`. Those fields accept ANY string and the datalist is a
+ * convenience over free text, so browser-owned matching is fine. Here two
+ * things are required that a datalist cannot give: matching over text the
+ * option DISPLAYS (a chat's topic, its members) while the value is an opaque
+ * id, and a "nothing matched" state that says so in a sentence. A datalist
+ * matches on the option's `value` and renders an empty popup for a miss —
+ * which reads like a broken list rather than like an answer.
+ *
+ * KEYBOARD AND SCREEN READER PARITY IS THE ACCEPTANCE BAR, not a nicety: this
+ * replaces a native control, so anything a `<select>` did must still work.
+ * ArrowDown/ArrowUp move the active option (wrapping), Enter picks it, Escape
+ * closes and — pressed again on a closed list — clears the query, Home/End
+ * jump to the ends, Tab leaves. The input carries `role="combobox"` with
+ * `aria-expanded`, `aria-controls` and `aria-activedescendant`, so focus stays
+ * in the field while the announced option follows the arrow keys. A live
+ * region reports how many options remain after each keystroke, because a
+ * filter that silently shrinks a list IS worse than a `<select>` for anyone
+ * who cannot see it shrink.
+ *
+ * IT DOES NOT OWN THE VALUE. `value` is the id the caller holds, which may
+ * well be one this list has never heard of (hand-typed elsewhere). That is not
+ * an error state and is not corrected here: the matching row is marked
+ * selected when there is one, and otherwise nothing is. The control must never
+ * claim a choice the operator did not make.
+ */
+
+export interface SearchableOption {
+  readonly id: string;
+  /** What the row shows, and the primary thing the query matches. */
+  readonly label: string;
+  /**
+   * Extra text the query matches but the row does not repeat — a chat's
+   * member names, for instance, which are how a human recognises a chat whose
+   * topic is empty but which would double the length of every row.
+   */
+  readonly keywords?: readonly string[];
+}
+
+export interface SearchableSelectProps {
+  /** Visible label, and the input's accessible name. */
+  readonly label: string;
+  readonly placeholder: string;
+  readonly options: readonly SearchableOption[];
+  /** The id the caller currently holds. May be absent from `options`. */
+  readonly value: string;
+  readonly disabled: boolean;
+  /** One sentence for "your query matched nothing" — never an empty list. */
+  readonly noMatchText: (query: string) => string;
+  /** Live-region text for the number of remaining options. */
+  readonly matchCountText: (count: number) => string;
+  readonly onSelect: (id: string) => void;
+}
+
+/** Case- and accent-insensitive, so `muller` finds `Müller`. */
+function fold(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase();
+}
+
+function matches(option: SearchableOption, needle: string): boolean {
+  if (needle === '') return true;
+  // The id is searched too: an operator who pasted an id from somewhere else
+  // should see it light up in the list rather than wonder whether it is known.
+  const haystack = [option.label, option.id, ...(option.keywords ?? [])];
+  return haystack.some((part) => fold(part).includes(needle));
+}
+
+export function SearchableSelect({
+  label,
+  placeholder,
+  options,
+  value,
+  disabled,
+  noMatchText,
+  matchCountText,
+  onSelect,
+}: SearchableSelectProps): React.JSX.Element {
+  const listboxId = useId();
+  const inputId = useId();
+  const optionIdPrefix = useId();
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const needle = fold(query.trim());
+  const filtered = useMemo(
+    () => options.filter((option) => matches(option, needle)),
+    [options, needle],
+  );
+
+  // Clamped rather than reset: a filter that narrows under the cursor must
+  // leave a VALID active option, and index 0 is the only one always present.
+  const active = filtered.length === 0 ? -1 : Math.min(activeIndex, filtered.length - 1);
+  const noMatch = query.trim() !== '' && filtered.length === 0;
+  const expanded = open && filtered.length > 0;
+
+  function commit(index: number): void {
+    const option = filtered[index];
+    if (option === undefined) return;
+    onSelect(option.id);
+    // Showing what was picked is the whole point of a searchable list; the
+    // id itself stays visible in the field this writes into.
+    setQuery(option.label);
+    setOpen(false);
+    setActiveIndex(0);
+  }
+
+  function onKeyDown(event: React.KeyboardEvent<HTMLInputElement>): void {
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      if (!open) {
+        setOpen(true);
+        return;
+      }
+      if (filtered.length === 0) return;
+      const step = event.key === 'ArrowDown' ? 1 : -1;
+      setActiveIndex((active + step + filtered.length) % filtered.length);
+      return;
+    }
+    if (event.key === 'Home' || event.key === 'End') {
+      if (!open || filtered.length === 0) return;
+      event.preventDefault();
+      setActiveIndex(event.key === 'Home' ? 0 : filtered.length - 1);
+      return;
+    }
+    if (event.key === 'Enter') {
+      if (!open || active < 0) return;
+      event.preventDefault();
+      commit(active);
+      return;
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      // Two escapes, two different jobs — dismiss the popup, then undo the
+      // filter. Collapsing them would make Escape destroy a query the
+      // operator only wanted to stop covering the page.
+      if (open) setOpen(false);
+      else setQuery('');
+      return;
+    }
+    if (event.key === 'Tab') setOpen(false);
+  }
+
+  return (
+    <div className="flex flex-col gap-1 text-[11px] text-[color:var(--fg-muted)]">
+      {/* A real `<label>`, so clicking it focuses the field exactly as it did
+          when this was a `<select>`. It is also the input's accessible name —
+          there is no `aria-label` competing with it. */}
+      <label htmlFor={inputId}>{label}</label>
+      <div className="relative">
+        <input
+          id={inputId}
+          type="text"
+          role="combobox"
+          aria-expanded={expanded}
+          aria-controls={listboxId}
+          aria-autocomplete="list"
+          aria-activedescendant={
+            expanded && active >= 0 ? `${optionIdPrefix}-${active}` : undefined
+          }
+          autoComplete="off"
+          placeholder={placeholder}
+          value={query}
+          disabled={disabled}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setActiveIndex(0);
+            setOpen(true);
+          }}
+          onFocus={() => setOpen(true)}
+          // A click lands on the option before the blur closes the list, so
+          // the close is deferred past the pointer sequence rather than
+          // guessed at from `relatedTarget` (which is empty in Safari).
+          onBlur={() => window.setTimeout(() => setOpen(false), 0)}
+          onKeyDown={onKeyDown}
+          className="w-full rounded-md border border-[color:var(--border)] bg-transparent px-2 py-1 text-sm text-[color:var(--fg-strong)]"
+        />
+        {expanded && (
+          <ul
+            id={listboxId}
+            role="listbox"
+            aria-label={label}
+            className="absolute z-10 mt-1 max-h-64 w-full overflow-y-auto rounded-md border border-[color:var(--border)] bg-[color:var(--bg-elevated)] py-1 shadow-lg"
+          >
+            {filtered.map((option, index) => (
+              <li
+                key={option.id}
+                id={`${optionIdPrefix}-${index}`}
+                role="option"
+                aria-selected={option.id === value}
+                // Keeps focus in the input so `aria-activedescendant` stays
+                // the single thing describing "where am I" in this widget.
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => commit(index)}
+                onMouseEnter={() => setActiveIndex(index)}
+                className={`cursor-pointer px-2 py-1 text-sm ${
+                  index === active
+                    ? 'bg-[color:var(--accent)]/15 text-[color:var(--fg-strong)]'
+                    : 'text-[color:var(--fg-strong)]'
+                }`}
+              >
+                {option.label}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+      {noMatch && (
+        <p role="status" className="text-[11px] text-[color:var(--fg-muted)]">
+          {noMatchText(query.trim())}
+        </p>
+      )}
+      {/* Announced, not shown: a sighted operator watches the list shrink, and
+          repeating the count under every field would be noise. Bare
+          `aria-live` rather than `role="status"` on purpose — the visible
+          "nothing matched" sentence above owns that role, and two status
+          landmarks per field would make the real one impossible to address. */}
+      <span aria-live="polite" aria-atomic="true" className="sr-only">
+        {matchCountText(filtered.length)}
+      </span>
+    </div>
+  );
+}

--- a/web-ui/app/operator/agents/[slug]/__tests__/AgentTeamsIdentity.restart.test.tsx
+++ b/web-ui/app/operator/agents/[slug]/__tests__/AgentTeamsIdentity.restart.test.tsx
@@ -1,0 +1,218 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { renderWithIntl } from '../../../../_lib/test-utils';
+import type {
+  AgentTeamsTargetsDto,
+  TeamsIdentityStatusDto,
+} from '../../../../_lib/agents';
+import { AgentTeamsIdentity } from '../_components/AgentTeamsIdentity';
+
+/**
+ * Getting back OUT of a target-less identity.
+ *
+ * THE FIELD-TEST DEAD END. A reset returns the row to `pending` and nulls
+ * `team_id`. The panel then had no control at all that could start a run: the
+ * create form renders only when NO row exists, and "provision again" was
+ * `disabled` without a recorded target — because the POST requires `team_id`
+ * and the server has no re-run-as-recorded path. Status "PENDING", every field
+ * empty, nothing to click. The only remaining move was deleting the agent.
+ *
+ * WHAT IS PINNED HERE, and deliberately in terms of STATE rather than history:
+ *   - an identity with NO target offers a chooser and can start a run with it;
+ *   - `bot_slug` and `display_name` are NOT resent — they survive a reset, and
+ *     re-sending them could only introduce a difference nobody asked for;
+ *   - an identity WITH a target is untouched: it keeps the re-run button and
+ *     never grows a second, competing way to start the same run.
+ *
+ * Nothing here observes "was reset", and nothing may: a row reaches this shape
+ * by other routes too, and a test keyed on history would pass while the panel
+ * stayed broken for all of them.
+ */
+
+const { mockGet, mockProvision, mockTargets } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockProvision: vi.fn(),
+  mockTargets: vi.fn(),
+}));
+
+vi.mock('../../../../_lib/agents', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../_lib/agents')>()),
+  getAgentTeamsIdentity: mockGet,
+  provisionAgentTeamsIdentity: mockProvision,
+  getAgentTeamsTargets: mockTargets,
+}));
+
+const TEAM_ID = '2f1a9c44-1f0e-4f2c-8f1a-9c441f0e4f2c';
+
+function statusDto(
+  identity: Partial<TeamsIdentityStatusDto['identity']> = {},
+  overrides: Partial<TeamsIdentityStatusDto> = {},
+): TeamsIdentityStatusDto {
+  return {
+    ok: true,
+    agent: 'sales-bot',
+    // What a reset leaves behind: the chain is back at the start and nothing
+    // is running, so no poll and no in-flight run can explain the missing
+    // control away.
+    state: 'pending',
+    running: false,
+    provisioner_installed: true,
+    identity: {
+      bot_slug: 'sales-bot',
+      display_name: 'Sales Bot',
+      app_id: null,
+      tenant_id: null,
+      teams_app_id: null,
+      teams_app_external_id: null,
+      team_id: null,
+      last_error: null,
+      created_at: '2026-08-27T08:00:00.000Z',
+      updated_at: '2026-08-27T09:00:00.000Z',
+      ...identity,
+    },
+    teams_bot: null,
+    ...overrides,
+  };
+}
+
+function targetsDto(): AgentTeamsTargetsDto {
+  return {
+    ok: true,
+    agent: 'sales-bot',
+    provisioner_installed: true,
+    teams: { available: true, items: [{ id: TEAM_ID, displayName: 'Acme Team' }] },
+    chats: { available: false, reason: 'sign_in_required' },
+  };
+}
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockProvision.mockReset();
+  mockTargets.mockReset();
+  mockGet.mockResolvedValue(statusDto());
+  mockTargets.mockResolvedValue(targetsDto());
+  mockProvision.mockResolvedValue({
+    ok: true,
+    agent: 'sales-bot',
+    bot_slug: 'sales-bot',
+    state: 'pending',
+    running: true,
+  });
+});
+
+describe('AgentTeamsIdentity — an identity with no install target', () => {
+  it('offers a way to name a target instead of a dead end', async () => {
+    renderWithIntl(<AgentTeamsIdentity slug="sales-bot" />);
+
+    // THE REGRESSION GUARD. Without the fix this panel renders a state badge,
+    // a chain and nothing operable — every assertion below fails on the very
+    // first one.
+    expect(await screen.findByTestId('teams-identity-target')).toBeInTheDocument();
+    expect(await screen.findByLabelText('Target ID')).toBeInTheDocument();
+  });
+
+  it('starts a run with the typed target and resends nothing else', async () => {
+    const user = userEvent.setup();
+    renderWithIntl(<AgentTeamsIdentity slug="sales-bot" />);
+
+    await user.type(await screen.findByLabelText('Target ID'), TEAM_ID);
+    await user.click(
+      screen.getByRole('button', { name: 'Start provisioning' }),
+    );
+
+    await waitFor(() => expect(mockProvision).toHaveBeenCalledTimes(1));
+    // Exactly the target, and nothing else. `bot_slug` and `display_name`
+    // survive a reset on purpose; the server ignores them on an existing row,
+    // so resending them could only ever introduce a difference.
+    expect(mockProvision).toHaveBeenCalledWith('sales-bot', { team_id: TEAM_ID });
+  });
+
+  it('starts a run with a target picked from the tenant list', async () => {
+    const user = userEvent.setup();
+    renderWithIntl(<AgentTeamsIdentity slug="sales-bot" />);
+
+    await user.click(await screen.findByRole('combobox', { name: /Team/i }));
+    await user.click(await screen.findByRole('option', { name: 'Acme Team' }));
+    await user.click(screen.getByRole('button', { name: 'Start provisioning' }));
+
+    await waitFor(() =>
+      expect(mockProvision).toHaveBeenCalledWith('sales-bot', { team_id: TEAM_ID }),
+    );
+  });
+
+  it('refuses to start on an input that is not an install target', async () => {
+    const user = userEvent.setup();
+    renderWithIntl(<AgentTeamsIdentity slug="sales-bot" />);
+
+    // A channel id: five provisioning steps used to run before Graph said no.
+    await user.type(
+      await screen.findByLabelText('Target ID'),
+      '19:abc123@thread.tacv2',
+    );
+
+    expect(
+      (
+        screen.getByRole('button', {
+          name: 'Start provisioning',
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+    expect(mockProvision).not.toHaveBeenCalled();
+  });
+
+  it('still offers the chooser after a run has FAILED without a target', async () => {
+    // The condition is "no target", not "was reset" — a terminal failure with
+    // a nulled target must be just as startable.
+    mockGet.mockResolvedValue(statusDto({}, { state: 'failed', running: false }));
+    renderWithIntl(<AgentTeamsIdentity slug="sales-bot" />);
+
+    expect(await screen.findByTestId('teams-identity-target')).toBeInTheDocument();
+    // And the affordance that cannot work is not offered alongside it.
+    expect(
+      screen.queryByRole('button', { name: 'Re-run provisioning' }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('AgentTeamsIdentity — an identity that HAS a target', () => {
+  it('keeps the re-run button and grows no second way to start', async () => {
+    mockGet.mockResolvedValue(
+      statusDto({ team_id: TEAM_ID }, { state: 'installed', running: false }),
+    );
+    renderWithIntl(<AgentTeamsIdentity slug="sales-bot" />);
+
+    const rerun = await screen.findByRole('button', { name: 'Re-run provisioning' });
+    expect((rerun as HTMLButtonElement).disabled).toBe(false);
+    expect(screen.queryByTestId('teams-identity-target')).not.toBeInTheDocument();
+  });
+
+  it('resends the recorded target verbatim', async () => {
+    const user = userEvent.setup();
+    mockGet.mockResolvedValue(
+      statusDto({ team_id: TEAM_ID }, { state: 'installed', running: false }),
+    );
+    renderWithIntl(<AgentTeamsIdentity slug="sales-bot" />);
+
+    await user.click(
+      await screen.findByRole('button', { name: 'Re-run provisioning' }),
+    );
+
+    await waitFor(() =>
+      expect(mockProvision).toHaveBeenCalledWith('sales-bot', { team_id: TEAM_ID }),
+    );
+  });
+
+  it('does not enumerate the tenant for an identity that needs no target', async () => {
+    mockGet.mockResolvedValue(
+      statusDto({ team_id: TEAM_ID }, { state: 'installed', running: false }),
+    );
+    renderWithIntl(<AgentTeamsIdentity slug="sales-bot" />);
+
+    await screen.findByRole('button', { name: 'Re-run provisioning' });
+    // The directory costs the connector Graph calls; a panel with nothing to
+    // pick has no business spending them.
+    expect(mockTargets).not.toHaveBeenCalled();
+  });
+});

--- a/web-ui/app/operator/agents/[slug]/__tests__/AgentTeamsIdentity.test.tsx
+++ b/web-ui/app/operator/agents/[slug]/__tests__/AgentTeamsIdentity.test.tsx
@@ -341,7 +341,13 @@ describe('AgentTeamsIdentity (#860 W2a)', () => {
     );
   });
 
-  it('does not offer a re-run that could only 400 — no recorded target, no button', async () => {
+  it('replaces the re-run with a target chooser when nothing is recorded', async () => {
+    // This used to render a DISABLED re-run button plus a sentence explaining
+    // why it could not work, which is how the reset dead end got shipped: a
+    // reset nulls `team_id`, so the panel's only two ways to start a run both
+    // vanished and the agent could only be deleted. A control that can never
+    // fire is not the right answer to "no target" — asking for one is.
+    // Fully covered in `AgentTeamsIdentity.restart.test.tsx`.
     mockGet.mockResolvedValue(
       statusDto({
         state: 'failed',
@@ -351,13 +357,10 @@ describe('AgentTeamsIdentity (#860 W2a)', () => {
     );
     renderWithIntl(<AgentTeamsIdentity slug="sales-bot" />);
 
-    const button = await screen.findByRole('button', {
-      name: 'Re-run provisioning',
-    });
-    expect(button).toHaveProperty('disabled', true);
+    expect(await screen.findByTestId('teams-identity-target')).toBeTruthy();
     expect(
-      screen.getByText(/No target team is recorded for this identity/),
-    ).toBeTruthy();
+      screen.queryByRole('button', { name: 'Re-run provisioning' }),
+    ).toBeNull();
   });
 
   it('hides the re-run button while a run is still in flight', async () => {

--- a/web-ui/app/operator/agents/[slug]/__tests__/TeamsTargetPicker.test.tsx
+++ b/web-ui/app/operator/agents/[slug]/__tests__/TeamsTargetPicker.test.tsx
@@ -58,21 +58,35 @@ function render(
   return { onSelect };
 }
 
+/** The list is a combobox popup now: it exists once the field has focus. */
+async function openTeams(): Promise<HTMLElement> {
+  const field = screen.getByRole('combobox', { name: /Team/i });
+  await userEvent.click(field);
+  return field;
+}
+
+async function openChats(): Promise<HTMLElement> {
+  const field = screen.getByRole('combobox', { name: /Chat/i });
+  await userEvent.click(field);
+  return field;
+}
+
 describe('TeamsTargetPicker — offering a choice', () => {
-  it('lists teams and chats with their names', () => {
+  it('lists teams and chats with their names', async () => {
     render(dto());
 
+    await openTeams();
     expect(screen.getByRole('option', { name: 'Acme Team' })).toBeInTheDocument();
+
+    await openChats();
     expect(screen.getByRole('option', { name: /Support/ })).toBeInTheDocument();
   });
 
   it('hands the picked id up verbatim', async () => {
     const { onSelect } = render(dto());
 
-    await userEvent.selectOptions(
-      screen.getByRole('combobox', { name: /Team/i }),
-      TEAM.id,
-    );
+    await openTeams();
+    await userEvent.click(screen.getByRole('option', { name: 'Acme Team' }));
 
     // Verbatim matters: the id goes into the same field the operator could
     // have typed into, and the live classification decides what it is. A
@@ -80,16 +94,20 @@ describe('TeamsTargetPicker — offering a choice', () => {
     expect(onSelect).toHaveBeenCalledWith(TEAM.id);
   });
 
-  it('shows no selection for an id that was typed rather than picked', () => {
+  it('shows no selection for an id that was typed rather than picked', async () => {
     render(dto(), vi.fn(), { value: 'something-hand-typed' });
 
-    // Never pin the first option: the select must not claim a choice the
+    // Never pin the first option: the control must not claim a choice the
     // operator did not make.
-    const select = screen.getByRole('combobox', { name: /Team/i });
-    expect((select as HTMLSelectElement).value).toBe('');
+    const field = await openTeams();
+    expect((field as HTMLInputElement).value).toBe('');
+    expect(screen.getByRole('option', { name: 'Acme Team' })).toHaveAttribute(
+      'aria-selected',
+      'false',
+    );
   });
 
-  it('labels a nameless chat by its members rather than dropping it', () => {
+  it('labels a nameless chat by its members rather than dropping it', async () => {
     render(
       dto({
         chats: {
@@ -99,7 +117,99 @@ describe('TeamsTargetPicker — offering a choice', () => {
       }),
     );
 
+    await openChats();
     expect(screen.getByRole('option', { name: /Ada, Grace/ })).toBeInTheDocument();
+  });
+});
+
+/**
+ * SEARCH. Thirty teams in one tenant is an alphabetical wall, and a chat with
+ * no topic is a `19:…` stem — the part an operator cannot read is exactly the
+ * part they have to scroll past. What is pinned here is WHAT the query is
+ * allowed to match (the things a human sees, plus the id) and that a miss is
+ * an answer rather than an empty list.
+ */
+describe('TeamsTargetPicker — finding one among many', () => {
+  const MANY = Array.from({ length: 30 }, (_, i) => ({
+    id: `2f1a9c44-1f0e-4f2c-8f1a-9c441f0e4f${String(i).padStart(2, '0')}`,
+    displayName: `Team ${String(i).padStart(2, '0')}`,
+  }));
+
+  it('narrows a long list to what was typed', async () => {
+    render(dto({ teams: { available: true, items: MANY } }));
+
+    const field = await openTeams();
+    expect(screen.getAllByRole('option')).toHaveLength(30);
+
+    await userEvent.type(field, 'Team 17');
+    const remaining = screen.getAllByRole('option');
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]).toHaveTextContent('Team 17');
+  });
+
+  it('finds a chat by a member name the row does not show', async () => {
+    // The topic wins the label, so "Grace" is nowhere on screen — and is
+    // still how somebody looks for that chat.
+    render(
+      dto({
+        chats: {
+          available: true,
+          items: [{ ...CHAT, topic: 'Support', memberNames: ['Ada', 'Grace'] }],
+        },
+      }),
+    );
+
+    const field = await openChats();
+    await userEvent.type(field, 'grace');
+
+    expect(screen.getByRole('option', { name: /Support/ })).toBeInTheDocument();
+  });
+
+  it('matches a pasted id, so it does not look unknown', async () => {
+    render(dto());
+
+    const field = await openTeams();
+    await userEvent.type(field, TEAM.id);
+
+    expect(screen.getByRole('option', { name: 'Acme Team' })).toBeInTheDocument();
+  });
+
+  it('answers a miss with a sentence instead of an empty list', async () => {
+    render(dto());
+
+    const field = await openTeams();
+    await userEvent.type(field, 'zzzz');
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    // "Nothing matched" and "this tenant has no teams" are different
+    // statements and must not share a rendering.
+    expect(await screen.findByRole('status')).toHaveTextContent(/zzzz/);
+  });
+
+  it('is operable from the keyboard alone', async () => {
+    const { onSelect } = render(dto({ teams: { available: true, items: MANY } }));
+
+    const field = screen.getByRole('combobox', { name: /Team/i });
+    await userEvent.click(field);
+    await userEvent.type(field, 'Team 03');
+    await userEvent.keyboard('{ArrowDown}{Enter}');
+
+    expect(onSelect).toHaveBeenCalledWith(MANY[3]?.id);
+  });
+
+  it('closes on Escape, then clears the query on a second Escape', async () => {
+    render(dto());
+
+    const field = await openTeams();
+    await userEvent.type(field, 'Acme');
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+    await userEvent.keyboard('{Escape}');
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    expect((field as HTMLInputElement).value).toBe('Acme');
+
+    await userEvent.keyboard('{Escape}');
+    expect((field as HTMLInputElement).value).toBe('');
   });
 });
 
@@ -125,6 +235,7 @@ describe('TeamsTargetPicker — degrading without lying', () => {
       dto({ chats: { available: false, reason: 'scope_missing' } }),
     );
 
+    await openTeams();
     expect(screen.getByRole('option', { name: 'Acme Team' })).toBeInTheDocument();
     const notes = await screen.findAllByRole('note');
     expect(notes).toHaveLength(1);

--- a/web-ui/app/operator/agents/[slug]/_components/AgentTeamsIdentity.tsx
+++ b/web-ui/app/operator/agents/[slug]/_components/AgentTeamsIdentity.tsx
@@ -22,6 +22,7 @@ import {
   parseTeamsIdentityEnvelope,
 } from '../../../../_lib/teamsIdentity';
 import { AgentTeamsProvisioningTimeline } from './AgentTeamsProvisioningTimeline';
+import { AgentTeamsIdentityTarget } from './AgentTeamsIdentityTarget';
 import { humanizeApiError } from '../../_components/AgentsDashboard';
 import {
   Fact,
@@ -306,11 +307,13 @@ export function AgentTeamsIdentity(
           onReloaded={() => void load()}
           // The server has no "as recorded" re-run: `ensureForAgent` refreshes
           // the stored team from the request and the route hands `team_id`
-          // straight to the runner, so an empty body is a guaranteed 400. The
-          // recorded target comes back on the status projection and is
-          // resent verbatim; without one the affordance is disabled instead
-          // of offered and rejected.
-          onRerun={(recordedTeamId) => void provision({ team_id: recordedTeamId })}
+          // straight to the runner, so an empty body is a guaranteed 400.
+          // Every run therefore names its target — the recorded one when there
+          // is one, otherwise the one the operator just picked. Deliberately
+          // WITHOUT `bot_slug` / `display_name`: they survive a reset and the
+          // server ignores them on an existing row, so resending them could
+          // only ever introduce a difference nobody asked for.
+          onStartRun={(targetTeamId) => void provision({ team_id: targetTeamId })}
           formatDate={(iso) => formatTimestamp(iso, format)}
         />
       )}
@@ -321,7 +324,7 @@ export function AgentTeamsIdentity(
 function ReadyPanel(props: {
   readonly status: TeamsIdentityStatusDto;
   readonly busy: boolean;
-  readonly onRerun: (teamId: string) => void;
+  readonly onStartRun: (teamId: string) => void;
   readonly formatDate: (iso: string) => string;
   readonly slug: string;
   readonly onReloaded: () => void;
@@ -345,6 +348,14 @@ function ReadyPanel(props: {
   );
   // A re-run must resend the install target the server already recorded —
   // it requires `team_id` on every POST.
+  //
+  // `null` here is the whole of the restart bug: a reset nulls the column, and
+  // with no target there is nothing to resend, so the re-run affordance is not
+  // merely disabled — it is the wrong affordance. What that state needs is a
+  // way to NAME a target, which is {@link AgentTeamsIdentityTarget} below.
+  // Keyed on "there is no target", never on "this row was reset": nothing in
+  // this projection can see a reset, and a row can reach the same shape by
+  // other routes.
   const recordedTeamId =
     status.identity.team_id !== null && status.identity.team_id !== ''
       ? status.identity.team_id
@@ -359,30 +370,41 @@ function ReadyPanel(props: {
             ? t('teamsIdentity.running')
             : t('teamsIdentity.idle')}
         </span>
-        {isTerminalTeamsProvisioningState(status.state) && (
-          <div className="ml-auto flex flex-wrap items-center gap-2">
-            {recordedTeamId === null && (
-              <span className="text-[11px] text-[color:var(--fg-muted)]">
-                {t('teamsIdentity.rerunNeedsTeam')}
-              </span>
-            )}
-            <Button
-              size="sm"
-              variant="secondary"
-              busy={props.busy}
-              disabled={recordedTeamId === null}
-              busyLabel={t('teamsIdentity.submitBusy')}
-              onClick={() => {
-                if (recordedTeamId !== null) props.onRerun(recordedTeamId);
-              }}
-            >
-              {t('teamsIdentity.rerun')}
-            </Button>
-          </div>
-        )}
+        {/* Only with a recorded target: without one this button could never
+            do anything, and the target form below is the affordance that
+            state actually needs. */}
+        {isTerminalTeamsProvisioningState(status.state) &&
+          recordedTeamId !== null && (
+            <div className="ml-auto flex flex-wrap items-center gap-2">
+              <Button
+                size="sm"
+                variant="secondary"
+                busy={props.busy}
+                busyLabel={t('teamsIdentity.submitBusy')}
+                onClick={() => props.onStartRun(recordedTeamId)}
+              >
+                {t('teamsIdentity.rerun')}
+              </Button>
+            </div>
+          )}
       </div>
 
       <StateChain state={status.state} />
+
+      {/* THE WAY BACK IN. An identity with no target cannot start a run at
+          all — not from the create form (which renders only when no row
+          exists) and not from "provision again" (which has nothing to
+          resend). Placed directly under the chain because it is the operator's
+          next move, and the chain is where they just read that nothing is
+          happening. */}
+      {recordedTeamId === null && (
+        <AgentTeamsIdentityTarget
+          slug={props.slug}
+          busy={props.busy}
+          running={status.running}
+          onStart={props.onStartRun}
+        />
+      )}
 
       {/* #915 — the chain above says WHERE the run is; this says what it has
           been doing, which is where the minutes actually go. Placed directly

--- a/web-ui/app/operator/agents/[slug]/_components/AgentTeamsIdentityTarget.tsx
+++ b/web-ui/app/operator/agents/[slug]/_components/AgentTeamsIdentityTarget.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+import { Button } from '@/app/_components/ui/Button';
+import { isSubmittableTarget, classifyTeamsInstallTarget } from '@/app/_lib/teamsInstallTarget';
+import {
+  getAgentTeamsTargets,
+  type AgentTeamsTargetsDto,
+} from '@/app/_lib/agents';
+import { TeamsTargetField } from './TeamsTargetField';
+
+/**
+ * The way back into a run for an identity that HAS no install target.
+ *
+ * THE DEAD END THIS REMOVES. A reset returns the row to `pending` and nulls
+ * `team_id` — deliberately, because the team the operator was aiming at is no
+ * longer a commitment once the app registration, the bot and the catalogue
+ * entry have been torn down. But the panel had exactly two ways to start a
+ * run and neither survived that: the create form renders only when NO identity
+ * row exists, and "provision again" is disabled without a recorded target
+ * (the POST requires `team_id` and the server has no re-run-as-recorded path).
+ * So a reset produced a panel reading "PENDING", every field empty, and not
+ * one control that could start anything. The only remaining move was deleting
+ * the agent.
+ *
+ * THE CONDITION IS "NO TARGET", NOT "WAS RESET". Nothing here can observe a
+ * reset, and it must not try: a row can reach the same shape by other routes —
+ * an identity created before `team_id` existed, a partial write, a future
+ * re-target flow that clears the field first. The state is what is renderable,
+ * so the state is what this is keyed on.
+ *
+ * `bot_slug` AND `display_name` ARE NOT ASKED AGAIN. They survive a reset on
+ * purpose — they are the only two fields a human typed — and re-asking would
+ * turn a retry into a fresh form, invite a slug change nobody wanted, and
+ * contradict the reset panel's own promise that they are kept. Only the target
+ * is missing, so only the target is asked for.
+ */
+
+export interface AgentTeamsIdentityTargetProps {
+  readonly slug: string;
+  /** A provisioning POST is in flight from the parent panel. */
+  readonly busy: boolean;
+  /** The runner is holding a run for this agent. Starting a second one is
+   *  refused server-side, so the control says so instead of inviting a 409. */
+  readonly running: boolean;
+  readonly onStart: (teamId: string) => void;
+}
+
+export function AgentTeamsIdentityTarget({
+  slug,
+  busy,
+  running,
+  onStart,
+}: AgentTeamsIdentityTargetProps): React.JSX.Element {
+  const t = useTranslations('operatorAgents.teamsIdentity');
+  const [teamId, setTeamId] = useState('');
+  const [targets, setTargets] = useState<AgentTeamsTargetsDto | null>(null);
+  const [targetsLoading, setTargetsLoading] = useState(true);
+
+  // Loaded once per agent, mirroring `AgentTeamsInstalls`: a tenant's teams
+  // and chats do not change while somebody fills in a form, and this panel
+  // polls every three seconds — re-enumerating on each poll would spend the
+  // connector's Graph budget on a list nobody is looking at any more.
+  useEffect(() => {
+    let cancelled = false;
+    setTargetsLoading(true);
+    void getAgentTeamsTargets(slug)
+      .then((dto) => {
+        if (!cancelled) setTargets(dto);
+      })
+      .catch(() => {
+        // Swallowed on purpose: the text field works without a directory, and
+        // an error banner for a failed convenience would read as though the
+        // restart itself were broken — which is the very thing being fixed.
+        if (!cancelled) setTargets(null);
+      })
+      .finally(() => {
+        if (!cancelled) setTargetsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [slug]);
+
+  const submittable = isSubmittableTarget(classifyTeamsInstallTarget(teamId));
+  const locked = busy || running;
+
+  return (
+    <div
+      data-testid="teams-identity-target"
+      className="flex flex-col gap-2 rounded border border-[color:var(--border)] p-3"
+    >
+      <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[color:var(--fg-muted)]">
+        {t('retarget.heading')}
+      </div>
+      <p className="text-xs text-[color:var(--fg-muted)]">
+        {running ? t('retarget.runningHint') : t('retarget.hint')}
+      </p>
+
+      <TeamsTargetField
+        targets={targets}
+        targetsLoading={targetsLoading}
+        value={teamId}
+        onChange={setTeamId}
+        disabled={locked}
+      />
+
+      <div>
+        <Button
+          size="sm"
+          busy={busy}
+          disabled={locked || !submittable}
+          busyLabel={t('submitBusy')}
+          onClick={() => onStart(teamId.trim())}
+        >
+          {t('submit')}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web-ui/app/operator/agents/[slug]/_components/AgentTeamsInstalls.tsx
+++ b/web-ui/app/operator/agents/[slug]/_components/AgentTeamsInstalls.tsx
@@ -10,7 +10,6 @@ import { ConfirmDialog } from '@/app/_components/ConfirmDialog';
 import {
   classifyTeamsInstallTarget,
   isSubmittableTarget,
-  TEAMS_TARGET_EXAMPLES,
 } from '../../../../_lib/teamsInstallTarget';
 import {
   getAgentTeams,
@@ -26,7 +25,7 @@ import {
   getAgentTeamsTargets,
   type AgentTeamsTargetsDto,
 } from '../../../../_lib/agents';
-import { TeamsTargetPicker } from './TeamsTargetPicker';
+import { TeamsTargetField } from './TeamsTargetField';
 import { ApiError } from '../../../../_lib/api';
 
 /**
@@ -476,86 +475,16 @@ export function AgentTeamsInstalls({
             <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[color:var(--fg-muted)]">
               {t('installHeading')}
             </div>
-            {/* PICK first, TYPE second — and both write the same state, so the
-                live classification below stays the single verdict. */}
-            <TeamsTargetPicker
+            {/* Pick or type, plus the live verdict — shared verbatim with the
+                Teams identity panel, which asks the same question when a
+                target-less identity needs one before a run can start. */}
+            <TeamsTargetField
               targets={targets}
-              loading={targetsLoading}
-              disabled={!canInstall || inFlight}
+              targetsLoading={targetsLoading}
               value={teamId}
-              onSelect={setTeamId}
+              onChange={setTeamId}
+              disabled={!canInstall || inFlight}
             />
-
-            <label className="flex flex-col gap-1 text-[11px] text-[color:var(--fg-muted)]">
-              {t('fieldTarget')}
-              <input
-                type="text"
-                value={teamId}
-                disabled={!canInstall || inFlight}
-                onChange={(e) => setTeamId(e.target.value)}
-                aria-label={t('fieldTarget')}
-                className="rounded-md border border-[color:var(--border)] bg-transparent px-2 py-1 font-mono text-sm text-[color:var(--fg-strong)]"
-              />
-              <span>{t('fieldTargetHint')}</span>
-              {/* Shown BEFORE anything is submitted: what a good answer looks
-                  like beats only being told the last one was wrong. */}
-              <span className="font-mono text-[10px] opacity-70">
-                {t('targetExamples', {
-                  team: TEAMS_TARGET_EXAMPLES.team,
-                  groupChat: TEAMS_TARGET_EXAMPLES.groupChat,
-                })}
-              </span>
-            </label>
-
-            {/* The verdict. A recognised target is named — "Team" or
-                "Gruppenchat" — so the operator can see the field understood
-                them; the three that cannot be installed each say what to do. */}
-            {targetSubmittable ? (
-              <div className="text-[11px] text-[color:var(--success)]">
-                {t('targetKindLabel', {
-                  kind: t(`targetKind.${target.kind}`),
-                })}
-              </div>
-            ) : null}
-            {target.kind === 'channel' ? (
-              <div role="alert" className="text-[11px] text-[color:var(--danger)]">
-                {t('targetChannel')}
-              </div>
-            ) : null}
-            {target.kind === 'unrecognised' ? (
-              <div role="alert" className="text-[11px] text-[color:var(--danger)]">
-                {t('targetUnrecognised')}
-              </div>
-            ) : null}
-            {/* THE FIELD-TEST CASE. 32 hex digits are both a team id without
-                its dashes and the stem of a group-chat id. Nothing is guessed:
-                the operator is handed the two spellings and picks one, which
-                is the only place the missing context actually exists. */}
-            {target.kind === 'ambiguous' ? (
-              <div className="flex flex-col gap-1.5 rounded-md border border-[color:var(--border)] px-3 py-2">
-                <span role="alert" className="text-[11px] text-[color:var(--fg-muted)]">
-                  {t('targetAmbiguous')}
-                </span>
-                <div className="flex flex-wrap items-center gap-2">
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    disabled={inFlight}
-                    onClick={() => setTeamId(target.asTeamId)}
-                  >
-                    {t('targetAmbiguousUseTeam')}
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    disabled={inFlight}
-                    onClick={() => setTeamId(target.asGroupChatId)}
-                  >
-                    {t('targetAmbiguousUseChat')}
-                  </Button>
-                </div>
-              </div>
-            ) : null}
             <div className="flex flex-wrap items-center gap-2">
               <Button
                 size="sm"

--- a/web-ui/app/operator/agents/[slug]/_components/TeamsTargetField.tsx
+++ b/web-ui/app/operator/agents/[slug]/_components/TeamsTargetField.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import { Button } from '@/app/_components/ui/Button';
+import {
+  classifyTeamsInstallTarget,
+  TEAMS_TARGET_EXAMPLES,
+} from '@/app/_lib/teamsInstallTarget';
+import type { AgentTeamsTargetsDto } from '@/app/_lib/agents';
+import { TeamsTargetPicker } from './TeamsTargetPicker';
+
+/**
+ * "Which team or chat?", as one control — pick from the tenant, or type.
+ *
+ * ONE COMPONENT, TWO CALLERS, because the question is literally the same one
+ * in both places: {@link AgentTeamsInstalls} asks it to add an install, and
+ * the Teams identity panel asks it to give a target-less identity a target so
+ * a run can start at all (the state a reset leaves behind). The copy, the
+ * classification and the two ambiguity escapes have to agree between them —
+ * an operator told "19:… is a channel id, not an install target" on one panel
+ * and allowed to submit it on the other would be reading a bug.
+ *
+ * IT READS `operatorAgents.teamsInstalls` FOR THE TARGET COPY on purpose. That
+ * namespace is where these sentences were written and where they belong: they
+ * describe Teams install targets, not the panel that happens to render them.
+ * Copying them into a second namespace would be two places to correct the day
+ * Microsoft changes an id shape — the exact failure the sentences warn about.
+ *
+ * THE CLASSIFICATION IS GUIDANCE, NEVER AUTHORITY. The server re-decides on
+ * every POST. What this buys is the five provisioning steps that used to run
+ * before Graph answered `404 No team found with Group Id`: the verdict now
+ * appears under the field while the operator is still typing.
+ */
+
+export interface TeamsTargetFieldProps {
+  /** `null` covers BOTH "still loading" and "the directory failed" — see
+   *  {@link TeamsTargetPicker}; either way the text field carries the load. */
+  readonly targets: AgentTeamsTargetsDto | null;
+  readonly targetsLoading: boolean;
+  readonly value: string;
+  readonly onChange: (value: string) => void;
+  readonly disabled: boolean;
+}
+
+export function TeamsTargetField({
+  targets,
+  targetsLoading,
+  value,
+  onChange,
+  disabled,
+}: TeamsTargetFieldProps): React.JSX.Element {
+  const t = useTranslations('operatorAgents.teamsInstalls');
+  const target = classifyTeamsInstallTarget(value);
+
+  return (
+    <>
+      {/* PICK first, TYPE second — and both write the same state, so the
+          live classification below stays the single verdict. */}
+      <TeamsTargetPicker
+        targets={targets}
+        loading={targetsLoading}
+        disabled={disabled}
+        value={value}
+        onSelect={onChange}
+      />
+
+      <label className="flex flex-col gap-1 text-[11px] text-[color:var(--fg-muted)]">
+        {t('fieldTarget')}
+        <input
+          type="text"
+          value={value}
+          disabled={disabled}
+          onChange={(e) => onChange(e.target.value)}
+          aria-label={t('fieldTarget')}
+          className="rounded-md border border-[color:var(--border)] bg-transparent px-2 py-1 font-mono text-sm text-[color:var(--fg-strong)]"
+        />
+        <span>{t('fieldTargetHint')}</span>
+        {/* Shown BEFORE anything is submitted: what a good answer looks
+            like beats only being told the last one was wrong. */}
+        <span className="font-mono text-[10px] opacity-70">
+          {t('targetExamples', {
+            team: TEAMS_TARGET_EXAMPLES.team,
+            groupChat: TEAMS_TARGET_EXAMPLES.groupChat,
+          })}
+        </span>
+      </label>
+
+      {/* The verdict. A recognised target is named — "Team" or
+          "Gruppenchat" — so the operator can see the field understood
+          them; the three that cannot be installed each say what to do. */}
+      {target.kind === 'team' ||
+      target.kind === 'group-chat' ||
+      target.kind === 'one-on-one-chat' ? (
+        <div className="text-[11px] text-[color:var(--success)]">
+          {t('targetKindLabel', { kind: t(`targetKind.${target.kind}`) })}
+        </div>
+      ) : null}
+      {target.kind === 'channel' ? (
+        <div role="alert" className="text-[11px] text-[color:var(--danger)]">
+          {t('targetChannel')}
+        </div>
+      ) : null}
+      {target.kind === 'unrecognised' ? (
+        <div role="alert" className="text-[11px] text-[color:var(--danger)]">
+          {t('targetUnrecognised')}
+        </div>
+      ) : null}
+      {/* THE FIELD-TEST CASE. 32 hex digits are both a team id without
+          its dashes and the stem of a group-chat id. Nothing is guessed:
+          the operator is handed the two spellings and picks one, which
+          is the only place the missing context actually exists. */}
+      {target.kind === 'ambiguous' ? (
+        <div className="flex flex-col gap-1.5 rounded-md border border-[color:var(--border)] px-3 py-2">
+          <span role="alert" className="text-[11px] text-[color:var(--fg-muted)]">
+            {t('targetAmbiguous')}
+          </span>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              size="sm"
+              variant="ghost"
+              disabled={disabled}
+              onClick={() => onChange(target.asTeamId)}
+            >
+              {t('targetAmbiguousUseTeam')}
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              disabled={disabled}
+              onClick={() => onChange(target.asGroupChatId)}
+            >
+              {t('targetAmbiguousUseChat')}
+            </Button>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/web-ui/app/operator/agents/[slug]/_components/TeamsTargetPicker.tsx
+++ b/web-ui/app/operator/agents/[slug]/_components/TeamsTargetPicker.tsx
@@ -2,6 +2,10 @@
 
 import { useTranslations } from 'next-intl';
 
+import {
+  SearchableSelect,
+  type SearchableOption,
+} from '@/app/_components/ui/SearchableSelect';
 import type {
   AgentTeamsTargetsDto,
   TeamsChatOptionDto,
@@ -29,6 +33,15 @@ import type {
  * below it keeps running and keeps being the thing that decides. One code
  * path, one verdict — and the free-text field stays usable for the cases a
  * list cannot cover.
+ *
+ * EACH HALF IS SEARCHABLE, not a plain dropdown. The byte5 tenant alone
+ * publishes thirty teams, and a chat with no topic renders as a `19:…` stem,
+ * so an alphabetical list is a wall an operator scrolls rather than reads.
+ * {@link SearchableSelect} carries the keyboard and screen-reader contract a
+ * `<select>` used to provide for free; what is decided HERE is what the query
+ * is allowed to match. It matches what a human SEES — a team's name, a chat's
+ * topic — plus the member names that identify a topicless chat and the id
+ * itself, so a pasted id lights up its own row instead of looking unknown.
  *
  * ─────────────────────────────────────────────────────────────────────────
  * DEGRADATION IS THE INTERESTING HALF
@@ -98,11 +111,13 @@ export function TeamsTargetPicker({
       <TargetSelect
         label={t('teamsLabel')}
         emptyLabel={t('teamsEmpty')}
-        placeholder={t('choose')}
+        placeholder={t('filter')}
         listing={teams}
         disabled={disabled}
         value={value}
         onSelect={onSelect}
+        noMatchText={(query) => t('noMatch', { query })}
+        matchCountText={(count) => t('matchCount', { count })}
         optionsOf={(items: readonly TeamsTeamOptionDto[]) =>
           items.map((team) => ({ id: team.id, label: team.displayName }))
         }
@@ -113,17 +128,26 @@ export function TeamsTargetPicker({
       <TargetSelect
         label={t('chatsLabel')}
         emptyLabel={t('chatsEmpty')}
-        placeholder={t('choose')}
+        placeholder={t('filter')}
         listing={chats}
         disabled={disabled}
         value={value}
         onSelect={onSelect}
+        noMatchText={(query) => t('noMatch', { query })}
+        matchCountText={(count) => t('matchCount', { count })}
         optionsOf={(items: readonly TeamsChatOptionDto[]) =>
           items.map((chat) => ({
             id: chat.id,
             label: `${chatLabel(chat, (names) => names.join(', '))} · ${t(
               `chatType.${chat.chatType}`,
             )}`,
+            // Searchable but not repeated in the row: for a chat with no
+            // topic the members ARE the name, and the label already falls
+            // back to them — for one that HAS a topic they are still how an
+            // operator looks for it.
+            ...(chat.memberNames !== undefined && chat.memberNames.length > 0
+              ? { keywords: chat.memberNames }
+              : {}),
           }))
         }
         unavailableText={(reason) =>
@@ -142,21 +166,22 @@ interface TargetSelectProps<T> {
   readonly disabled: boolean;
   readonly value: string;
   readonly onSelect: (id: string) => void;
-  readonly optionsOf: (items: readonly T[]) => readonly {
-    id: string;
-    label: string;
-  }[];
+  readonly optionsOf: (items: readonly T[]) => readonly SearchableOption[];
   readonly unavailableText: (reason: string) => string;
+  readonly noMatchText: (query: string) => string;
+  readonly matchCountText: (count: number) => string;
 }
 
 /**
  * One half of the picker.
  *
- * THREE STATES, KEPT APART ON PURPOSE: a usable list, a tenant that genuinely
+ * FOUR STATES, KEPT APART ON PURPOSE: a usable list, a tenant that genuinely
  * has none (`available` with no items — an explicit sentence, still no empty
- * dropdown), and a listing that could not be produced (one sentence naming
- * the reason). Collapsing the last two is the bug this whole shape exists to
- * prevent.
+ * dropdown), a listing that could not be produced (one sentence naming the
+ * reason), and — inside {@link SearchableSelect} — a query that matched none
+ * of a list that does exist. Collapsing any two of them is the bug this whole
+ * shape exists to prevent: "I have nothing", "I could not look" and "nothing
+ * you typed matches" are three different instructions to the operator.
  */
 function TargetSelect<T>({
   label,
@@ -168,6 +193,8 @@ function TargetSelect<T>({
   onSelect,
   optionsOf,
   unavailableText,
+  noMatchText,
+  matchCountText,
 }: TargetSelectProps<T>): React.JSX.Element {
   if (!listing.available) {
     return (
@@ -186,30 +213,19 @@ function TargetSelect<T>({
       <p className="text-[11px] text-[color:var(--fg-muted)]">{emptyLabel}</p>
     );
   }
-  // `value` is the text field's content, which may be a hand-typed id that is
-  // in neither list. Falling back to '' then shows the placeholder rather than
-  // silently pinning the first option — the select must never claim a choice
-  // the operator did not make.
-  const selected = options.some((option) => option.id === value) ? value : '';
+  // `value` is passed through untouched, hand-typed ids included: the control
+  // marks a matching row as selected and otherwise marks none. It must never
+  // claim a choice the operator did not make.
   return (
-    <label className="flex flex-col gap-1 text-[11px] text-[color:var(--fg-muted)]">
-      {label}
-      <select
-        value={selected}
-        disabled={disabled}
-        aria-label={label}
-        onChange={(e) => {
-          if (e.target.value !== '') onSelect(e.target.value);
-        }}
-        className="rounded-md border border-[color:var(--border)] bg-transparent px-2 py-1 text-sm text-[color:var(--fg-strong)]"
-      >
-        <option value="">{placeholder}</option>
-        {options.map((option) => (
-          <option key={option.id} value={option.id}>
-            {option.label}
-          </option>
-        ))}
-      </select>
-    </label>
+    <SearchableSelect
+      label={label}
+      placeholder={placeholder}
+      options={options}
+      value={value}
+      disabled={disabled}
+      onSelect={onSelect}
+      noMatchText={noMatchText}
+      matchCountText={matchCountText}
+    />
   );
 }

--- a/web-ui/app/operator/teams/__tests__/TeamsTenantSignIn.test.tsx
+++ b/web-ui/app/operator/teams/__tests__/TeamsTenantSignIn.test.tsx
@@ -220,15 +220,36 @@ describe('TeamsTenantSignIn — terminal verdicts', () => {
 });
 
 describe('TeamsTenantSignIn — signed in', () => {
-  it('shows who, since when, and until when', async () => {
+  it('shows who and since when, and leads with the durable truth', async () => {
     mockStatus.mockResolvedValue(signedOut({ signIn: signedIn() }));
     renderWithIntl(<TeamsTenantSignIn />, { locale: 'de' });
 
     const panel = await screen.findByTestId('teams-signed-in');
     expect(panel.textContent).toMatch(/Ada Admin/);
     expect(panel.textContent).toMatch(/Angemeldet seit/);
-    expect(panel.textContent).toMatch(/Zugriffstoken läuft ab/);
     expect(screen.getByRole('button', { name: /Abmelden/i })).toBeTruthy();
+
+    // THE HEADLINE, and the reason it is one: the panel used to put the
+    // access token's expiry beside "signed in since", and operators read the
+    // pair as a one-hour session. It is not — Microsoft fixes that lifetime
+    // and the refresh token behind it lasts weeks.
+    const headline = await screen.findByTestId('teams-sign-in-self-renewing');
+    expect(headline.textContent).toMatch(/erneuert sich selbst/i);
+  });
+
+  it('keeps the access-token expiry as a technical detail, not a countdown', async () => {
+    mockStatus.mockResolvedValue(signedOut({ signIn: signedIn() }));
+    renderWithIntl(<TeamsTenantSignIn />, { locale: 'de' });
+
+    const panel = await screen.findByTestId('teams-signed-in');
+    // Still available — it is genuinely useful in a support conversation.
+    expect(panel.textContent).toMatch(/Aktuelles Zugriffstoken gültig bis/);
+    // But behind a disclosure, and next to the sentence that says the number
+    // means nothing for the sign-in.
+    const details = panel.querySelector('details');
+    expect(details).not.toBeNull();
+    expect(details?.textContent).toMatch(/Aktuelles Zugriffstoken gültig bis/);
+    expect(details?.textContent).toMatch(/gibt Microsoft vor/);
   });
 
   it('a stale access token is a neutral note, never an alert', async () => {

--- a/web-ui/app/operator/teams/_components/TeamsTenantSignIn.tsx
+++ b/web-ui/app/operator/teams/_components/TeamsTenantSignIn.tsx
@@ -40,10 +40,16 @@ import {
  *   admin whose sign-in page demands consent first and who has not been given
  *   that URL is simply stuck.
  *
- *   SIGNED IN — who, since when, until when, and sign out. `accessTokenStale`
- *   is rendered as a neutral note: the refresh token outlives the access token
- *   and the next upload refreshes silently, so showing it in red would send an
- *   operator to fix something that fixes itself.
+ *   SIGNED IN — who, since when, and sign out, led by the sentence that
+ *   actually answers the operator's question: the sign-in persists and renews
+ *   itself. The access token's expiry is NOT among the facts. It used to be,
+ *   and it taught operators the opposite of the truth — "signed in since
+ *   08:06 / access token expires 09:06" reads as a one-hour session. Microsoft
+ *   fixes that lifetime at roughly 60–90 minutes with no way to configure it,
+ *   while the refresh token behind it lasts weeks to months; so the number is
+ *   a technical detail behind a disclosure, next to the sentence that says so.
+ *   `accessTokenStale` lives there too, as a neutral note: an expired access
+ *   token is a non-event the runner clears before its next call.
  *
  * `declined` IS NEVER RENDERED AS "THE ADMIN CANCELLED". Microsoft returns it
  * for Conditional Access blocks and device-compliance failures just as readily.
@@ -335,20 +341,27 @@ export function TeamsTenantSignIn(): React.ReactElement {
               </Button>
             </div>
           </div>
+          {/* THE HEADLINE, and the reason it is one. An access-token expiry
+              rendered as a fact beside "signed in since" reads as a countdown
+              on the SIGN-IN, and operators drew exactly that conclusion:
+              "the sign-in only lasts an hour". It does not. Microsoft fixes
+              the access token's lifetime at roughly 60–90 minutes and it is
+              not configurable (the token-lifetime policy that once governed it
+              was withdrawn for access tokens); the refresh token behind it
+              lasts weeks to months and the runner renews silently. So the
+              first thing said here is the durable truth, and the number that
+              caused the misreading moves behind a disclosure. */}
+          <p
+            data-testid="teams-sign-in-self-renewing"
+            className="text-sm text-[color:var(--fg-muted)]"
+          >
+            {t('signedIn.selfRenewing')}
+          </p>
           <dl className="grid gap-x-4 gap-y-1 text-xs sm:grid-cols-2">
             {signIn.signedInAt && (
               <Fact
                 label={t('signedIn.since')}
                 value={format.dateTime(new Date(signIn.signedInAt), {
-                  dateStyle: 'medium',
-                  timeStyle: 'short',
-                })}
-              />
-            )}
-            {signIn.expiresAt && (
-              <Fact
-                label={t('signedIn.tokenExpires')}
-                value={format.dateTime(new Date(signIn.expiresAt), {
                   dateStyle: 'medium',
                   timeStyle: 'short',
                 })}
@@ -364,17 +377,38 @@ export function TeamsTenantSignIn(): React.ReactElement {
               />
             )}
           </dl>
-          {/* Deliberately NOT an alert: the refresh token outlives the access
-              token, so this fixes itself on the next upload. */}
-          {signIn.accessTokenStale && (
-            <p
-              role="status"
-              data-testid="teams-token-stale"
-              className="text-xs text-[color:var(--fg-muted)]"
-            >
-              {t('signedIn.staleNote')}
-            </p>
-          )}
+          {/* Second rank, on purpose. Everything in here is true and
+              occasionally useful in a support conversation; none of it is
+              something an operator has to act on. */}
+          <details className="text-xs text-[color:var(--fg-muted)]">
+            <summary className="cursor-pointer">
+              {t('signedIn.technicalHeading')}
+            </summary>
+            <div className="mt-2 space-y-1">
+              {signIn.expiresAt && (
+                <dl className="grid gap-x-4 gap-y-1 sm:grid-cols-2">
+                  <Fact
+                    label={t('signedIn.tokenExpires')}
+                    value={format.dateTime(new Date(signIn.expiresAt), {
+                      dateStyle: 'medium',
+                      timeStyle: 'short',
+                    })}
+                  />
+                </dl>
+              )}
+              <p>{t('signedIn.tokenExpiresHint')}</p>
+              {/* Deliberately NOT an alert, and deliberately in here: a
+                  refresh token outlives the access token, so an expired
+                  access token is a non-event the runner clears on its own.
+                  Rendering it where an operator scans for problems would
+                  send them to fix something that fixes itself. */}
+              {signIn.accessTokenStale && (
+                <p role="status" data-testid="teams-token-stale">
+                  {t('signedIn.staleNote')}
+                </p>
+              )}
+            </div>
+          </details>
         </div>
       )}
 

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -2306,11 +2306,15 @@
           "unknown": "Ob diese Konfiguration bereits übernommen wurde, lässt sich gerade nicht feststellen. Vergleiche sie mit dem Teams-Channel-Plugin und füge den Block unten ein, falls er fehlt."
         }
       },
-      "rerunNeedsTeam": "Für diese Identität ist kein Ziel-Team hinterlegt, deshalb lässt sich das Provisioning hier nicht erneut starten.",
       "package": {
         "heading": "App-Paket herunterladen",
         "hint": "Das Provisioning lädt dieses Paket selbst in den Tenant-Katalog — ein manueller Upload pro Agent ist nicht nötig. Der Download bleibt als Rückfallebene: für Tenants, in denen programmatische Katalog-Uploads nicht erlaubt sind, oder wenn du das Manifest vorher ansehen willst. Es wird bei jeder Anfrage neu erzeugt und entspricht damit genau dem, was das Provisioning hochladen würde.",
         "download": "Teams-App-Paket (.zip) herunterladen"
+      },
+      "retarget": {
+        "heading": "Ziel wählen und Provisioning starten",
+        "hint": "Für diese Identität ist kein Ziel hinterlegt — nach einem Zurücksetzen ist das der Normalfall. Bot-Slug und Anzeigename bleiben erhalten; es fehlt nur das Team oder der Chat, in das die App installiert werden soll.",
+        "runningHint": "Für diesen Agenten läuft bereits ein Durchlauf. Warte, bis er beendet ist — einen zweiten lehnt der Server ab."
       }
     },
     "teamsTargets": {
@@ -2342,7 +2346,10 @@
           "consent_required": "Dem Tenant fehlt die Zustimmung zum Auflisten von Chats. Bis dahin trage die Chat-ID unten ein.",
           "lookup_failed": "Die Chatliste konnte gerade nicht geladen werden. Lade die Seite neu oder trage die Chat-ID unten ein."
         }
-      }
+      },
+      "filter": "Tippen zum Filtern …",
+      "noMatch": "Kein Eintrag passt zu „{query}“. Für eine ID, die hier nicht auftaucht, nutze das Feld darunter.",
+      "matchCount": "{count, plural, =0 {Keine Treffer} one {Ein Treffer} other {# Treffer}}"
     },
     "teamsReset": {
       "heading": "Provisionierung zurücksetzen",
@@ -5559,10 +5566,13 @@
       "as": "Angemeldet als {who}",
       "unknownAccount": "unbekanntes Konto",
       "since": "Angemeldet seit",
-      "tokenExpires": "Zugriffstoken läuft ab",
+      "tokenExpires": "Aktuelles Zugriffstoken gültig bis",
       "tenant": "Tenant",
       "scopes": "Berechtigungen",
-      "staleNote": "Das Zugriffstoken ist abgelaufen. Das ist kein Fehler — omadia erneuert es beim nächsten Upload automatisch, die Anmeldung bleibt bestehen."
+      "staleNote": "Das aktuelle Zugriffstoken ist abgelaufen — kein Fehler und kein Handlungsbedarf. omadia erneuert es vor dem nächsten Zugriff, die Anmeldung bleibt bestehen.",
+      "selfRenewing": "Die Anmeldung bleibt bestehen und erneuert sich selbst. Erneut anmelden musst du dich erst, wenn hier steht, dass die Anmeldung fehlt.",
+      "technicalHeading": "Technische Details",
+      "tokenExpiresHint": "Die Laufzeit des Zugriffstokens gibt Microsoft vor (rund 60 bis 90 Minuten), sie lässt sich nicht einstellen. Über die Anmeldung sagt sie nichts aus: omadia besorgt sich vor jedem Zugriff ein frisches Token."
     },
     "expired": {
       "headline": "Der Anmeldecode ist abgelaufen.",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -2306,11 +2306,15 @@
           "unknown": "Whether this configuration is already applied cannot be determined right now. Compare it against the Teams channel plugin and paste the block below if it is missing."
         }
       },
-      "rerunNeedsTeam": "No target team is recorded for this identity, so provisioning cannot be re-run from here.",
       "package": {
         "heading": "Download the app package",
         "hint": "Provisioning uploads this package to the tenant catalogue itself — no manual upload per agent is needed. The download stays as a fallback: for tenants where programmatic catalogue uploads are not allowed, or when you want to inspect the manifest first. It is rendered fresh on every request, so it matches exactly what provisioning would upload.",
         "download": "Download the Teams app package (.zip)"
+      },
+      "retarget": {
+        "heading": "Pick a target and start provisioning",
+        "hint": "No target is recorded for this identity — after a reset that is the normal state. The bot slug and the display name are kept; all that is missing is the team or chat the app should be installed into.",
+        "runningHint": "A run is already under way for this agent. Wait for it to finish — the server refuses a second one."
       }
     },
     "teamsTargets": {
@@ -2342,7 +2346,10 @@
           "consent_required": "The tenant has not consented to listing chats. Until it does, type the chat id below.",
           "lookup_failed": "The chat list could not be loaded just now. Reload the page, or type the chat id below."
         }
-      }
+      },
+      "filter": "Type to filter …",
+      "noMatch": "Nothing matches “{query}”. For an id that does not appear here, use the field below.",
+      "matchCount": "{count, plural, =0 {No matches} one {One match} other {# matches}}"
     },
     "teamsReset": {
       "heading": "Reset provisioning",
@@ -5559,10 +5566,13 @@
       "as": "Signed in as {who}",
       "unknownAccount": "unknown account",
       "since": "Signed in since",
-      "tokenExpires": "Access token expires",
+      "tokenExpires": "Current access token valid until",
       "tenant": "Tenant",
       "scopes": "Permissions",
-      "staleNote": "The access token has expired. This is not a fault — omadia renews it automatically on the next upload, and the sign-in stays valid."
+      "staleNote": "The current access token has expired — not a fault, and nothing to act on. omadia renews it before the next use and the sign-in stays valid.",
+      "selfRenewing": "The sign-in stays valid and renews itself. You only have to sign in again when this panel says the sign-in is missing.",
+      "technicalHeading": "Technical details",
+      "tokenExpiresHint": "Microsoft sets the access token lifetime (roughly 60 to 90 minutes) and it cannot be configured. It says nothing about the sign-in: omadia fetches a fresh token before each use."
     },
     "expired": {
       "headline": "The sign-in code expired.",


### PR DESCRIPTION
Three things the field test surfaced within an hour of the reset shipping.

## A reset left the operator with no way forward

The reset nulls `team_id` on purpose — after tearing the Azure objects down, the old target is no longer a promise anyone should keep. But the panel had no affordance for an identity that exists without a target:

- the create form renders only when there is **no identity row at all**, and after a reset there is one;
- the re-run button sits inside `isTerminalTeamsProvisioningState(state)`, and a reset leaves `pending`, which is not terminal.

So the screen showed status "pending", every field empty, and **nothing at all** — not a greyed-out button, not the sentence explaining why. The only way out was deleting the agent.

The panel now offers a target chooser whenever no target is recorded. The condition is `recordedTeamId === null` and nothing else: no reference to reset, no state check, no event history. A `failed` row with a nulled target gets the chooser exactly like a `pending` one. The re-run button is gated on the same expression rather than merely disabled by it, so the two affordances are mutually exclusive by construction.

**A test was pinning the bug.** `does not offer a re-run that could only 400 — no recorded target, no button` asserted the disabled button *and* its explanation as intended behaviour. It read like a correctness guarantee, which is how this shipped in the first place. Rewritten to assert the chooser; the now-dead explanation string is deleted.

## The target chooser was in the wrong panel

`TeamsTargetPicker` and the live classification lived only in `AgentTeamsInstalls.tsx`. The identity panel's form used a plain text field with no classification at all — the very screen where a wrong id costs a whole provisioning run.

Both now share an extracted `TeamsTargetField` (picker, input, verdict, ambiguity escapes). Net effect is ~80 duplicated lines **removed** from the install panel rather than added to the identity panel.

## The dropdowns needed searching, and the token display was lying

30 teams in one tenant is a scroll wall, so the selects became an ARIA 1.2 combobox: typing filters, keyboard and screen-reader behaviour preserved, no-match is its own sentence rather than an empty list that reads as a load failure. Matching runs over what a human sees — team name, chat topic, member names — and over the id, for anyone who pastes one.

The sign-in card showed "access token expires 09:06" in the facts grid, next to "signed in since". Read as a pair, that is a countdown, and an operator reasonably concludes the sign-in dies within the hour. It does not: Microsoft fixes the access token's lifetime (~60–90 min, no longer configurable), the refresh token outlives it by a wide margin, and the runner already refreshes automatically. The copy underneath even said so — the lie was structural, not textual, so moving the technical expiry out of the facts grid was the fix.

**Refresh is now pre-emptive as well as reactive.** `ACCESS_TOKEN_REFRESH_MARGIN_MS` is 300 s, bounded by three terms: it must cover the call it protects (a multi-megabyte catalogue upload takes seconds to tens of seconds), it must cover realistic clock skew against Microsoft, and firing early costs a token rotation — on a 60-minute token, five minutes is the last ~8% of its life. It is also MSAL's own proactive window, so tokens age here on the same schedule as in the library the connector refreshes with, rather than on a second opinion. A failing pre-emptive refresh logs and continues with the stored token: worst case is exactly today's behaviour, and the reactive path stays as the backstop against skew and server-side early invalidation.

`describe()` had its own inline expiry arithmetic, unrelated to the runner's. Both now call the same predicate — margin 0 for the display, 300 s for the runner — so "stale" on screen and "refresh now" in the runner cannot drift into two definitions.

## Verification

middleware: **8060 tests, 8044 pass, 0 fail** (16 skipped); typecheck, `typecheck:test` and lint all clean. web-ui: **1101 pass, 0 fail** across 119 files; typecheck clean, `i18n:check` OK at 4334 keys.

Red-without-fix, measured: stashing only `AgentTeamsIdentity.tsx` and re-running the new restart suite gives **5 failed / 3 passed** — the five no-target cases fail, the three has-target guards still pass, which is what they are for.

## Known, not addressed here

A `pending` identity is non-terminal, so the panel polls it every 3 s indefinitely even with `running: false`. Pre-existing and unchanged, but a reset row now sits in that state while an operator reads the chooser.

Refs #860, #924.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790738138&installation_model_id=428086&pr_number=953&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F953&signature=2c74419b2769d9ddfe576010e0aa9739737626848705a6d92a8b2b4c7a4983ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->