### PR TITLE
fix: refresh the tenant sign-in instead of claiming there is none, and offer a full reset

### DIFF
--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -3490,8 +3490,14 @@ async function main(): Promise<void> {
         // delegated-only at Microsoft, exactly like uploading it. Resolved
         // live for the same reason as the provisioner: an admin can sign in
         // (or out) while the process runs.
+        // WRITE included, and that is what lets both routes refresh a spent
+        // access token instead of telling a signed-in admin to sign in
+        // (#949). `TeamsDelegatedTokenStore` has always had it; the router's
+        // port simply never asked, which is why the target listing had no way
+        // to recover and reported the expiry as a missing sign-in.
         const delegatedTokens = serviceRegistry.get<{
           read(): Promise<DelegatedTokenSet | undefined>;
+          write(tokens: DelegatedTokenSet): Promise<void>;
         }>('teamsDelegatedTokenStore');
         const withEvents: OperatorTeamsIdentityDeps = {
           ...teamsDeps,

--- a/middleware/src/platform/agentTeamsIdentityStore.ts
+++ b/middleware/src/platform/agentTeamsIdentityStore.ts
@@ -396,6 +396,45 @@ export class AgentTeamsIdentityStore {
     });
   }
 
+  /**
+   * Drop the row — the last act of a FULL teardown
+   * (`services/teamsIdentityReset.ts`, scope `'identity'`).
+   *
+   * A DELETION, NOT A RESET, and the difference is the whole point.
+   * {@link resetForRetry} deliberately keeps `bot_slug` and `display_name`
+   * because they are the two answers a human typed and a retry should not
+   * make them retype either. That is exactly wrong when the identity ITSELF
+   * was the mistake: a slug that reads badly, a name nobody agreed to. A
+   * `bot_slug` is `UNIQUE`, so as long as the row exists nothing else may
+   * claim that name — keeping it is what makes "pick a different slug"
+   * impossible. Dropping the row is the only thing that frees it.
+   *
+   * WHAT GOES WITH IT, BY SCHEMA. `agent_teams_installs` (migration 0051) and
+   * `agent_teams_provisioning_events` (0053) both reference `agent_id`
+   * `ON DELETE CASCADE`, and 0051 says in as many words that deleting the
+   * identity is the documented way to unprovision an agent. So the bindings
+   * and the progress timeline go too, which is correct: both are statements
+   * ABOUT an identity that no longer exists.
+   *
+   * WHAT MUST HAVE HAPPENED FIRST. Every Azure object this row points at has
+   * to be provably gone before this is called — `app_id` is the only handle
+   * left for finding a deleted registration in the directory's recycle bin,
+   * so a row dropped too early strands a tombstone that quietly holds the
+   * `uniqueName` for thirty days with nothing left pointing at it. The
+   * teardown enforces that ordering; this method only obeys it.
+   *
+   * Idempotent: deleting a row that is not there reports `false` rather than
+   * raising, so a retried teardown finishes instead of failing on its own
+   * success.
+   */
+  async deleteForAgent(agentId: string): Promise<boolean> {
+    const res = await this.pool.query(
+      `DELETE FROM agent_teams_identities WHERE agent_id = $1`,
+      [agentId],
+    );
+    return (res.rowCount ?? 0) > 0;
+  }
+
   /** Persist an enqueue failure so the status endpoint can show WHY nothing
    *  is running (the POST handler calls this best-effort from its
    *  fire-and-forget catch). State is deliberately untouched. */

--- a/middleware/src/platform/teamsDelegatedRefresh.ts
+++ b/middleware/src/platform/teamsDelegatedRefresh.ts
@@ -1,0 +1,208 @@
+/**
+ * ONE piece of refresh arithmetic, for every caller that holds a delegated
+ * token set (byte5ai/omadia#924/#949).
+ *
+ * WHY THIS MODULE EXISTS AT ALL
+ * -----------------------------
+ * A delegated access token lives about an hour; the refresh token behind it
+ * lives for weeks. So "the access token is spent" is not a state a human has
+ * to fix — it is one silent call away from being fixed — and every caller
+ * that treats it as a human problem has invented a dead end.
+ *
+ * The catalogue upload in `services/teamsProvisioningJob.ts` got this right
+ * first, and it got it right in about forty lines: refresh BEFORE the call
+ * when the clock says the token is spent, refresh AFTER the call when
+ * Microsoft says so, persist every rotation the instant it happens, and give
+ * up only when the refresh itself fails. Every one of those four rules is a
+ * decision somebody had to make once and would have to make again — and the
+ * SECOND caller to need them was the target listing, which instead reported
+ * an expired token as "nobody is signed in" and told a signed-in admin to
+ * sign in.
+ *
+ * That is the failure this module exists to make unrepeatable. The same trap
+ * had already been sprung once between `describe()` and the runner over the
+ * expiry MARGIN, which is why {@link isAccessTokenExpiring} is shared rather
+ * than reimplemented; this is the same lesson one level up. Two sites with
+ * their own refresh arithmetic drift, and the drift stays invisible until an
+ * operator is standing in front of the wrong sentence.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * NO WRITE, NO REFRESH
+ * ─────────────────────────────────────────────────────────────────────────
+ * A refresh ROTATES the refresh token: the moment Microsoft answers, the
+ * value we held is spent and only the new one works. So a caller that cannot
+ * PERSIST the result must not refresh at all — it would trade a recoverable
+ * expiry for a silent, permanent sign-out of the whole tenant. That is why
+ * custody here is a required write port and not an optional convenience, and
+ * why the persist happens on the line after the refresh returns, before
+ * anything else can throw.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * PROACTIVE FAILS SOFT, REACTIVE FAILS LOUD
+ * ─────────────────────────────────────────────────────────────────────────
+ * The two halves have deliberately opposite failure policies, inherited from
+ * the runner:
+ *
+ *   * {@link refreshExpiringDelegatedTokens} reads OUR clock, so a failure
+ *     may well mean our clock is the thing that is wrong. It keeps the stored
+ *     token and lets the call proceed — the worst case of trying is exactly
+ *     the behaviour of not having tried.
+ *   * the reactive half inside {@link withDelegatedTokenRefresh} reads
+ *     MICROSOFT'S verdict, which is not a matter of opinion. A refresh that
+ *     fails there is the end of the line, and it is the one delegated failure
+ *     that genuinely does need a human.
+ */
+
+import {
+  ACCESS_TOKEN_REFRESH_MARGIN_MS,
+  isAccessTokenExpiring,
+  isDelegatedConsentRequiredError,
+  isDelegatedSignInRequiredError,
+  isDelegatedTokenExpiredError,
+  isRecoverableByRefresh,
+  type DelegatedTokenSet,
+} from './teamsDelegatedSignIn.js';
+
+/**
+ * Where a rotated token set is persisted. WRITE ONLY — the caller has already
+ * read the set it hands in, and a port that could also read would invite a
+ * second read racing the rotation this very call is performing.
+ */
+export interface DelegatedTokenWriter {
+  write(tokens: DelegatedTokenSet): Promise<void>;
+}
+
+/** The one connector method this module calls. Optional, like every mirrored
+ *  contract member: a middleware may be newer than its connector. */
+export interface DelegatedRefreshProvisioner {
+  refreshDelegatedToken?(input: {
+    readonly tokens: DelegatedTokenSet;
+  }): Promise<DelegatedTokenSet>;
+}
+
+export interface DelegatedRefreshContext {
+  readonly provisioner: DelegatedRefreshProvisioner;
+  readonly custody: DelegatedTokenWriter;
+  readonly now?: () => Date;
+  /**
+   * Called AFTER a rotation is persisted, never before. The runner turns this
+   * into a progress event the operator watches; the listing has nothing to
+   * say and leaves it out.
+   */
+  readonly onRefreshed?: () => Promise<void> | void;
+  readonly log?: (msg: string) => void;
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Refresh and persist, as one indivisible act.
+ *
+ * The write is awaited before the value is returned for the reason spelled
+ * out in the module doc: between Microsoft answering and the vault accepting,
+ * the only working refresh token exists in a local variable.
+ */
+async function rotate(
+  ctx: DelegatedRefreshContext,
+  tokens: DelegatedTokenSet,
+): Promise<DelegatedTokenSet> {
+  const refresh = ctx.provisioner.refreshDelegatedToken;
+  if (typeof refresh !== 'function') return tokens;
+  const rotated = await refresh.call(ctx.provisioner, { tokens });
+  await ctx.custody.write(rotated);
+  await ctx.onRefreshed?.();
+  return rotated;
+}
+
+/**
+ * THE PROACTIVE HALF — refresh before the call, when our clock says the token
+ * is spent or close enough to it.
+ *
+ * NEVER THROWS. See the module doc: this reads our own clock, and a host
+ * whose clock is wrong must not be able to fail a call whose token was fine.
+ * A failure here leaves the stored set in place and the caller proceeds
+ * exactly as it would have without this function — the reactive half is what
+ * catches a token that really is dead.
+ */
+export async function refreshExpiringDelegatedTokens(
+  ctx: DelegatedRefreshContext,
+  tokens: DelegatedTokenSet,
+): Promise<DelegatedTokenSet> {
+  const now = ctx.now?.() ?? new Date();
+  if (!isAccessTokenExpiring(tokens.expiresAt, now, ACCESS_TOKEN_REFRESH_MARGIN_MS)) {
+    return tokens;
+  }
+  try {
+    return await rotate(ctx, tokens);
+  } catch (err) {
+    ctx.log?.(
+      `[teams-delegated] pre-emptive token refresh failed, continuing with the stored token: ${errorMessage(err)}`,
+    );
+    return tokens;
+  }
+}
+
+/**
+ * Which error to report when a REACTIVE refresh fails.
+ *
+ * The default is the ORIGINAL expiry error, not the refresh's own. That is
+ * deliberate, and it is what makes "the access token expired and could not be
+ * renewed" a stable, classifiable outcome for every caller instead of
+ * whatever prose the token endpoint happened to return — a listing turning
+ * `invalid_grant` into `lookup_failed` would put a retry button in front of a
+ * condition no retry can fix.
+ *
+ * The exception is a refresh that failed with a TYPED delegated error of its
+ * own. Those name a DIFFERENT human action — grant consent, sign in — and a
+ * more specific actionable answer must never be discarded in favour of a
+ * general one.
+ */
+function reactiveFailure(original: unknown, refreshErr: unknown): unknown {
+  if (
+    isDelegatedSignInRequiredError(refreshErr) ||
+    isDelegatedConsentRequiredError(refreshErr) ||
+    isDelegatedTokenExpiredError(refreshErr)
+  ) {
+    return refreshErr;
+  }
+  return original;
+}
+
+/**
+ * Run a delegated call with both halves of the recovery around it: refresh
+ * first if the clock says so, and refresh-then-retry-once if Microsoft says
+ * so.
+ *
+ * `run` receives the token set that is actually current — callers must use
+ * the ARGUMENT and never close over the set they passed in, or the retry
+ * replays the spent token.
+ *
+ * RETRIED EXACTLY ONCE, and only for an expiry the connector itself marked
+ * recoverable. Anything else — including a refresh that failed — travels on
+ * to the caller, which is the layer that knows how to say it to a human.
+ */
+export async function withDelegatedTokenRefresh<T>(
+  ctx: DelegatedRefreshContext,
+  tokens: DelegatedTokenSet,
+  run: (tokens: DelegatedTokenSet) => Promise<T>,
+): Promise<T> {
+  const current = await refreshExpiringDelegatedTokens(ctx, tokens);
+  try {
+    return await run(current);
+  } catch (err) {
+    if (!isDelegatedTokenExpiredError(err) || !isRecoverableByRefresh(err)) throw err;
+    if (typeof ctx.provisioner.refreshDelegatedToken !== 'function') throw err;
+    let rotated: DelegatedTokenSet;
+    try {
+      rotated = await rotate(ctx, current);
+    } catch (refreshErr) {
+      ctx.log?.(
+        `[teams-delegated] token refresh after an expiry failed: ${errorMessage(refreshErr)}`,
+      );
+      throw reactiveFailure(err, refreshErr);
+    }
+    return run(rotated);
+  }
+}

--- a/middleware/src/routes/operatorAgents.ts
+++ b/middleware/src/routes/operatorAgents.ts
@@ -38,10 +38,13 @@ import type { DelegatedTokenSet } from '../platform/teamsDelegatedSignIn.js';
 import { loadTeamsTargetDirectory } from '../services/teamsTargetDirectoryService.js';
 import {
   resetTeamsIdentity,
+  TEAMS_RESET_SCOPES,
   TeamsIdentityResetNotFoundError,
+  TeamsIdentityResetUnsupportedError,
   type TeamsResetEventSink,
-  type TeamsResetIdentityRecord,
+  type TeamsResetIdentityStore,
   type TeamsResetProvisionerPort,
+  type TeamsResetScope,
 } from '../services/teamsIdentityReset.js';
 import {
   projectTeamsBotConfig,
@@ -337,6 +340,17 @@ export interface OperatorTeamsIdentityStore {
    * provisioning run building a bot on an application that is gone.
    */
   resetForRetry?(agentId: string): Promise<OperatorTeamsIdentityRecord>;
+  /**
+   * Drop the row entirely — the last act of a FULL teardown, the one that
+   * winds the agent back to having no Teams identity at all so a new
+   * `bot_slug` and display name can be chosen.
+   *
+   * Optional and gated the same way as the two above: without it the route
+   * answers 501 for `scope: 'identity'` while the milder reset keeps working,
+   * because a half-supported destructive reset is worse than an unavailable
+   * one.
+   */
+  deleteForAgent?(agentId: string): Promise<unknown>;
   /** Persist a single field mid-teardown — today only the freshly resolved
    *  `appObjectId`, which must reach the database BEFORE the delete that
    *  makes it unlookupable. Optional, like every other write above. */
@@ -457,6 +471,17 @@ export interface OperatorTeamsIdentityDeps {
    */
   readonly delegatedTokens?: {
     read(): Promise<DelegatedTokenSet | undefined>;
+    /**
+     * WRITE, for rotations only — both consumers refresh a spent access token
+     * rather than reporting it as a missing sign-in, and a rotation the vault
+     * never sees is a refresh token already spent.
+     *
+     * Optional, and its absence is enforced rather than merely tolerated: no
+     * write port means neither route refreshes at all. Signing a tenant out
+     * silently is a far worse outcome than one blocked listing. See
+     * `platform/teamsDelegatedRefresh.ts`.
+     */
+    write?(tokens: DelegatedTokenSet): Promise<void>;
   };
   /**
    * WRITE access to the provisioning progress log, so a teardown lands on the
@@ -2349,17 +2374,32 @@ export function createOperatorAgentsRouter(
    * cannot persist the object id simply forces the teardown down its
    * recycle-bin-search path instead.
    */
+  /**
+   * Read the teardown scope off a request body.
+   *
+   * `undefined` means REFUSE — an unknown value must not fall back to the
+   * default, because the two scopes differ in exactly the way a silent
+   * fallback would hide: the destructive one frees the bot slug and the
+   * milder one keeps it, and an operator who asked to free it and got it kept
+   * finds out only when the create form is still filled in.
+   *
+   * A body-less POST, on the other hand, is not an unknown value — it is
+   * every client written before scopes existed, and it means what it has
+   * always meant.
+   */
+  function parseTeamsResetScope(body: unknown): TeamsResetScope | undefined {
+    const raw = (body as { scope?: unknown } | null | undefined)?.scope;
+    if (raw === undefined || raw === null) return 'run';
+    return (TEAMS_RESET_SCOPES as readonly string[]).includes(raw as string)
+      ? (raw as TeamsResetScope)
+      : undefined;
+  }
+
   function teamsResetStore(
     deps: OperatorTeamsIdentityDeps,
     resetForRetry: (agentId: string) => Promise<OperatorTeamsIdentityRecord>,
-  ): {
-    getByAgentId(agentId: string): Promise<TeamsResetIdentityRecord | undefined>;
-    update(
-      agentId: string,
-      patch: { readonly appObjectId?: string | null },
-    ): Promise<unknown>;
-    resetForRetry(agentId: string): Promise<unknown>;
-  } {
+  ): TeamsResetIdentityStore {
+    const deleteForAgent = deps.store.deleteForAgent;
     return {
       getByAgentId: async (agentId) => {
         const row = await deps.store.getByAgentId(agentId);
@@ -2378,6 +2418,12 @@ export function createOperatorAgentsRouter(
         return update.call(deps.store, agentId, patch);
       },
       resetForRetry: (agentId) => resetForRetry.call(deps.store, agentId),
+      // Forwarded only when the store really has it, so the teardown's own
+      // feature detection (`typeof … === 'function'`) reads the truth rather
+      // than a wrapper that would throw on the line after it was called.
+      ...(typeof deleteForAgent === 'function'
+        ? { deleteForAgent: (agentId: string) => deleteForAgent.call(deps.store, agentId) }
+        : {}),
     };
   }
 
@@ -2531,11 +2577,22 @@ export function createOperatorAgentsRouter(
   /**
    * POST /:slug/teams-identity/reset — undo a provisioning run.
    *
-   * DESTRUCTIVE, AND DELIBERATELY NOT A DELETE OF ANYTHING THE OPERATOR
-   * TYPED. The Entra app registration, the Azure bot and the tenant catalog
-   * entry go; `bot_slug` and `display_name` stay, because they are the two
-   * answers a human gave and the whole point is that the retry is one button
-   * with the same slug.
+   * TWO SCOPES, ONE TEARDOWN. The body's optional `scope` chooses how far
+   * back the agent is wound:
+   *
+   *   * `'run'` (the default, and what a body-less POST has always meant) —
+   *     the Entra app registration, the Azure bot and the tenant catalog
+   *     entry go; `bot_slug` and `display_name` stay, because they are the
+   *     two answers a human gave and the point is that the retry is one
+   *     button with the same slug.
+   *   * `'identity'` — the same Azure teardown, and then the row itself, so
+   *     the agent is back to having no Teams identity and the operator picks
+   *     a fresh slug and display name from an empty form. `bot_slug` is
+   *     `UNIQUE`, so nothing short of dropping the row can free the name.
+   *
+   * DEFAULTING TO `'run'` IS THE SAFE DIRECTION and it is also what keeps
+   * every existing caller correct: a client that does not know about scopes
+   * cannot accidentally ask for the destructive one.
    *
    * WHY THE ORDER AND THE PARTIAL REPORT LIVE IN THE SERVICE, NOT HERE:
    * `services/teamsIdentityReset.ts`. This route owns three things the
@@ -2570,6 +2627,20 @@ export function createOperatorAgentsRouter(
           });
           return;
         }
+        // Read BEFORE the capability gates, so an unknown scope is refused as
+        // the client error it is rather than being silently downgraded to the
+        // milder teardown — a caller that asked to free the slug and got a
+        // row back at `pending` would have no way to tell.
+        const scope = parseTeamsResetScope(req.body);
+        if (scope === undefined) {
+          res.status(400).json({
+            error: 'invalid_body',
+            message: `scope must be one of ${TEAMS_RESET_SCOPES.join(' | ')}`,
+            agent: agent.slug,
+          });
+          return;
+        }
+
         const provisioner = deps.getProvisioner?.();
         const resetForRetry = deps.store.resetForRetry;
         if (provisioner === undefined || typeof resetForRetry !== 'function') {
@@ -2580,6 +2651,20 @@ export function createOperatorAgentsRouter(
           res.status(501).json({
             error: 'teams_reset_unsupported',
             message: TEAMS_RESET_UNSUPPORTED_REASON,
+            agent: agent.slug,
+          });
+          return;
+        }
+        if (scope === 'identity' && typeof deps.store.deleteForAgent !== 'function') {
+          // Refused BEFORE the exclusive lease and before the first Azure
+          // call. A full reset that emptied Azure and then could not drop the
+          // row would leave the operator holding a filled-in form for an
+          // identity whose objects are gone — the state this route exists to
+          // prevent, reached by the route itself.
+          res.status(501).json({
+            error: 'teams_reset_unsupported',
+            message:
+              'this deployment cannot delete Teams identity rows — reset the run instead, or upgrade the middleware that owns the identity store.',
             agent: agent.slug,
           });
           return;
@@ -2629,6 +2714,7 @@ export function createOperatorAgentsRouter(
               ...(deps.eventWriter ? { events: deps.eventWriter } : {}),
             },
             agent.id,
+            scope,
           );
           // `agentId` is dropped rather than spread: every other route on
           // this router identifies an agent by its SLUG, and leaking the
@@ -2650,6 +2736,16 @@ export function createOperatorAgentsRouter(
         if (err instanceof TeamsIdentityResetNotFoundError) {
           res.status(404).json({
             error: 'teams_identity_not_found',
+            message: err.message,
+          });
+          return;
+        }
+        if (err instanceof TeamsIdentityResetUnsupportedError) {
+          // Belt and braces: the gate above already answered this, and the
+          // service raises it too so that a future caller wiring the teardown
+          // directly cannot half-perform a full reset either.
+          res.status(501).json({
+            error: 'teams_reset_unsupported',
             message: err.message,
           });
           return;

--- a/middleware/src/services/teamsIdentityReset.ts
+++ b/middleware/src/services/teamsIdentityReset.ts
@@ -90,7 +90,12 @@
  * slug would stay blocked with no way left to find out why.
  */
 
-import type { DelegatedTokenSet } from '../platform/teamsDelegatedSignIn.js';
+import {
+  isDelegatedSignInRequiredError,
+  isDelegatedTokenExpiredError,
+  type DelegatedTokenSet,
+} from '../platform/teamsDelegatedSignIn.js';
+import { withDelegatedTokenRefresh } from '../platform/teamsDelegatedRefresh.js';
 import {
   correctedObjectIdOf,
   isDeletedObjectIdMismatchError,
@@ -117,9 +122,39 @@ export const TEAMS_RESET_STEPS = [
   'bot_deleted',
   'app_deleted',
   'identity_reset',
+  'identity_deleted',
 ] as const;
 
 export type TeamsResetStep = (typeof TEAMS_RESET_STEPS)[number];
+
+/**
+ * HOW FAR BACK a teardown winds the agent.
+ *
+ * The three Azure steps are IDENTICAL for both — same order, same refusals,
+ * same partial report. Only the last step differs, and only in what it does
+ * to the database row:
+ *
+ *   * `'run'` — the original teardown (byte5ai/omadia#951). Azure is emptied
+ *     and the row returns to `pending`, KEEPING `bot_slug` and
+ *     `display_name`: the two answers a human typed, so a retry is one button
+ *     with the same name.
+ *   * `'identity'` — the row goes too, so the agent is back to having no
+ *     Teams identity at all and the operator picks a new slug and a new
+ *     display name from an empty form. This is what an operator wants when
+ *     the identity itself was the mistake — a slug that reads wrong, a name
+ *     nobody agreed to — rather than when a run merely died in the middle.
+ *
+ * BOTH ARE KEPT rather than one replacing the other, because they answer
+ * genuinely different questions and the wrong one is expensive in both
+ * directions: `'run'` on a bad slug leaves the operator unable to change it,
+ * and `'identity'` on a died-mid-chain run makes them retype two fields they
+ * had already got right. What the UI owes them in exchange is that nobody
+ * can mistake one for the other — see the reset panel, where the destructive
+ * one is confirmed by typing the slug rather than by ticking a box.
+ */
+export const TEAMS_RESET_SCOPES = ['run', 'identity'] as const;
+
+export type TeamsResetScope = (typeof TEAMS_RESET_SCOPES)[number];
 
 /**
  * The run-level step of a teardown — the counterpart of the chain's `'run'`.
@@ -166,6 +201,20 @@ export const TEAMS_RESET_DETAILS = {
   catalogRemovalUnsupported: 'catalog_removal_unsupported',
   /** `DELETE /appCatalogs/teamsApps` is delegated-only: nobody is signed in. */
   tenantSignInRequired: 'tenant_sign_in_required',
+  /**
+   * Somebody IS signed in, the access token is spent, and renewing it failed.
+   *
+   * Its own code rather than a reuse of `tenantSignInRequired` for exactly the
+   * reason the target listing had to learn the hard way: telling an operator
+   * whose account is on screen to "sign in" is a sentence that cannot be
+   * acted on. This one says the sign-in EXPIRED, which is a different fact
+   * and points at a different cause — a revoked session, a password change, a
+   * Conditional Access policy.
+   *
+   * `blocked`, never `failed`: nothing broke and nothing was destroyed, one
+   * person has to sign in again.
+   */
+  tenantSignInExpired: 'tenant_sign_in_expired',
   /** The connector publishes no `purgeDeletedAppRegistration` (< 0.8.0).
    *  DELETING ANYWAY IS REFUSED — see the module doc. */
   purgeUnsupported: 'purge_unsupported',
@@ -187,6 +236,25 @@ export const TEAMS_RESET_DETAILS = {
   appProvablyGone: 'app_provably_gone',
   /** ARM is not configured, so no bot service can ever have been created. */
   armNotConfigured: 'arm_not_configured',
+  /**
+   * A FULL reset refused to drop the row, because the row is the last trace
+   * of an app registration nobody could prove is gone.
+   *
+   * Raised only for `'identity'` scope, and only after
+   * {@link TEAMS_RESET_DETAILS.appAbsentUnpurgeable}: the application is not
+   * in `/applications`, the connector cannot search the recycle bin, and so
+   * nothing can say whether a tombstone is still holding this agent's
+   * `uniqueName`. A `'run'` reset survives that uncertainty because the row
+   * survives it too. Deleting the row would not.
+   *
+   * `app_id` is the ONLY input `findDeletedAppRegistration` takes. Drop the
+   * row and a future connector that CAN search the recycle bin has nothing
+   * left to search for — the tombstone becomes permanently unaddressable and
+   * quietly holds the name for its thirty days. So the Azure work stands, the
+   * row stays, and the operator is told to use the milder reset or upgrade
+   * the connector.
+   */
+  appTraceRequired: 'app_trace_required',
 } as const;
 
 /** Prefixes for the failure details, mirroring the runner's convention of a
@@ -201,9 +269,14 @@ export const TEAMS_RESET_FAILURE_PREFIXES = {
 
 export type TeamsIdentityResetResult =
   | {
-      /** Every step is done and the row is back at `pending`. */
+      /**
+       * Every step is done. The row is back at `pending` (`scope: 'run'`) or
+       * gone entirely (`scope: 'identity'`) — {@link steps} says which, and
+       * so does {@link scope}.
+       */
       readonly status: 'reset';
       readonly agentId: string;
+      readonly scope: TeamsResetScope;
       readonly steps: readonly TeamsResetStepReport[];
     }
   | {
@@ -214,6 +287,7 @@ export type TeamsIdentityResetResult =
        */
       readonly status: 'incomplete';
       readonly agentId: string;
+      readonly scope: TeamsResetScope;
       readonly steps: readonly TeamsResetStepReport[];
       readonly stoppedAt: TeamsResetStep;
       readonly detail: string;
@@ -241,6 +315,15 @@ export interface TeamsResetIdentityStore {
     patch: { readonly appObjectId?: string | null },
   ): Promise<unknown>;
   resetForRetry(agentId: string): Promise<unknown>;
+  /**
+   * Drop the row entirely — the last act of an `'identity'`-scope teardown.
+   *
+   * OPTIONAL so a mount (or a test) that only wired the milder teardown keeps
+   * working unchanged. A full reset asked of a store without it is refused
+   * before a single Azure object is touched, rather than half-performed: see
+   * {@link resetTeamsIdentity}.
+   */
+  deleteForAgent?(agentId: string): Promise<unknown>;
 }
 
 /** The recorded team/chat bindings (migration 0051), when one is wired. */
@@ -261,6 +344,14 @@ export type TeamsResetDeleteBotResult =
  */
 export interface TeamsResetProvisionerPort {
   readonly tenantMode: 'customer' | 'home';
+  /**
+   * Renew a spent delegated access token (connector >= 0.6.0). Optional like
+   * every mirrored member; without it the teardown simply does not refresh
+   * and reports a spent token as blocked, exactly as it did before.
+   */
+  refreshDelegatedToken?(input: {
+    readonly tokens: DelegatedTokenSet;
+  }): Promise<DelegatedTokenSet>;
   getAppRegistration(
     appId: string,
     tenantMode: 'customer' | 'home',
@@ -317,10 +408,24 @@ export interface TeamsIdentityResetOptions {
    */
   readonly buildBotHandle: (botSlug: string, appId: string) => string;
   readonly installs?: TeamsResetInstallStore;
-  /** The tenant sign-in the catalog removal rides on (#924/#949). */
-  readonly delegatedTokens?: { read(): Promise<DelegatedTokenSet | undefined> };
+  /**
+   * The tenant sign-in the catalog removal rides on (#924/#949).
+   *
+   * `write` is optional and its absence is load-bearing — see
+   * `platform/teamsDelegatedRefresh.ts`. Without somewhere to persist a
+   * rotation the teardown must not refresh: spending the refresh token
+   * without recording the replacement signs the whole tenant out, which is a
+   * far worse outcome than the one blocked step it would have avoided.
+   */
+  readonly delegatedTokens?: {
+    read(): Promise<DelegatedTokenSet | undefined>;
+    write?(tokens: DelegatedTokenSet): Promise<void>;
+  };
   /** Progress log. Absent = the teardown runs identically, silently. */
   readonly events?: TeamsResetEventSink;
+  /** Wall clock, injectable — read only to decide whether the delegated
+   *  access token is spent before the catalog removal spends a call on it. */
+  readonly now?: () => Date;
   readonly log?: (msg: string) => void;
 }
 
@@ -331,6 +436,23 @@ export class TeamsIdentityResetNotFoundError extends Error {
   constructor(agentId: string) {
     super(`no teams identity row for agent '${agentId}'`);
     this.name = 'TeamsIdentityResetNotFoundError';
+  }
+}
+
+/**
+ * A FULL reset was asked of a store that cannot drop a row — the caller (a
+ * route) turns it into 501, like every other unwired capability.
+ *
+ * Raised before the first Azure call on purpose. See {@link resetTeamsIdentity}.
+ */
+export class TeamsIdentityResetUnsupportedError extends Error {
+  public readonly code = 'teams_reset_unsupported';
+
+  constructor(agentId: string) {
+    super(
+      `the identity store cannot delete rows, so agent '${agentId}' cannot be reset to no identity at all`,
+    );
+    this.name = 'TeamsIdentityResetUnsupportedError';
   }
 }
 
@@ -385,10 +507,22 @@ function createEmitter(
 export async function resetTeamsIdentity(
   opts: TeamsIdentityResetOptions,
   agentId: string,
+  scope: TeamsResetScope = 'run',
 ): Promise<TeamsIdentityResetResult> {
   const emit = createEmitter(opts, agentId);
   const row = await opts.store.getByAgentId(agentId);
   if (!row) throw new TeamsIdentityResetNotFoundError(agentId);
+
+  // REFUSED BEFORE ANYTHING IS TOUCHED, not half-performed. A store that
+  // cannot drop a row would otherwise let a full reset delete every Azure
+  // object and then leave the identity behind — the operator would be told
+  // the slug is free, find the form still filled in, and have no way to tell
+  // which of the two they are looking at. Throwing here is a caller error in
+  // the same family as a missing row: the route gates on this and answers
+  // 501, exactly as it already does for `resetForRetry`.
+  if (scope === 'identity' && typeof opts.store.deleteForAgent !== 'function') {
+    throw new TeamsIdentityResetUnsupportedError(agentId);
+  }
 
   // Open a fresh timeline, exactly as a provisioning run does: the log
   // describes ONE operation, and an operator watching a teardown is not
@@ -417,7 +551,7 @@ export async function resetTeamsIdentity(
     detail: string,
   ): Promise<TeamsIdentityResetResult> => {
     await emit(TEAMS_RESET_RUN_STEP, 'failed', stoppedAt);
-    return { status: 'incomplete', agentId, steps, stoppedAt, detail };
+    return { status: 'incomplete', agentId, scope, steps, stoppedAt, detail };
   };
 
   const provisioner = opts.getProvisioner();
@@ -444,23 +578,92 @@ export async function resetTeamsIdentity(
   }
 
   // ── Step 4 — the row and the recorded bindings ──────────────────────────
-  await emit('identity_reset', 'started');
+  //
+  // The ONLY step the two scopes disagree about. Everything above ran
+  // identically, which is the point: a full reset is the same teardown with a
+  // different last line, not a second teardown with its own order to get
+  // wrong.
+  const rowStep: TeamsResetStep =
+    scope === 'identity' ? 'identity_deleted' : 'identity_reset';
+
+  // THE GUARD THAT KEEPS THE ROW ALIVE, and it applies to the destructive
+  // scope only.
+  //
+  // `app_absent_unpurgeable` is reported as a SUCCESS above, and correctly
+  // so — there is genuinely no call left to make. But it is the one success
+  // that means "I could not look", not "it is gone": the application is out
+  // of `/applications` and the connector cannot search the recycle bin, so a
+  // tombstone may still be holding this agent's `uniqueName` for thirty days.
+  //
+  // The row is what would find it again. `app_id` is the only input
+  // `findDeletedAppRegistration` takes, so deleting the row converts a
+  // recoverable uncertainty into a permanent one — a leftover in Azure with
+  // nothing left pointing at it. A `'run'` reset can live with the doubt
+  // because it keeps the row; this one cannot, so it stops with everything
+  // else already cleaned up and says exactly why.
+  if (scope === 'identity' && outcomeOf(steps, 'app_deleted')?.detail ===
+      TEAMS_RESET_DETAILS.appAbsentUnpurgeable) {
+    await emit(rowStep, 'started');
+    await finish({
+      step: rowStep,
+      outcome: 'blocked',
+      detail: TEAMS_RESET_DETAILS.appTraceRequired,
+    });
+    return halt(rowStep, TEAMS_RESET_DETAILS.appTraceRequired);
+  }
+
+  await emit(rowStep, 'started');
   try {
     // Bindings first: they are a read model OF the row, and a row already
     // back at `pending` while its installs still list three teams is a
     // screen that contradicts itself. If this throws, nothing above it is
     // undone and the retry repeats it — `DELETE` of an empty set is a no-op.
+    //
+    // Redundant under `'identity'` — migration 0051's foreign key cascades
+    // them away with the row — and done anyway, because a mount whose
+    // installs store is wired against a different backing table would
+    // otherwise keep them. Deleting an empty set costs one statement.
     if (opts.installs) await opts.installs.removeAllForAgent(agentId);
-    await opts.store.resetForRetry(agentId);
+    if (scope === 'identity') {
+      await (
+        opts.store.deleteForAgent as NonNullable<
+          TeamsResetIdentityStore['deleteForAgent']
+        >
+      ).call(opts.store, agentId);
+    } else {
+      await opts.store.resetForRetry(agentId);
+    }
   } catch (err) {
     const detail = `${TEAMS_RESET_FAILURE_PREFIXES.identity}${errorMessage(err)}`;
-    await finish({ step: 'identity_reset', outcome: 'failed', detail });
-    return halt('identity_reset', detail);
+    await finish({ step: rowStep, outcome: 'failed', detail });
+    return halt(rowStep, detail);
   }
-  await finish({ step: 'identity_reset', outcome: 'removed' });
 
+  if (scope === 'identity') {
+    // THE TIMELINE WENT WITH THE ROW. `agent_teams_provisioning_events`
+    // cascades on `agent_id` (migration 0053), so the log these events would
+    // be written to no longer exists — and writing them would only produce a
+    // swallowed foreign-key violation on every single full reset.
+    //
+    // Nothing is lost that anybody can still reach: after this there is no
+    // identity for a timeline to be about, the operator lands on the empty
+    // create form, and the per-step report in the HTTP response is the record
+    // of what happened.
+    steps.push({ step: rowStep, outcome: 'removed' });
+    return { status: 'reset', agentId, scope, steps };
+  }
+
+  await finish({ step: rowStep, outcome: 'removed' });
   await emit(TEAMS_RESET_RUN_STEP, 'succeeded');
-  return { status: 'reset', agentId, steps };
+  return { status: 'reset', agentId, scope, steps };
+}
+
+/** The report recorded for one step, or `undefined` when it never ran. */
+function outcomeOf(
+  steps: readonly TeamsResetStepReport[],
+  step: TeamsResetStep,
+): TeamsResetStepReport | undefined {
+  return steps.find((entry) => entry.step === step);
 }
 
 // ---------------------------------------------------------------------------
@@ -502,17 +705,54 @@ async function removeCatalogEntry(
       detail: TEAMS_RESET_DETAILS.tenantSignInRequired,
     };
   }
+  const teamsAppId = row.teamsAppId;
+  const remove = provisioner.removeFromCatalog as NonNullable<
+    TeamsResetProvisionerPort['removeFromCatalog']
+  >;
+  const call = (set: DelegatedTokenSet): Promise<{ readonly outcome: string }> =>
+    remove.call(provisioner, { teamsAppId, tokens: set });
+
+  const write = opts.delegatedTokens?.write;
   try {
-    const res = await (
-      provisioner.removeFromCatalog as NonNullable<
-        TeamsResetProvisionerPort['removeFromCatalog']
-      >
-    ).call(provisioner, { teamsAppId: row.teamsAppId, tokens });
+    // A SPENT ACCESS TOKEN IS NOT A REASON TO ABANDON A TEARDOWN. Before this
+    // the expiry surfaced as `catalog_removal_failed: <whatever Graph said>`,
+    // which stopped the whole teardown — catalogue first, and its failure
+    // stops everything — over a condition that needs no human at all.
+    //
+    // The refresh is the SHARED one (`platform/teamsDelegatedRefresh.ts`), for
+    // the same reason the target listing uses it: this is the third caller to
+    // need the arithmetic and the second to have got it wrong on its own.
+    // No `write` port, no refresh — see that module.
+    const res =
+      write === undefined
+        ? await call(tokens)
+        : await withDelegatedTokenRefresh(
+            {
+              provisioner,
+              custody: { write: (set) => write.call(opts.delegatedTokens, set) },
+              ...(opts.now ? { now: opts.now } : {}),
+              ...(opts.log ? { log: opts.log } : {}),
+            },
+            tokens,
+            call,
+          );
     return {
       step,
       outcome: res.outcome === 'already-absent' ? 'already-absent' : 'removed',
     };
   } catch (err) {
+    // `blocked`, not `failed`: an expiry that survived the refresh is a
+    // missing human action, exactly like the missing sign-in above it, and
+    // reporting it as a fault would send an operator looking for a broken
+    // Graph call that never happened. Its own detail, though — "sign in
+    // again because yours expired" is a different sentence from "nobody has
+    // signed in", and the operator is entitled to know which one they are in.
+    if (isDelegatedTokenExpiredError(err)) {
+      return { step, outcome: 'blocked', detail: TEAMS_RESET_DETAILS.tenantSignInExpired };
+    }
+    if (isDelegatedSignInRequiredError(err)) {
+      return { step, outcome: 'blocked', detail: TEAMS_RESET_DETAILS.tenantSignInRequired };
+    }
     return {
       step,
       outcome: 'failed',

--- a/middleware/src/services/teamsProvisioningJob.ts
+++ b/middleware/src/services/teamsProvisioningJob.ts
@@ -64,18 +64,18 @@ import {
   type TeamsProvisioningState,
 } from '../platform/agentTeamsIdentityStore.js';
 import {
-  ACCESS_TOKEN_REFRESH_MARGIN_MS,
   adminConsentUrlOf,
   delegatedStepOf,
-  isAccessTokenExpiring,
   isDelegatedConsentRequiredError,
   isDelegatedSignInRequiredError,
   isDelegatedTokenExpiredError,
   isDeviceCodeFlowError,
-  isRecoverableByRefresh,
   requiredScopesOf,
   type DelegatedTokenSet,
 } from '../platform/teamsDelegatedSignIn.js';
+// The refresh arithmetic itself — shared with the target listing so the two
+// can never grow separate opinions about when a token is spent.
+import { withDelegatedTokenRefresh } from '../platform/teamsDelegatedRefresh.js';
 import type { TimerSeam } from '../plugins/jobScheduler.js';
 import type {
   BackgroundJob,
@@ -1899,47 +1899,36 @@ export class TeamsProvisioningJobRunner {
       detail: DELEGATED_UPLOAD_DETAIL,
     });
 
-    // PROACTIVE REFRESH — before the call, not after it has failed.
+    // THE REFRESH, IN BOTH DIRECTIONS — and no longer written here.
     //
-    // The reactive path below still exists and still matters, but it can only
-    // ever run once the upload has already failed: a package re-sent, and a
-    // recovery that depends on the failure being classified exactly as
-    // "expired". If Graph answers with anything else, a run dies for a reason
-    // no human needs to fix. Asking the token whether it is spent costs
-    // nothing and removes that whole class of failure.
+    // This block used to hold the whole thing inline: refresh before the call
+    // when our clock says the token is spent, refresh and retry once when
+    // Microsoft says so, persist every rotation the instant it happens. It
+    // was correct, and it was the ONLY place that was — the target listing
+    // grew the same need and answered it by reporting an expired token as
+    // "nobody is signed in", which is how a signed-in admin ended up being
+    // told to sign in.
     //
-    // A FAILURE HERE IS NOT FATAL, deliberately. If the refresh throws we
-    // carry on with the stored token: our clock may be the thing that is
-    // wrong, and a token we wrongly believed spent may work perfectly. When it
-    // does not, the upload fails exactly as it did before this block existed
-    // and the reactive path takes over — so the worst case of a proactive
-    // refresh is today's behaviour, never worse than it.
-    const refreshDelegated = provisioner.refreshDelegatedToken;
-    let current = tokens;
-    if (
-      typeof refreshDelegated === 'function' &&
-      isAccessTokenExpiring(
-        current.expiresAt,
-        this.now(),
-        ACCESS_TOKEN_REFRESH_MARGIN_MS,
-      )
-    ) {
-      try {
-        current = await refreshDelegated.call(provisioner, { tokens: current });
-        // Persisted IMMEDIATELY, for the same reason the reactive path does:
-        // a rotation the vault has not seen is a refresh token already spent,
-        // and a crash here would sign the tenant out silently.
-        await custody.write(current);
+    // So the arithmetic moved to `platform/teamsDelegatedRefresh.ts` and both
+    // callers now share it, for the same reason `isAccessTokenExpiring` is
+    // shared rather than reimplemented: two sites with their own expiry rules
+    // drift, and the drift is invisible until an operator is standing in
+    // front of the wrong sentence. The policies it enforces are unchanged —
+    // proactive failures are swallowed (our clock may be the wrong one),
+    // reactive failures are not (Microsoft's verdict is not an opinion).
+    const refreshCtx = {
+      provisioner,
+      custody,
+      now: (): Date => this.now(),
+      onRefreshed: async (): Promise<void> => {
         await this.emit(agentId, 'catalog_uploaded', 'progress', {
           detail: DELEGATED_TOKEN_REFRESHED_DETAIL,
         });
-      } catch (err) {
-        current = tokens;
-        this.log(
-          `[teams-provisioning] pre-emptive delegated token refresh for agent '${agentId}' failed, continuing with the stored token: ${errorMessage(err)}`,
-        );
-      }
-    }
+      },
+      log: (msg: string): void => {
+        this.log(`[teams-provisioning] agent '${agentId}': ${msg}`);
+      },
+    };
 
     const attemptUpload = async (set: DelegatedTokenSet): Promise<string> => {
       const result = await delegatedUpload.call(provisioner, {
@@ -1947,6 +1936,10 @@ export class TeamsProvisioningJobRunner {
         externalId,
         tokens: set,
       });
+      // The connector's OWN rotation, which is a third path the shared helper
+      // deliberately knows nothing about: it happens inside the upload, is
+      // reported by the result rather than by an error, and only this call
+      // site can see it. Persisted on the same terms as every other rotation.
       if (result.refreshed) {
         await custody.write(result.tokens);
         await this.emit(agentId, 'catalog_uploaded', 'progress', {
@@ -1956,32 +1949,16 @@ export class TeamsProvisioningJobRunner {
       return result.app.value.teamsAppId;
     };
 
-    try {
-      return { kind: 'uploaded', teamsAppId: await attemptUpload(current) };
-    } catch (err) {
-      // THE FALLBACK, and it stays a fallback rather than becoming dead code.
-      // The check above reads a clock; this reads Microsoft's actual verdict.
-      // It is what still catches a host whose clock is behind, and a token the
-      // server invalidated early — a revoked session, a password change, a
-      // Conditional Access policy — neither of which any expiry arithmetic can
-      // see coming.
-      //
-      // The ONE delegated failure an operator must never be shown: an access
-      // token past its expiry with a refresh token that is still good. It is
-      // recovered right here — refresh, retry once — because surfacing it
-      // would ask a human to fix something no human needs to touch. Anything
-      // else, INCLUDING a refresh that itself fails, travels on to
-      // {@link handleFailure}, which is where the four errors are told apart.
-      if (!isDelegatedTokenExpiredError(err) || !isRecoverableByRefresh(err)) throw err;
-      const refresh = provisioner.refreshDelegatedToken;
-      if (typeof refresh !== 'function') throw err;
-      const rotated = await refresh.call(provisioner, { tokens: current });
-      await custody.write(rotated);
-      await this.emit(agentId, 'catalog_uploaded', 'progress', {
-        detail: DELEGATED_TOKEN_REFRESHED_DETAIL,
-      });
-      return { kind: 'uploaded', teamsAppId: await attemptUpload(rotated) };
-    }
+    // The ONE delegated failure an operator must never be shown: an access
+    // token past its expiry with a refresh token that is still good. It is
+    // recovered in here — refresh, retry once — because surfacing it would
+    // ask a human to fix something no human needs to touch. Anything else,
+    // INCLUDING a refresh that itself failed, travels on to
+    // {@link handleFailure}, which is where the four errors are told apart.
+    return {
+      kind: 'uploaded',
+      teamsAppId: await withDelegatedTokenRefresh(refreshCtx, tokens, attemptUpload),
+    };
   }
 
   /**

--- a/middleware/src/services/teamsTargetDirectoryService.ts
+++ b/middleware/src/services/teamsTargetDirectoryService.ts
@@ -25,6 +25,27 @@
  * They are therefore probed separately and reported separately: a missing
  * chat scope must not be able to hide the team list, which is the half that
  * always works.
+ *
+ * A SPENT ACCESS TOKEN IS NOT A MISSING SIGN-IN
+ * ---------------------------------------------
+ * This listing used to report an expired access token as `sign_in_required`,
+ * which put an operator who was demonstrably signed in — account on screen,
+ * tenant sign-in green — in front of the sentence "sign in once". It was
+ * wrong twice over: the sign-in existed, and the expiry needed no human at
+ * all, only the refresh the catalogue upload had been doing since #924.
+ *
+ * So the listing now performs that refresh itself, through the SHARED
+ * arithmetic in `platform/teamsDelegatedRefresh.ts` rather than a second copy
+ * of it — the drift between two hand-rolled refresh paths is exactly the trap
+ * that had already been sprung once between `describe()` and the runner.
+ *
+ * The refresh is not only a repair, it is what makes the REAL diagnosis
+ * reachable. The connector validates a token before it considers what the
+ * token is allowed to do, so while the access token was spent, the expiry was
+ * the only error it ever threw and {@link classifyListingFailure}'s scope
+ * branch could not be reached however correctly it was ordered. With a live
+ * token the connector gets far enough to notice a missing `Chat.ReadBasic`,
+ * and the operator is finally told the thing that is actually true.
  */
 
 import {
@@ -33,6 +54,10 @@ import {
   isDelegatedTokenExpiredError,
   type DelegatedTokenSet,
 } from '../platform/teamsDelegatedSignIn.js';
+import {
+  withDelegatedTokenRefresh,
+  type DelegatedRefreshProvisioner,
+} from '../platform/teamsDelegatedRefresh.js';
 import {
   isDelegatedScopeRequiredError,
   supportsChatListing,
@@ -53,19 +78,36 @@ export type TeamsTargetListingUnavailable =
   | 'connector_unavailable'
   /** The installed connector publishes no such method (older version). */
   | 'connector_unsupported'
-  /** A tenant admin has to sign in before Graph will answer (#924/#949). */
+  /**
+   * NOBODY IS SIGNED IN. That is the whole meaning of this code, and it is
+   * now the only one — see `sign_in_expired` below for what used to be folded
+   * in here and for why that was the field-test bug (#924/#949).
+   */
   | 'sign_in_required'
   /**
-   * Somebody IS signed in, but with a credential issued before this listing's
+   * Somebody IS signed in, the access token is spent, and renewing it failed.
+   *
+   * The admin does have to sign in again, so the ACTION is the same as
+   * `sign_in_required` — and that is precisely why the two must stay apart.
+   * "You never signed in" and "your sign-in stopped working" send a person to
+   * the same button with completely different expectations, and only one of
+   * them is worth investigating (a revoked session, a password change, a
+   * Conditional Access policy). Folding them together is what produced a
+   * screen telling a signed-in admin to sign in, with no hint that anything
+   * had expired.
+   *
+   * Reaching this code at all means the refresh was TRIED and failed: a spent
+   * access token whose refresh works never surfaces to a human.
+   */
+  | 'sign_in_expired'
+  /**
+   * Somebody IS signed in, with a credential issued before this listing's
    * scope existed (`Chat.ReadBasic`, connector 0.8.0).
    *
-   * Kept apart from `sign_in_required` because the two look identical to the
-   * code and completely different to the person: this one means "you are
-   * signed in, it still is not enough, sign in once more" — and, crucially,
-   * that a refresh will never fix it, because a refresh token only renews the
-   * scopes it was issued for. Folding it into `sign_in_required` would put an
-   * operator who is demonstrably signed in in front of a message telling them
-   * to sign in, with no explanation of why the first time did not count.
+   * Kept apart from both codes above because a refresh will never fix it — a
+   * refresh token only renews the scopes it was issued for — so this is the
+   * one case where signing in again is genuinely the only way forward, and
+   * the copy can say why the first sign-in did not count.
    */
   | 'scope_missing'
   /** Signed in, but the tenant never granted the permission at all. */
@@ -85,9 +127,9 @@ export interface TeamsTargetDirectory {
   readonly chats: TeamsTargetListing<TeamsChatSummary>;
 }
 
-/** The provisioner surface this service uses — structural, both methods
+/** The provisioner surface this service uses — structural, every method
  *  optional, so feature detection reads the object the call would go to. */
-export interface TeamsTargetDirectoryProvisioner {
+export interface TeamsTargetDirectoryProvisioner extends DelegatedRefreshProvisioner {
   listTeams?(): Promise<readonly TeamsTeamSummary[]>;
   listChats?(input?: ListChatsInput): Promise<readonly TeamsChatSummary[]>;
 }
@@ -95,19 +137,42 @@ export interface TeamsTargetDirectoryProvisioner {
 export interface TeamsTargetDirectoryOptions {
   /** `undefined` when the connector plugin is not installed/active. */
   readonly getProvisioner: () => TeamsTargetDirectoryProvisioner | undefined;
-  /** The tenant sign-in, when one is wired. Absent is not an error — it only
-   *  means `listChats` is called without tokens and the connector decides. */
-  readonly delegatedTokens?: { read(): Promise<DelegatedTokenSet | undefined> };
+  /**
+   * The tenant sign-in, when one is wired. Absent is not an error — it only
+   * means `listChats` is called without tokens and the connector decides.
+   *
+   * `write` is OPTIONAL and its absence is load-bearing: without somewhere to
+   * persist a rotation this listing must not refresh at all. A refresh spends
+   * the refresh token the instant Microsoft answers, so rotating without
+   * recording the result would trade a recoverable expiry for a silent,
+   * permanent sign-out of the entire tenant. One bad sentence is the cheaper
+   * failure. See `platform/teamsDelegatedRefresh.ts`.
+   */
+  readonly delegatedTokens?: {
+    read(): Promise<DelegatedTokenSet | undefined>;
+    write?(tokens: DelegatedTokenSet): Promise<void>;
+  };
+  /** Wall clock, injectable — the proactive refresh reads it, and that
+   *  decision has to be testable without waiting an hour. */
+  readonly now?: () => Date;
   readonly log?: (msg: string) => void;
 }
 
 /**
  * Classify a thrown enumeration failure.
  *
- * The three delegated guards come first because they are the only ones that
- * name a HUMAN ACTION: "sign in", "grant consent". Reporting either of those
- * as `lookup_failed` would put an operator in front of a retry button for a
+ * The delegated guards come first because they are the only ones that name a
+ * HUMAN ACTION: "sign in", "grant consent". Reporting any of those as
+ * `lookup_failed` would put an operator in front of a retry button for a
  * condition no retry can fix.
+ *
+ * ON THE ORDER, AND ON WHAT THE ORDER CANNOT DO. It is written most-specific
+ * first, and that is right — but ordering alone never made `scope_missing`
+ * reachable for the operator who reported this. Only ONE error is ever
+ * thrown, and while the access token was spent that error was always the
+ * expiry: the connector will not scope-check a credential it cannot
+ * authenticate. What made the scope answer reachable is the refresh in
+ * {@link listChatsSafely}, not this list.
  */
 function classifyListingFailure(err: unknown): TeamsTargetListingUnavailable {
   // FIRST, and deliberately: the connector raises this one WITHOUT calling
@@ -116,7 +181,10 @@ function classifyListingFailure(err: unknown): TeamsTargetListingUnavailable {
   // the wrong shape" rather than "there is no sign-in".
   if (isDelegatedScopeRequiredError(err)) return 'scope_missing';
   if (isDelegatedSignInRequiredError(err)) return 'sign_in_required';
-  if (isDelegatedTokenExpiredError(err)) return 'sign_in_required';
+  // NOT `sign_in_required`. Getting here means a refresh was attempted and
+  // did not work — the whole recoverable case is handled upstream and never
+  // reaches a human.
+  if (isDelegatedTokenExpiredError(err)) return 'sign_in_expired';
   if (isDelegatedConsentRequiredError(err)) return 'consent_required';
   return 'lookup_failed';
 }
@@ -188,12 +256,33 @@ async function listChatsSafely(
   } catch (err) {
     opts.log?.(`[teams-targets] delegated token read failed: ${errorMessage(err)}`);
   }
+
+  const listChats = provisioner.listChats as NonNullable<
+    TeamsTargetDirectoryProvisioner['listChats']
+  >;
+  const call = (set: DelegatedTokenSet | undefined): Promise<readonly TeamsChatSummary[]> =>
+    listChats.call(provisioner, set === undefined ? undefined : { tokens: set });
+
+  const write = opts.delegatedTokens?.write;
   try {
-    const items = await (
-      provisioner.listChats as NonNullable<
-        TeamsTargetDirectoryProvisioner['listChats']
-      >
-    ).call(provisioner, tokens === undefined ? undefined : { tokens });
+    // NO WRITE, NO REFRESH — and no refresh method, nothing to call. Either
+    // way the listing behaves exactly as it did before #949: it spends the
+    // token it was given and reports whatever comes back.
+    const items =
+      tokens === undefined || write === undefined
+        ? await call(tokens)
+        : await withDelegatedTokenRefresh(
+            {
+              provisioner,
+              custody: { write: (set) => write.call(opts.delegatedTokens, set) },
+              ...(opts.now ? { now: opts.now } : {}),
+              ...(opts.log ? { log: opts.log } : {}),
+            },
+            tokens,
+            // The ARGUMENT, never the captured `tokens` — a retry that
+            // replayed the spent set would fail identically forever.
+            (set) => call(set),
+          );
     return { available: true, items };
   } catch (err) {
     opts.log?.(`[teams-targets] listChats failed: ${errorMessage(err)}`);

--- a/middleware/test/teamsIdentityReset.test.ts
+++ b/middleware/test/teamsIdentityReset.test.ts
@@ -27,6 +27,7 @@ import { describe, it } from 'node:test';
 import {
   resetTeamsIdentity,
   TeamsIdentityResetNotFoundError,
+  TeamsIdentityResetUnsupportedError,
   TEAMS_RESET_DETAILS,
   type TeamsIdentityResetOptions,
   type TeamsResetDeleteBotResult,
@@ -46,15 +47,25 @@ interface MemoryStore {
   row: TeamsResetIdentityRecord | undefined;
   readonly writes: { readonly appObjectId?: string | null }[];
   resetCalls: number;
+  deleteCalls: number;
   getByAgentId(agentId: string): Promise<TeamsResetIdentityRecord | undefined>;
   update(
     agentId: string,
     patch: { readonly appObjectId?: string | null },
   ): Promise<unknown>;
   resetForRetry(agentId: string): Promise<unknown>;
+  deleteForAgent?(agentId: string): Promise<unknown>;
 }
 
-function memoryStore(row: Partial<TeamsResetIdentityRecord>): MemoryStore {
+/**
+ * @param canDelete `false` models a store that predates the full teardown —
+ *   the capability gate the route also enforces, exercised here from the
+ *   service's own side.
+ */
+function memoryStore(
+  row: Partial<TeamsResetIdentityRecord>,
+  opts: { readonly canDelete?: boolean; readonly deleteFails?: boolean } = {},
+): MemoryStore {
   const store: MemoryStore = {
     row: {
       agentId: 'agent-1',
@@ -66,6 +77,7 @@ function memoryStore(row: Partial<TeamsResetIdentityRecord>): MemoryStore {
     },
     writes: [],
     resetCalls: 0,
+    deleteCalls: 0,
     getByAgentId: async () => store.row,
     update: async (_agentId, patch) => {
       store.writes.push(patch);
@@ -76,9 +88,25 @@ function memoryStore(row: Partial<TeamsResetIdentityRecord>): MemoryStore {
     },
     resetForRetry: async () => {
       store.resetCalls += 1;
+      // Deliberately a COUNTER and not a model of the real write. The real
+      // `resetForRetry` NULLs the Azure identifiers, and several tests here
+      // read `row.appObjectId` AFTER a completed teardown to prove the id was
+      // persisted mid-teardown — the property that makes an interrupted purge
+      // resumable at all. Emptying the row here would erase the evidence
+      // those tests exist to inspect. What distinguishes the two scopes in
+      // this double is `resetCalls` versus `deleteCalls` and whether `row`
+      // survives at all, which `deleteForAgent` below does model.
       return undefined;
     },
   };
+  if (opts.canDelete !== false) {
+    store.deleteForAgent = async () => {
+      store.deleteCalls += 1;
+      if (opts.deleteFails) throw new Error('pg is down');
+      store.row = undefined;
+      return undefined;
+    };
+  }
   return store;
 }
 
@@ -632,5 +660,415 @@ describe('teams identity reset — the #916 trap, closed from both sides', () =>
       assert.equal(store.resetCalls, 0, `failOn=${failOn}: the row must be kept`);
       assert.equal(store.row?.appId, APP_ID, `failOn=${failOn}: the app id must be kept`);
     }
+  });
+});
+
+/**
+ * THE FULL RESET — winding an agent back to having no Teams identity at all,
+ * so a new bot slug and display name can be chosen.
+ *
+ * It is the SAME teardown as above with one different last line, and this
+ * suite is written to prove exactly that: the order, the refusals and the
+ * partial report are inherited unchanged, and only the fate of the database
+ * row differs. `bot_slug` is `UNIQUE`, so nothing short of dropping the row
+ * frees the name — which is the entire reason this scope exists.
+ *
+ * THE RULE IT MUST NEVER BREAK. The row may only disappear once every Azure
+ * object it points at is provably gone. `app_id` is the sole input
+ * `findDeletedAppRegistration` accepts, so a row deleted while a registration
+ * may still be sitting in the directory's recycle bin destroys the only route
+ * back to it: the tombstone then holds the `uniqueName` for thirty days with
+ * nothing left able to name it. A reset that leaves an unreachable corpse
+ * behind is strictly worse than the state it was asked to repair.
+ */
+describe('teams identity reset — the full reset', () => {
+  it('tears Azure down in the SAME order, then removes the row', async () => {
+    const store = memoryStore({});
+    const provisioner = stubProvisioner();
+
+    const result = await resetTeamsIdentity(
+      options(store, provisioner),
+      'agent-1',
+      'identity',
+    );
+
+    assert.equal(result.status, 'reset');
+    assert.equal(result.scope, 'identity');
+    // Byte for byte the order the milder teardown uses. A second teardown
+    // with its own order is exactly what this scope must not become.
+    assert.deepEqual(
+      provisioner.calls.filter((c) => !c.startsWith('getAppRegistration')),
+      [
+        'removeFromCatalog:catalog-1',
+        'deleteBot:omadia-acme-app-1111',
+        'deleteAppRegistration:app-1111',
+        `purge:${OBJECT_ID}`,
+      ],
+    );
+    assert.equal(store.deleteCalls, 1);
+    assert.equal(store.resetCalls, 0, 'the milder reset must not also run');
+    assert.equal(store.row, undefined, 'the identity is gone');
+    assert.equal(
+      outcomeOf(result.steps, 'identity_deleted')?.outcome,
+      'removed',
+    );
+    assert.equal(
+      outcomeOf(result.steps, 'identity_reset'),
+      undefined,
+      'exactly one row step is reported, never both',
+    );
+  });
+
+  it('THE RULE: an abort mid-teardown leaves the row exactly where it was', async () => {
+    // The single most important assertion in this file. Every way the
+    // teardown can stop early, across BOTH scopes: nothing may delete the row
+    // while an Azure object it points at might still exist, because the row
+    // is the only thing that still knows the object's name.
+    for (const failOn of ['catalog', 'bot', 'delete', 'purge'] as const) {
+      const store = memoryStore({});
+      const result = await resetTeamsIdentity(
+        options(store, stubProvisioner({ failOn })),
+        'agent-1',
+        'identity',
+      );
+
+      assert.equal(result.status, 'incomplete', `failOn=${failOn}`);
+      assert.equal(store.deleteCalls, 0, `failOn=${failOn}: the row must survive`);
+      assert.notEqual(store.row, undefined, `failOn=${failOn}: the row must survive`);
+      // And it must survive INTACT — a row stripped of `app_id` is a row that
+      // can no longer find the registration it was keeping a trace of.
+      assert.equal(
+        store.row?.appId,
+        APP_ID,
+        `failOn=${failOn}: the trace back to Azure must be kept`,
+      );
+    }
+  });
+
+  it('refuses to drop the row when the app registration cannot be proven gone', async () => {
+    // The subtle one, and the reason `app_absent_unpurgeable` could not
+    // simply be treated as the success it is reported as.
+    //
+    // The application is out of `/applications` and the connector cannot
+    // search the recycle bin, so nothing can say whether a tombstone is still
+    // holding this agent's `uniqueName`. The milder reset survives that doubt
+    // because it keeps the row. This one would delete the doubt along with
+    // the only pointer that could ever resolve it — so it stops instead, with
+    // every Azure step already done.
+    const store = memoryStore({});
+    const provisioner = stubProvisioner({ live: false, deleted: false, canFind: false });
+
+    const result = await resetTeamsIdentity(
+      options(store, provisioner),
+      'agent-1',
+      'identity',
+    );
+
+    assert.equal(result.status, 'incomplete');
+    assert.equal(
+      outcomeOf(result.steps, 'app_deleted')?.detail,
+      TEAMS_RESET_DETAILS.appAbsentUnpurgeable,
+    );
+    assert.equal(outcomeOf(result.steps, 'identity_deleted')?.outcome, 'blocked');
+    assert.equal(
+      outcomeOf(result.steps, 'identity_deleted')?.detail,
+      TEAMS_RESET_DETAILS.appTraceRequired,
+    );
+    assert.equal(store.deleteCalls, 0);
+    assert.equal(store.row?.appId, APP_ID, 'the trace stays addressable');
+    // The catalog and the bot really were removed — this is a refusal to
+    // finish, not a refusal to start.
+    assert.equal(outcomeOf(result.steps, 'catalog_removed')?.outcome, 'removed');
+    assert.equal(outcomeOf(result.steps, 'bot_deleted')?.outcome, 'removed');
+  });
+
+  it('the MILDER reset still completes in that same state', async () => {
+    // The contrast that justifies keeping both. Same Azure uncertainty, and
+    // `'run'` may finish: it keeps the row, so the trace survives and the
+    // operator is merely warned to pick a different slug.
+    const store = memoryStore({});
+
+    const result = await resetTeamsIdentity(
+      options(store, stubProvisioner({ live: false, deleted: false, canFind: false })),
+      'agent-1',
+      'run',
+    );
+
+    assert.equal(result.status, 'reset');
+    assert.equal(result.scope, 'run');
+    assert.equal(store.resetCalls, 1);
+  });
+
+  it('a store that cannot delete is refused BEFORE anything is torn down', async () => {
+    // Half-performing this is the worst available outcome: Azure emptied, the
+    // row still filled in, and no way for the operator to tell which of the
+    // two they are looking at.
+    const store = memoryStore({}, { canDelete: false });
+    const provisioner = stubProvisioner();
+
+    await assert.rejects(
+      () => resetTeamsIdentity(options(store, provisioner), 'agent-1', 'identity'),
+      TeamsIdentityResetUnsupportedError,
+    );
+    assert.deepEqual(provisioner.calls, [], 'not one Azure call was made');
+    assert.equal(store.resetCalls, 0);
+  });
+
+  it('a failing row deletion keeps every identifier for the retry', async () => {
+    const store = memoryStore({}, { deleteFails: true });
+
+    const result = await resetTeamsIdentity(
+      options(store, stubProvisioner()),
+      'agent-1',
+      'identity',
+    );
+
+    assert.equal(result.status, 'incomplete');
+    assert.equal(result.status === 'incomplete' ? result.stoppedAt : null, 'identity_deleted');
+    assert.equal(outcomeOf(result.steps, 'identity_deleted')?.outcome, 'failed');
+    assert.notEqual(store.row, undefined);
+  });
+
+  it('is idempotent — a second call finishes on already-absent objects', async () => {
+    // Resumption without a cursor: every primitive answers `already-absent`
+    // for something that is not there, and the teardown treats that as
+    // success. Here the first attempt dies on the purge and the second one
+    // completes, all the way through the row.
+    const store = memoryStore({});
+    const first = await resetTeamsIdentity(
+      options(store, stubProvisioner({ failOn: 'purge' })),
+      'agent-1',
+      'identity',
+    );
+    assert.equal(first.status, 'incomplete');
+    assert.equal(store.deleteCalls, 0);
+    // The object id was persisted mid-teardown — that is what makes the
+    // recycle-bin entry addressable at all after the delete.
+    assert.equal(store.row?.appObjectId, OBJECT_ID);
+
+    const second = await resetTeamsIdentity(
+      options(store, stubProvisioner({ live: false, deleted: true })),
+      'agent-1',
+      'identity',
+    );
+
+    assert.equal(second.status, 'reset');
+    assert.equal(store.deleteCalls, 1);
+    assert.equal(store.row, undefined);
+  });
+
+  it('nothing provisioned yet: four skips and the row still goes', async () => {
+    // The state an operator is in when they typed a slug they regret before
+    // ever starting a run. There is nothing in Azure to remove, and the whole
+    // point is that the slug becomes free again.
+    const store = memoryStore({ appId: null, teamsAppId: null });
+    const provisioner = stubProvisioner();
+
+    const result = await resetTeamsIdentity(
+      options(store, provisioner),
+      'agent-1',
+      'identity',
+    );
+
+    assert.equal(result.status, 'reset');
+    assert.deepEqual(provisioner.calls, []);
+    assert.equal(store.row, undefined);
+  });
+
+  it('a blocked catalog entry stops a full reset exactly as it stops a mild one', async () => {
+    // The refusal that must survive both scopes. `stableTeamsAppExternalId`
+    // is derived from the AGENT id, so it outlives any reset — an abandoned
+    // catalog entry is adopted by the next run and pairs a new bot with a
+    // deleted app id. Under `'identity'` it would be worse still: the row
+    // that knew about the entry would be gone too.
+    const store = memoryStore({});
+
+    const result = await resetTeamsIdentity(
+      options(store, stubProvisioner({ canRemoveFromCatalog: false })),
+      'agent-1',
+      'identity',
+    );
+
+    assert.equal(result.status, 'incomplete');
+    assert.equal(result.status === 'incomplete' ? result.stoppedAt : null, 'catalog_removed');
+    assert.equal(
+      outcomeOf(result.steps, 'catalog_removed')?.detail,
+      TEAMS_RESET_DETAILS.catalogRemovalUnsupported,
+    );
+    assert.equal(store.deleteCalls, 0);
+  });
+
+  it('a connector that cannot purge still may not delete, under either scope', async () => {
+    const store = memoryStore({}, {});
+    const provisioner = stubProvisioner({ canPurge: false });
+
+    const result = await resetTeamsIdentity(
+      options(store, provisioner),
+      'agent-1',
+      'identity',
+    );
+
+    assert.equal(result.status, 'incomplete');
+    assert.equal(
+      outcomeOf(result.steps, 'app_deleted')?.detail,
+      TEAMS_RESET_DETAILS.purgeUnsupported,
+    );
+    assert.ok(
+      !provisioner.calls.some((c) => c.startsWith('deleteAppRegistration')),
+      'deleting without a purge would burn the slug for 30 days',
+    );
+    assert.equal(store.deleteCalls, 0);
+  });
+});
+
+/**
+ * A SPENT TENANT TOKEN IS NOT A MISSING ONE — the teardown's half of the
+ * field-test bug.
+ *
+ * The catalog withdrawal is delegated-only, it runs FIRST, and its failure
+ * stops the whole teardown. So an expired access token used to abort the
+ * entire reset with `catalog_removal_failed: <whatever Graph said>` — over a
+ * condition that needs no human at all. The same refresh the catalogue upload
+ * has performed since #924 fixes it, and it is now literally the same code.
+ */
+describe('teams identity reset — the tenant sign-in', () => {
+  const HOUR = 60 * 60 * 1000;
+  const NOW = new Date('2026-08-31T12:00:00.000Z');
+
+  function tokens(expiresAt: Date, accessToken = 'access-1'): Record<string, unknown> {
+    return {
+      accessToken,
+      refreshToken: 'refresh-1',
+      expiresAt: expiresAt.toISOString(),
+      scopes: ['AppCatalog.ReadWrite.All'],
+      clientId: 'client-1',
+      tenantId: 'tenant-1',
+    };
+  }
+
+  function expiredError(): Error {
+    return Object.assign(new Error('access token expired'), {
+      name: 'DelegatedTokenExpiredError',
+      reason: 'access-token-expired',
+      recoverableByRefresh: true,
+    });
+  }
+
+  it('refreshes a spent token rather than aborting the whole teardown', async () => {
+    const store = memoryStore({});
+    const provisioner = stubProvisioner();
+    const written: unknown[] = [];
+    let stored: unknown = tokens(new Date(NOW.getTime() - HOUR));
+
+    const result = await resetTeamsIdentity(
+      options(store, {
+        ...provisioner,
+        refreshDelegatedToken: async () => tokens(new Date(NOW.getTime() + HOUR), 'access-2'),
+      } as never, {
+        now: () => NOW,
+        delegatedTokens: {
+          read: async () => stored as never,
+          write: async (set: unknown) => {
+            written.push(set);
+            stored = set;
+          },
+        },
+      }),
+      'agent-1',
+      'identity',
+    );
+
+    assert.equal(result.status, 'reset');
+    assert.equal(outcomeOf(result.steps, 'catalog_removed')?.outcome, 'removed');
+    assert.equal(written.length, 1, 'the rotation was persisted');
+    assert.equal((written[0] as { accessToken: string }).accessToken, 'access-2');
+  });
+
+  it('reports a token whose refresh failed as EXPIRED, not as never signed in', async () => {
+    const store = memoryStore({});
+    const base = stubProvisioner();
+
+    const result = await resetTeamsIdentity(
+      options(store, {
+        ...base,
+        removeFromCatalog: async () => {
+          throw expiredError();
+        },
+        refreshDelegatedToken: async () => {
+          throw new Error('invalid_grant');
+        },
+      } as never, {
+        now: () => NOW,
+        delegatedTokens: {
+          read: async () => tokens(new Date(NOW.getTime() + HOUR)) as never,
+          write: async () => {},
+        },
+      }),
+      'agent-1',
+      'identity',
+    );
+
+    assert.equal(result.status, 'incomplete');
+    const catalog = outcomeOf(result.steps, 'catalog_removed');
+    // BLOCKED, not FAILED: nothing broke, a human has to act.
+    assert.equal(catalog?.outcome, 'blocked');
+    assert.equal(catalog?.detail, TEAMS_RESET_DETAILS.tenantSignInExpired);
+    assert.notEqual(
+      catalog?.detail,
+      TEAMS_RESET_DETAILS.tenantSignInRequired,
+      'an expired sign-in is not a missing one',
+    );
+    assert.equal(store.deleteCalls, 0);
+  });
+
+  it('still says a plain sign-in is required when nobody signed in', async () => {
+    const store = memoryStore({});
+
+    const result = await resetTeamsIdentity(
+      options(store, stubProvisioner(), {
+        delegatedTokens: { read: async () => undefined, write: async () => {} },
+      }),
+      'agent-1',
+      'identity',
+    );
+
+    assert.equal(result.status, 'incomplete');
+    assert.equal(
+      outcomeOf(result.steps, 'catalog_removed')?.detail,
+      TEAMS_RESET_DETAILS.tenantSignInRequired,
+    );
+  });
+
+  it('never refreshes without somewhere to persist the rotation', async () => {
+    // Same safety rule the listing obeys: spending the refresh token without
+    // recording its replacement signs the tenant out for good.
+    const store = memoryStore({});
+    const base = stubProvisioner();
+    let refreshed = 0;
+
+    const result = await resetTeamsIdentity(
+      options(store, {
+        ...base,
+        removeFromCatalog: async () => {
+          throw expiredError();
+        },
+        refreshDelegatedToken: async () => {
+          refreshed += 1;
+          return tokens(new Date(NOW.getTime() + HOUR)) as never;
+        },
+      } as never, {
+        now: () => NOW,
+        // READ ONLY.
+        delegatedTokens: { read: async () => tokens(new Date(NOW.getTime() + HOUR)) as never },
+      }),
+      'agent-1',
+      'identity',
+    );
+
+    assert.equal(refreshed, 0);
+    assert.equal(
+      outcomeOf(result.steps, 'catalog_removed')?.detail,
+      TEAMS_RESET_DETAILS.tenantSignInExpired,
+    );
   });
 });

--- a/middleware/test/teamsTargetDirectory.test.ts
+++ b/middleware/test/teamsTargetDirectory.test.ts
@@ -22,6 +22,7 @@ import {
   loadTeamsTargetDirectory,
   type TeamsTargetDirectoryProvisioner,
 } from '../src/services/teamsTargetDirectoryService.js';
+import type { DelegatedTokenSet } from '../src/platform/teamsDelegatedSignIn.js';
 import {
   isDelegatedScopeRequiredError,
   supportsChatListing,
@@ -51,6 +52,88 @@ function signInError(): Error {
   return Object.assign(new Error('sign in first'), {
     name: 'DelegatedSignInRequiredError',
   });
+}
+
+/**
+ * The connector's verdict on a token it will not use.
+ *
+ * `recoverableByRefresh` is the WHOLE distinction this file cares about: true
+ * means a machine fixes it, false means a human does. Reporting the first one
+ * as "sign in" is the bug the suite below exists for.
+ */
+function expiredError(recoverable = true): Error {
+  return Object.assign(new Error('access token expired'), {
+    name: 'DelegatedTokenExpiredError',
+    reason: recoverable ? 'access-token-expired' : 'refresh-token-invalid',
+    recoverableByRefresh: recoverable,
+  });
+}
+
+const HOUR = 60 * 60 * 1000;
+const NOW = new Date('2026-08-31T12:00:00.000Z');
+
+function tokenSet(expiresAt: Date, accessToken = 'access-1'): DelegatedTokenSet {
+  return {
+    accessToken,
+    refreshToken: 'refresh-1',
+    expiresAt: expiresAt.toISOString(),
+    scopes: ['AppCatalog.ReadWrite.All'],
+    clientId: 'client-1',
+    tenantId: 'tenant-1',
+  };
+}
+
+/** A live token: an hour of life left, well outside the refresh margin. */
+const FRESH = tokenSet(new Date(NOW.getTime() + HOUR));
+/** The field-test token: issued long ago, spent. */
+const SPENT = tokenSet(new Date(NOW.getTime() - HOUR));
+
+interface RefreshingCustody {
+  read(): Promise<DelegatedTokenSet | undefined>;
+  write(tokens: DelegatedTokenSet): Promise<void>;
+  readonly written: DelegatedTokenSet[];
+  readonly refreshes: DelegatedTokenSet[];
+}
+
+/**
+ * A tenant sign-in with a working vault behind it, plus the connector's
+ * `refreshDelegatedToken`.
+ *
+ * Modelled rather than scripted: the refresh really does hand back a new
+ * access token with a new expiry, so a test can assert that the SECOND call
+ * carried the rotated value instead of replaying the spent one.
+ */
+function refreshingSetup(opts: {
+  readonly stored?: DelegatedTokenSet;
+  readonly refresh?: (tokens: DelegatedTokenSet) => Promise<DelegatedTokenSet>;
+} = {}): {
+  readonly custody: RefreshingCustody;
+  readonly refreshDelegatedToken: (input: {
+    readonly tokens: DelegatedTokenSet;
+  }) => Promise<DelegatedTokenSet>;
+} {
+  let stored: DelegatedTokenSet | undefined = opts.stored ?? SPENT;
+  const written: DelegatedTokenSet[] = [];
+  const refreshes: DelegatedTokenSet[] = [];
+  const custody: RefreshingCustody = {
+    read: async () => stored,
+    write: async (tokens) => {
+      written.push(tokens);
+      stored = tokens;
+    },
+    written,
+    refreshes,
+  };
+  const refreshDelegatedToken = async ({
+    tokens,
+  }: {
+    readonly tokens: DelegatedTokenSet;
+  }): Promise<DelegatedTokenSet> => {
+    refreshes.push(tokens);
+    if (opts.refresh) return opts.refresh(tokens);
+    return tokenSet(new Date(NOW.getTime() + HOUR), 'access-2');
+  };
+  return { custody, refreshDelegatedToken };
 }
 
 function directoryOf(
@@ -203,6 +286,248 @@ describe('teams target directory — degradation', () => {
     });
 
     assert.deepEqual(result.teams, { available: true, items: [TEAM] });
+  });
+});
+
+/**
+ * THE FIELD-TEST BUG. An operator whose tenant sign-in stood, whose account
+ * was on screen, and whose chat picker said "sign in once".
+ *
+ * The chain that produced it: the stored access token was hours past its
+ * expiry, so the connector refused the enumeration on the token alone and
+ * never reached its own scope check; this service classified that refusal as
+ * `sign_in_required`; and the UI rendered the one sentence that could not
+ * possibly help — sign in, to someone already signed in.
+ *
+ * Two rules come out of it, and every test here pins one of them:
+ *
+ *   1. AN EXPIRED ACCESS TOKEN IS NOT A MISSING SIGN-IN. It is one silent
+ *      refresh away from working, and the listing now performs that refresh
+ *      itself — the same refresh the catalogue upload has always done.
+ *   2. `sign_in_required` NOW MEANS EXACTLY ONE THING: nobody is signed in.
+ *      An expiry whose refresh failed is `sign_in_expired`, which sends the
+ *      operator to the same button for a reason worth knowing.
+ */
+describe('teams target directory — an expired sign-in is not a missing one', () => {
+  it('refreshes a spent access token instead of reporting it as signed out', async () => {
+    // RED BEFORE THE FIX: `isDelegatedTokenExpiredError` mapped straight to
+    // `sign_in_required` and the listing never even tried to refresh.
+    const { custody, refreshDelegatedToken } = refreshingSetup();
+    const seen: unknown[] = [];
+
+    const result = await loadTeamsTargetDirectory({
+      now: () => NOW,
+      getProvisioner: () => ({
+        listTeams: async () => [TEAM],
+        listChats: async (input?: { tokens?: unknown }) => {
+          seen.push((input?.tokens as { accessToken?: string } | undefined)?.accessToken);
+          return [CHAT];
+        },
+        refreshDelegatedToken,
+      }),
+      delegatedTokens: custody,
+    });
+
+    assert.deepEqual(result.chats, { available: true, items: [CHAT] });
+    // The ROTATED token went to Graph, not the spent one it replaced.
+    assert.deepEqual(seen, ['access-2']);
+  });
+
+  it('persists the rotated set the moment the connector hands it over', async () => {
+    // A rotation the vault has not seen is a refresh token already spent —
+    // the tenant would be silently signed out on the next restart.
+    const { custody, refreshDelegatedToken } = refreshingSetup();
+
+    await loadTeamsTargetDirectory({
+      now: () => NOW,
+      getProvisioner: () => ({
+        listTeams: async () => [TEAM],
+        listChats: async () => [CHAT],
+        refreshDelegatedToken,
+      }),
+      delegatedTokens: custody,
+    });
+
+    assert.equal(custody.written.length, 1);
+    assert.equal(
+      (custody.written[0] as { accessToken: string }).accessToken,
+      'access-2',
+    );
+  });
+
+  it('recovers from the connector`s own expiry verdict, not just from our clock', async () => {
+    // The reactive half: our clock said the token was fine, Microsoft
+    // disagreed. That verdict is the authoritative one — a revoked session or
+    // a password change is invisible to any expiry arithmetic.
+    const { custody, refreshDelegatedToken } = refreshingSetup({ stored: FRESH });
+    let attempts = 0;
+
+    const result = await loadTeamsTargetDirectory({
+      now: () => NOW,
+      getProvisioner: () => ({
+        listTeams: async () => [TEAM],
+        listChats: async () => {
+          attempts += 1;
+          if (attempts === 1) throw expiredError();
+          return [CHAT];
+        },
+        refreshDelegatedToken,
+      }),
+      delegatedTokens: custody,
+    });
+
+    assert.deepEqual(result.chats, { available: true, items: [CHAT] });
+    assert.equal(attempts, 2, 'retried exactly once');
+  });
+
+  it('reports sign_in_expired — never sign_in_required — when the refresh fails', async () => {
+    // The admin really does have to sign in again here, but for a DIFFERENT
+    // reason than "you never signed in", and the copy has to be able to say
+    // which. Note the refresh fails with untyped prose (`invalid_grant`), and
+    // it must still not degrade into `lookup_failed` and a retry button.
+    const { custody, refreshDelegatedToken } = refreshingSetup({
+      stored: FRESH,
+      refresh: async () => {
+        throw new Error('invalid_grant');
+      },
+    });
+
+    const result = await loadTeamsTargetDirectory({
+      now: () => NOW,
+      getProvisioner: () => ({
+        listTeams: async () => [TEAM],
+        listChats: async () => {
+          throw expiredError();
+        },
+        refreshDelegatedToken,
+      }),
+      delegatedTokens: custody,
+    });
+
+    assert.deepEqual(result.chats, { available: false, reason: 'sign_in_expired' });
+    // And the half that never needed the sign-in is untouched.
+    assert.deepEqual(result.teams, { available: true, items: [TEAM] });
+  });
+
+  it('an expiry the connector calls unrecoverable is not retried', async () => {
+    const { custody, refreshDelegatedToken } = refreshingSetup({ stored: FRESH });
+    let attempts = 0;
+
+    const result = await loadTeamsTargetDirectory({
+      now: () => NOW,
+      getProvisioner: () => ({
+        listTeams: async () => [TEAM],
+        listChats: async () => {
+          attempts += 1;
+          throw expiredError(false);
+        },
+        refreshDelegatedToken,
+      }),
+      delegatedTokens: custody,
+    });
+
+    assert.deepEqual(result.chats, { available: false, reason: 'sign_in_expired' });
+    assert.equal(attempts, 1);
+    assert.equal(custody.refreshes.length, 0, 'a dead refresh token is not spent again');
+  });
+
+  it('THE FIELD-TEST CASE: a spent token that also predates the scope says scope_missing', async () => {
+    // RED BEFORE THE FIX, and this is the one the operator actually hit.
+    //
+    // Both faults are present at once: the access token is hours stale AND
+    // the credential predates `Chat.ReadBasic` (connector 0.8.0). The
+    // connector checks the token before it checks what the token is allowed
+    // to do, so the expiry is the only error that was ever thrown — the
+    // scope branch of `classifyListingFailure` was unreachable, however
+    // correctly it was ordered.
+    //
+    // Refreshing first is what makes the SECOND fault observable: with a
+    // valid access token the connector gets far enough to notice the missing
+    // scope, and the operator is finally told the true thing.
+    const { custody, refreshDelegatedToken } = refreshingSetup();
+    let attempts = 0;
+
+    const result = await loadTeamsTargetDirectory({
+      now: () => NOW,
+      getProvisioner: () => ({
+        listTeams: async () => [TEAM],
+        listChats: async (input?: { tokens?: { accessToken?: string } }) => {
+          attempts += 1;
+          // Exactly the connector's order: a token it cannot authenticate
+          // with is refused before its scopes are ever considered.
+          if (input?.tokens?.accessToken !== 'access-2') throw expiredError();
+          throw scopeError();
+        },
+        refreshDelegatedToken,
+      }),
+      delegatedTokens: custody,
+    });
+
+    assert.deepEqual(result.chats, { available: false, reason: 'scope_missing' });
+    assert.equal(attempts, 1, 'the proactive refresh spared the wasted call');
+    assert.deepEqual(result.teams, { available: true, items: [TEAM] });
+  });
+
+  it('still says sign_in_required when there is genuinely no sign-in', async () => {
+    // The narrowing must not go so far that the real thing loses its name.
+    const result = await loadTeamsTargetDirectory({
+      now: () => NOW,
+      getProvisioner: () => ({
+        listTeams: async () => [TEAM],
+        listChats: async () => {
+          throw signInError();
+        },
+      }),
+      delegatedTokens: { read: async () => undefined, write: async () => {} },
+    });
+
+    assert.deepEqual(result.chats, { available: false, reason: 'sign_in_required' });
+  });
+
+  it('NEVER refreshes without somewhere to persist the result', async () => {
+    // The safety rule of `platform/teamsDelegatedRefresh.ts`: a rotation the
+    // vault cannot record spends the refresh token for good. Not refreshing
+    // costs one bad sentence; refreshing without custody costs the tenant its
+    // sign-in.
+    let refreshed = 0;
+
+    const result = await loadTeamsTargetDirectory({
+      now: () => NOW,
+      getProvisioner: () => ({
+        listTeams: async () => [TEAM],
+        listChats: async () => {
+          throw expiredError();
+        },
+        refreshDelegatedToken: async () => {
+          refreshed += 1;
+          return FRESH as never;
+        },
+      }),
+      // READ ONLY — a pre-#949 mount, and the shape the old tests still use.
+      delegatedTokens: { read: async () => SPENT as never },
+    });
+
+    assert.equal(refreshed, 0);
+    assert.deepEqual(result.chats, { available: false, reason: 'sign_in_expired' });
+  });
+
+  it('a healthy token is left alone — no rotation on every poll', async () => {
+    // This screen polls. Refreshing a token with an hour of life left would
+    // rotate the refresh token continuously for no reason.
+    const { custody, refreshDelegatedToken } = refreshingSetup({ stored: FRESH });
+
+    await loadTeamsTargetDirectory({
+      now: () => NOW,
+      getProvisioner: () => ({
+        listTeams: async () => [TEAM],
+        listChats: async () => [CHAT],
+        refreshDelegatedToken,
+      }),
+      delegatedTokens: custody,
+    });
+
+    assert.equal(custody.refreshes.length, 0);
+    assert.equal(custody.written.length, 0);
   });
 });
 

--- a/web-ui/app/_lib/agents.ts
+++ b/web-ui/app/_lib/agents.ts
@@ -1181,13 +1181,45 @@ export function parseTeamsAssignmentCapabilities(
  * `middleware/src/services/teamsTargetDirectoryService.ts` — a closed set of
  * machine codes, each with its own sentence in `messages/*.json`.
  */
+export const TEAMS_TARGET_LISTING_UNAVAILABLE = [
+  'connector_unavailable',
+  'connector_unsupported',
+  /** NOBODY is signed in — and since #949 nothing else. */
+  'sign_in_required',
+  /**
+   * Somebody IS signed in, their access token is spent, and renewing it
+   * failed. Kept apart from `sign_in_required` because the two send an
+   * operator to the same button with completely different expectations, and
+   * folding them together is what put "sign in once" in front of an admin
+   * whose account was on screen.
+   */
+  'sign_in_expired',
+  'scope_missing',
+  'consent_required',
+  'lookup_failed',
+] as const;
+
 export type TeamsTargetListingUnavailable =
-  | 'connector_unavailable'
-  | 'connector_unsupported'
-  | 'sign_in_required'
-  | 'scope_missing'
-  | 'consent_required'
-  | 'lookup_failed';
+  (typeof TEAMS_TARGET_LISTING_UNAVAILABLE)[number];
+
+/**
+ * Is this a reason this build has a sentence for?
+ *
+ * A RUNTIME check and not merely a cast, because the middleware ships
+ * independently of this bundle: a server that learns a new reason code before
+ * the UI does would otherwise hand it straight to `t()` and render a missing
+ * translation key at the operator. Degrading to `lookup_failed` is honest —
+ * we could not look, and we cannot say why — and it is exactly how
+ * `sign_in_expired` itself would have surfaced on an older build.
+ */
+export function isTeamsTargetListingUnavailable(
+  value: unknown,
+): value is TeamsTargetListingUnavailable {
+  return (
+    typeof value === 'string' &&
+    (TEAMS_TARGET_LISTING_UNAVAILABLE as readonly string[]).includes(value)
+  );
+}
 
 /**
  * A listing that can say "I don't know".
@@ -1241,10 +1273,9 @@ function parseTargetListing<T>(
     const reason = record['reason'];
     return {
       available: false,
-      reason:
-        typeof reason === 'string'
-          ? (reason as TeamsTargetListingUnavailable)
-          : 'lookup_failed',
+      // Validated, not cast — see `isTeamsTargetListingUnavailable`. A code
+      // this build has no sentence for must not reach `t()`.
+      reason: isTeamsTargetListingUnavailable(reason) ? reason : 'lookup_failed',
     };
   }
   const raw = record['items'];
@@ -1310,9 +1341,27 @@ export async function getAgentTeamsTargets(
   };
 }
 
+/**
+ * HOW FAR BACK a teardown winds the agent — mirrors `TeamsResetScope`.
+ *
+ * `'run'` empties Azure and returns the row to `pending`, keeping the bot
+ * slug and display name so a retry is one button. `'identity'` does the same
+ * Azure teardown and then removes the row, so the agent has no Teams identity
+ * at all and the operator picks a new slug and name from an empty form —
+ * `bot_slug` is `UNIQUE`, so nothing less frees the name.
+ */
+export type TeamsResetScope = 'run' | 'identity';
+
 /** One step of a teardown — mirrors `TeamsResetStepReport`. */
 export interface TeamsResetStepDto {
-  step: 'catalog_removed' | 'bot_deleted' | 'app_deleted' | 'identity_reset';
+  step:
+    | 'catalog_removed'
+    | 'bot_deleted'
+    | 'app_deleted'
+    /** The `'run'` scope's last step: the row is back at `pending`. */
+    | 'identity_reset'
+    /** The `'identity'` scope's last step: the row is gone. */
+    | 'identity_deleted';
   outcome: 'removed' | 'already-absent' | 'skipped' | 'blocked' | 'failed';
   detail?: string;
 }
@@ -1321,6 +1370,9 @@ export interface ResetAgentTeamsIdentityResponse {
   ok: boolean;
   agent: string;
   status: 'reset' | 'incomplete';
+  /** Echoed by the server so the report cannot be read against the wrong
+   *  copy if a poll and a reset ever cross. */
+  scope?: TeamsResetScope;
   previous_state?: string;
   steps: readonly TeamsResetStepDto[];
   stoppedAt?: TeamsResetStepDto['step'];
@@ -1331,8 +1383,14 @@ export interface ResetAgentTeamsIdentityResponse {
  * `POST /v1/operator/agents/:slug/teams-identity/reset` — DESTRUCTIVE.
  *
  * Removes the Entra app registration (delete AND recycle-bin purge), the
- * Azure bot and the tenant catalog entry, then returns the row to `pending`
- * keeping `bot_slug` and `display_name`.
+ * Azure bot and the tenant catalog entry. What happens to the identity row
+ * afterwards is the `scope`'s business — see {@link TeamsResetScope}.
+ *
+ * THE SCOPE IS ALWAYS SENT EXPLICITLY, including the default. The server
+ * treats a missing one as `'run'` for the sake of clients written before
+ * scopes existed, and relying on that here would make the destructive call
+ * and the safe one differ by an omission rather than by a value — the kind of
+ * difference that survives a refactor in the wrong direction.
  *
  * A PARTIAL TEARDOWN RESOLVES, IT DOES NOT REJECT. `status: 'incomplete'`
  * comes back as a 200 with the per-step report, because "which of the three
@@ -1341,10 +1399,15 @@ export interface ResetAgentTeamsIdentityResponse {
  */
 export async function resetAgentTeamsIdentity(
   slug: string,
+  scope: TeamsResetScope = 'run',
 ): Promise<ResetAgentTeamsIdentityResponse> {
   const dto = await callJson<ResetAgentTeamsIdentityResponse>(
     `/v1/operator/agents/${encodeURIComponent(slug)}/teams-identity/reset`,
-    { method: 'POST' },
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ scope }),
+    },
   );
   return { ...dto, steps: Array.isArray(dto.steps) ? dto.steps : [] };
 }

--- a/web-ui/app/operator/agents/[slug]/__tests__/AgentTeamsIdentity.test.tsx
+++ b/web-ui/app/operator/agents/[slug]/__tests__/AgentTeamsIdentity.test.tsx
@@ -24,9 +24,10 @@ import { AgentTeamsIdentity } from '../_components/AgentTeamsIdentity';
  *   - Raw API bodies never reach the UI (web-ui i18n hard rule).
  */
 
-const { mockGet, mockProvision } = vi.hoisted(() => ({
+const { mockGet, mockProvision, mockResetIdentity } = vi.hoisted(() => ({
   mockGet: vi.fn(),
   mockProvision: vi.fn(),
+  mockResetIdentity: vi.fn(),
 }));
 
 // Spread the real module so the error-code parser and the last_error narrower
@@ -36,6 +37,10 @@ vi.mock('../../../../_lib/agents', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../../_lib/agents')>()),
   getAgentTeamsIdentity: mockGet,
   provisionAgentTeamsIdentity: mockProvision,
+  // Stubbed only so the teardown control inside this panel does not reach the
+  // network. Its own behaviour is pinned in `AgentTeamsIdentityReset.test.tsx`;
+  // what THIS file cares about is what the panel does once the row is gone.
+  resetAgentTeamsIdentity: mockResetIdentity,
 }));
 
 function statusDto(
@@ -75,6 +80,14 @@ function apiError(status: number, code: string): ApiError {
 beforeEach(() => {
   mockGet.mockReset();
   mockProvision.mockReset();
+  mockResetIdentity.mockReset();
+  mockResetIdentity.mockResolvedValue({
+    ok: true,
+    agent: 'sales-bot',
+    status: 'reset',
+    scope: 'identity',
+    steps: [{ step: 'identity_deleted', outcome: 'removed' }],
+  });
   mockGet.mockResolvedValue(statusDto());
 });
 
@@ -369,5 +382,52 @@ describe('AgentTeamsIdentity (#860 W2a)', () => {
     expect(
       screen.queryByRole('button', { name: 'Re-run provisioning' }),
     ).toBeNull();
+  });
+
+  it('offers the ordinary create form again once the identity has been deleted', async () => {
+    // THE WHOLE POINT OF THE FULL RESET, asserted end to end through the
+    // panel rather than trusted to the two halves separately.
+    //
+    // The chain is: the teardown drops the row → the panel re-reads → the
+    // server answers 404 `teams_identity_not_found` → that is this panel's
+    // CREATE signal. Which means the operator does not merely get a "provision
+    // again" button carrying the old slug (what a `'run'` reset leaves them
+    // with), but the empty form, with a bot slug and a display name they can
+    // choose freely. Nothing else in the UI can offer that: every other path
+    // through a `ready` row renders both as read-only facts.
+    mockGet.mockResolvedValueOnce(statusDto({ state: 'failed', running: false }));
+    mockGet.mockRejectedValue(apiError(404, 'teams_identity_not_found'));
+    renderWithIntl(<AgentTeamsIdentity slug="sales-bot" />);
+
+    await screen.findByText('State: failed');
+    // Delete the identity, exactly as the reset panel does it.
+    await userEvent.click(
+      screen.getByRole('button', { name: /Delete the identity …/i }),
+    );
+    await userEvent.click(
+      within(screen.getByTestId('teams-reset-confirm-identity')).getByRole(
+        'checkbox',
+      ),
+    );
+    await userEvent.type(
+      within(screen.getByTestId('teams-reset-confirm-identity')).getByRole(
+        'textbox',
+      ),
+      'sales-bot',
+    );
+    await userEvent.click(
+      screen.getByRole('button', { name: /Delete the identity for good/i }),
+    );
+
+    const slugField = await screen.findByLabelText(/Bot slug/);
+    const nameField = screen.getByLabelText(/Display name/);
+    expect(screen.getByRole('button', { name: 'Start provisioning' })).toBeTruthy();
+
+    // FREELY CHOOSABLE, not merely present: both accept a value that is not
+    // the one the deleted identity carried.
+    await userEvent.type(slugField, 'renamed-bot');
+    await userEvent.type(nameField, 'Renamed Bot');
+    expect(slugField).toHaveValue('renamed-bot');
+    expect(nameField).toHaveValue('Renamed Bot');
   });
 });

--- a/web-ui/app/operator/agents/[slug]/__tests__/AgentTeamsIdentityReset.test.tsx
+++ b/web-ui/app/operator/agents/[slug]/__tests__/AgentTeamsIdentityReset.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -7,20 +7,24 @@ import type { ResetAgentTeamsIdentityResponse } from '../../../../_lib/agents';
 import { AgentTeamsIdentityReset } from '../_components/AgentTeamsIdentityReset';
 
 /**
- * The destructive control.
+ * The destructive controls.
  *
  * What is worth pinning here is not the rendering but the SAFETY and the
  * HONESTY:
  *
- *  - the teardown is never one click, and the first click only reveals what
+ *  - neither teardown is ever one click, and the first click only reveals what
  *    the second would destroy;
  *  - the consequences are named one by one (app registration, bot, catalog
  *    entry, installs) — an operator approving a deletion is entitled to the
- *    list — and so is the reassurance that the bot slug survives, because
- *    that is what tells them this is a retry and not a restart;
+ *    list — and so is the statement of what SURVIVES, which is the single
+ *    fact that separates the two variants;
+ *  - THE TWO ARE NOT INTERCHANGEABLE and must not be confusable. Resetting the
+ *    run keeps the bot slug; deleting the identity frees it. The second one
+ *    therefore costs more than a checkbox: the operator has to type the slug,
+ *    which is the one confirmation nobody performs by reflex;
  *  - a PARTIAL teardown renders per step. "Reset failed" as the only signal
  *    is what sends somebody into two Azure portals to find out what is left;
- *  - a run in flight locks the control, so nobody is invited into a 409.
+ *  - a run in flight locks the controls, so nobody is invited into a 409.
  */
 
 const { mockReset } = vi.hoisted(() => ({ mockReset: vi.fn() }));
@@ -30,16 +34,40 @@ vi.mock('../../../../_lib/agents', async (importOriginal) => ({
   resetAgentTeamsIdentity: mockReset,
 }));
 
+const BOT_SLUG = 'sales-bot-01';
+
+const OPEN_RUN = /Reset the run …|Lauf zurücksetzen …/i;
+const OPEN_IDENTITY = /Delete the identity …|Identität löschen …/i;
+const CONFIRM_RUN = /^(Reset the run|Lauf zurücksetzen)$/;
+const CONFIRM_IDENTITY =
+  /Delete the identity for good|Identität endgültig löschen/i;
+
 function complete(): ResetAgentTeamsIdentityResponse {
   return {
     ok: true,
     agent: 'sales-bot',
     status: 'reset',
+    scope: 'run',
     steps: [
       { step: 'catalog_removed', outcome: 'removed' },
       { step: 'bot_deleted', outcome: 'removed' },
       { step: 'app_deleted', outcome: 'removed' },
       { step: 'identity_reset', outcome: 'removed' },
+    ],
+  };
+}
+
+function completeIdentity(): ResetAgentTeamsIdentityResponse {
+  return {
+    ok: true,
+    agent: 'sales-bot',
+    status: 'reset',
+    scope: 'identity',
+    steps: [
+      { step: 'catalog_removed', outcome: 'removed' },
+      { step: 'bot_deleted', outcome: 'removed' },
+      { step: 'app_deleted', outcome: 'removed' },
+      { step: 'identity_deleted', outcome: 'removed' },
     ],
   };
 }
@@ -51,6 +79,7 @@ function render(props: { state?: string; running?: boolean } = {}): {
   renderWithIntl(
     <AgentTeamsIdentityReset
       slug="sales-bot"
+      botSlug={BOT_SLUG}
       state={props.state ?? 'failed'}
       running={props.running ?? false}
       onDone={onDone}
@@ -59,11 +88,18 @@ function render(props: { state?: string; running?: boolean } = {}): {
   return { onDone };
 }
 
-/** Open the panel and tick the acknowledgement — the two steps that stand
- *  between an operator and a deletion. */
-async function arm(): Promise<void> {
-  await userEvent.click(screen.getByRole('button', { name: /zurücksetzen …|reset …/i }));
+/** Open the milder panel and tick the acknowledgement — the two steps that
+ *  stand between an operator and a teardown. */
+async function armRun(): Promise<void> {
+  await userEvent.click(screen.getByRole('button', { name: OPEN_RUN }));
   await userEvent.click(screen.getByRole('checkbox'));
+}
+
+/** Open the destructive panel and clear BOTH of its gates. */
+async function armIdentity(): Promise<void> {
+  await userEvent.click(screen.getByRole('button', { name: OPEN_IDENTITY }));
+  await userEvent.click(screen.getByRole('checkbox'));
+  await userEvent.type(screen.getByRole('textbox'), BOT_SLUG);
 }
 
 beforeEach(() => {
@@ -72,29 +108,30 @@ beforeEach(() => {
 });
 
 describe('AgentTeamsIdentityReset — the confirmation', () => {
-  it('does not offer a teardown for an identity that never provisioned anything', () => {
+  it('offers only the identity deletion for a row that never provisioned anything', () => {
     render({ state: 'pending' });
 
-    // A destructive control that would be a no-op only teaches operators that
-    // the scary button is harmless.
-    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    // Resetting the RUN would be a no-op — there is nothing in Azure — and a
+    // scary button that does nothing teaches operators that scary buttons are
+    // harmless. Deleting the identity is a different matter: the row still
+    // holds a UNIQUE bot slug, and this is the only way to free it.
+    expect(screen.queryByRole('button', { name: OPEN_RUN })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: OPEN_IDENTITY })).toBeInTheDocument();
   });
 
-  it('never resets on a single click', async () => {
+  it('never tears down on a single click, in either variant', async () => {
     render();
 
-    await userEvent.click(
-      screen.getByRole('button', { name: /zurücksetzen …|reset …/i }),
-    );
+    await userEvent.click(screen.getByRole('button', { name: OPEN_RUN }));
+    expect(mockReset).not.toHaveBeenCalled();
 
+    await userEvent.click(screen.getByRole('button', { name: OPEN_IDENTITY }));
     expect(mockReset).not.toHaveBeenCalled();
   });
 
   it('names every Azure object it is about to delete', async () => {
     render();
-    await userEvent.click(
-      screen.getByRole('button', { name: /zurücksetzen …|reset …/i }),
-    );
+    await userEvent.click(screen.getByRole('button', { name: OPEN_RUN }));
 
     const note = screen.getByRole('note');
     expect(note).toHaveTextContent(/Entra/i);
@@ -107,49 +144,164 @@ describe('AgentTeamsIdentityReset — the confirmation', () => {
 
   it('keeps the confirm button locked until the acknowledgement is ticked', async () => {
     render();
-    await userEvent.click(
-      screen.getByRole('button', { name: /zurücksetzen …|reset …/i }),
-    );
+    await userEvent.click(screen.getByRole('button', { name: OPEN_RUN }));
 
-    const confirm = screen.getByRole('button', {
-      name: /endgültig zurücksetzen|reset for good/i,
-    });
+    const confirm = screen.getByRole('button', { name: CONFIRM_RUN });
     expect(confirm).toBeDisabled();
 
     await userEvent.click(screen.getByRole('checkbox'));
     expect(confirm).toBeEnabled();
   });
 
-  it('resets once armed, and asks the panel to re-read the row', async () => {
+  it('resets the run once armed, and asks the panel to re-read the row', async () => {
     const { onDone } = render();
-    await arm();
+    await armRun();
 
-    await userEvent.click(
-      screen.getByRole('button', { name: /endgültig zurücksetzen|reset for good/i }),
+    await userEvent.click(screen.getByRole('button', { name: CONFIRM_RUN }));
+
+    await waitFor(() =>
+      expect(mockReset).toHaveBeenCalledWith('sales-bot', 'run'),
     );
-
-    await waitFor(() => expect(mockReset).toHaveBeenCalledWith('sales-bot'));
     // The teardown rewrote the row underneath the panel; rendering the state
     // it just tore down would be stale by definition.
     expect(onDone).toHaveBeenCalled();
   });
 
-  it('locks the control while a provisioning run is in flight', () => {
+  it('locks both controls while a provisioning run is in flight', () => {
     render({ running: true });
 
-    expect(
-      screen.getByRole('button', { name: /zurücksetzen …|reset …/i }),
-    ).toBeDisabled();
+    expect(screen.getByRole('button', { name: OPEN_RUN })).toBeDisabled();
+    expect(screen.getByRole('button', { name: OPEN_IDENTITY })).toBeDisabled();
+  });
+
+  it('shows one confirmation at a time, never two with different consequences', async () => {
+    render();
+
+    await userEvent.click(screen.getByRole('button', { name: OPEN_RUN }));
+    expect(screen.getByTestId('teams-reset-confirm-run')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: OPEN_IDENTITY }));
+    expect(screen.getByTestId('teams-reset-confirm-identity')).toBeInTheDocument();
+    expect(screen.queryByTestId('teams-reset-confirm-run')).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * THE DESTRUCTIVE VARIANT — the one that throws away answers a human gave
+ * rather than identifiers Azure handed back, and therefore has to be harder
+ * to trigger and impossible to mistake for the other one.
+ */
+describe('AgentTeamsIdentityReset — deleting the identity', () => {
+  it('says the slug and the name go too, in as many words', async () => {
+    render();
+    await userEvent.click(screen.getByRole('button', { name: OPEN_IDENTITY }));
+
+    const note = screen.getByTestId('teams-reset-confirm-identity');
+    // The one fact that separates the two teardowns must be stated, not
+    // implied by the absence of the reassurance the other one carries.
+    expect(note).toHaveTextContent(/NOT kept|NICHT behalten/i);
+    expect(note).toHaveTextContent(/freely choosable|frei wählbar/i);
+  });
+
+  it('needs the bot slug TYPED, not just a checkbox', async () => {
+    render();
+    await userEvent.click(screen.getByRole('button', { name: OPEN_IDENTITY }));
+
+    const confirm = screen.getByRole('button', { name: CONFIRM_IDENTITY });
+    await userEvent.click(screen.getByRole('checkbox'));
+    // The acknowledgement alone arms the MILD reset. It must not arm this one.
+    expect(confirm).toBeDisabled();
+
+    await userEvent.type(screen.getByRole('textbox'), BOT_SLUG);
+    expect(confirm).toBeEnabled();
+  });
+
+  it('refuses a slug that is not this identity`s, and says so', async () => {
+    render();
+    await userEvent.click(screen.getByRole('button', { name: OPEN_IDENTITY }));
+    await userEvent.click(screen.getByRole('checkbox'));
+    await userEvent.type(screen.getByRole('textbox'), 'sales-bot-02');
+
+    expect(screen.getByRole('button', { name: CONFIRM_IDENTITY })).toBeDisabled();
+    expect(screen.getByTestId('teams-reset-confirm-identity')).toHaveTextContent(
+      /not the bot slug|stimmt nicht überein/i,
+    );
+  });
+
+  it('sends the identity scope — never silently the milder one', async () => {
+    // The two differ by a VALUE and not by an omission, precisely so this
+    // assertion can exist.
+    const { onDone } = render();
+    await armIdentity();
+
+    await userEvent.click(screen.getByRole('button', { name: CONFIRM_IDENTITY }));
+
+    await waitFor(() =>
+      expect(mockReset).toHaveBeenCalledWith('sales-bot', 'identity'),
+    );
+    expect(onDone).toHaveBeenCalled();
+  });
+
+  it('tells the operator the identity can now be created afresh', async () => {
+    // THE POINT OF THE WHOLE FEATURE. After this the panel's parent re-reads
+    // the row, gets a 404, and renders the create form with an empty slug —
+    // so the success line has to promise exactly that and not the milder
+    // "you can provision again with the same name".
+    mockReset.mockResolvedValue(completeIdentity());
+
+    render();
+    await armIdentity();
+    await userEvent.click(screen.getByRole('button', { name: CONFIRM_IDENTITY }));
+
+    const report = await screen.findByTestId('teams-reset-report');
+    expect(report).toHaveTextContent(/new bot slug|neuen Bot-Slug/i);
+    // And the row step is reported as the deletion it was.
+    expect(report.querySelectorAll('li')).toHaveLength(4);
+  });
+
+  it('explains a refusal to drop the row rather than reporting a bare failure', async () => {
+    // The subtle refusal: Azure is clean, but nobody could prove the app
+    // registration is gone, and the row is the only trace left pointing at
+    // it. The operator has to understand that this is a deliberate stop.
+    mockReset.mockResolvedValue({
+      ok: false,
+      agent: 'sales-bot',
+      status: 'incomplete',
+      scope: 'identity',
+      stoppedAt: 'identity_deleted',
+      detail: 'app_trace_required',
+      steps: [
+        { step: 'catalog_removed', outcome: 'removed' },
+        { step: 'bot_deleted', outcome: 'removed' },
+        {
+          step: 'app_deleted',
+          outcome: 'already-absent',
+          detail: 'app_absent_unpurgeable',
+        },
+        {
+          step: 'identity_deleted',
+          outcome: 'blocked',
+          detail: 'app_trace_required',
+        },
+      ],
+    } satisfies ResetAgentTeamsIdentityResponse);
+
+    render();
+    await armIdentity();
+    await userEvent.click(screen.getByRole('button', { name: CONFIRM_IDENTITY }));
+
+    const report = await screen.findByTestId('teams-reset-report');
+    expect(report).toHaveTextContent(/only trace|einzige Spur/i);
+    // And it points at the way forward that DOES work.
+    expect(report).toHaveTextContent(/reset the run|Lauf zurücksetzen/i);
   });
 });
 
 describe('AgentTeamsIdentityReset — the report', () => {
   it('renders each step of a completed teardown', async () => {
     render();
-    await arm();
-    await userEvent.click(
-      screen.getByRole('button', { name: /endgültig zurücksetzen|reset for good/i }),
-    );
+    await armRun();
+    await userEvent.click(screen.getByRole('button', { name: CONFIRM_RUN }));
 
     const report = await screen.findByTestId('teams-reset-report');
     expect(report.querySelectorAll('li')).toHaveLength(4);
@@ -163,6 +315,7 @@ describe('AgentTeamsIdentityReset — the report', () => {
       ok: false,
       agent: 'sales-bot',
       status: 'incomplete',
+      scope: 'run',
       stoppedAt: 'app_deleted',
       detail: 'purge_unsupported',
       steps: [
@@ -173,16 +326,43 @@ describe('AgentTeamsIdentityReset — the report', () => {
     } satisfies ResetAgentTeamsIdentityResponse);
 
     render();
-    await arm();
-    await userEvent.click(
-      screen.getByRole('button', { name: /endgültig zurücksetzen|reset for good/i }),
-    );
+    await armRun();
+    await userEvent.click(screen.getByRole('button', { name: CONFIRM_RUN }));
 
     const report = await screen.findByTestId('teams-reset-report');
     expect(report.querySelectorAll('li')).toHaveLength(3);
     // The blocked step explains the refusal — including WHY not deleting was
     // the right move, which is the least obvious part of the whole feature.
     expect(report).toHaveTextContent(/30 Tage|30 days/);
+  });
+
+  it('names an expired tenant sign-in as expired, not as a missing one', async () => {
+    // The teardown's half of the field-test bug: the catalog withdrawal is
+    // delegated-only and runs first, so a spent token used to abort the whole
+    // reset. Now it refreshes — and when even that fails, the copy has to say
+    // "your sign-in expired", never "sign in", to someone already signed in.
+    mockReset.mockResolvedValue({
+      ok: false,
+      agent: 'sales-bot',
+      status: 'incomplete',
+      scope: 'run',
+      stoppedAt: 'catalog_removed',
+      detail: 'tenant_sign_in_expired',
+      steps: [
+        {
+          step: 'catalog_removed',
+          outcome: 'blocked',
+          detail: 'tenant_sign_in_expired',
+        },
+      ],
+    } satisfies ResetAgentTeamsIdentityResponse);
+
+    render();
+    await armRun();
+    await userEvent.click(screen.getByRole('button', { name: CONFIRM_RUN }));
+
+    const report = await screen.findByTestId('teams-reset-report');
+    expect(report).toHaveTextContent(/expired|abgelaufen/i);
   });
 
   it('falls back to the raw detail for a code it has no sentence for', async () => {
@@ -192,6 +372,7 @@ describe('AgentTeamsIdentityReset — the report', () => {
       ok: false,
       agent: 'sales-bot',
       status: 'incomplete',
+      scope: 'run',
       stoppedAt: 'catalog_removed',
       detail: 'catalog_removal_failed: boom',
       steps: [
@@ -204,10 +385,8 @@ describe('AgentTeamsIdentityReset — the report', () => {
     } satisfies ResetAgentTeamsIdentityResponse);
 
     render();
-    await arm();
-    await userEvent.click(
-      screen.getByRole('button', { name: /endgültig zurücksetzen|reset for good/i }),
-    );
+    await armRun();
+    await userEvent.click(screen.getByRole('button', { name: CONFIRM_RUN }));
 
     expect(await screen.findByTestId('teams-reset-report')).toHaveTextContent(
       /catalog_removal_failed: boom/,
@@ -218,13 +397,24 @@ describe('AgentTeamsIdentityReset — the report', () => {
     mockReset.mockRejectedValue(new Error('teams_provisioning_running'));
 
     render();
-    await arm();
-    await userEvent.click(
-      screen.getByRole('button', { name: /endgültig zurücksetzen|reset for good/i }),
-    );
+    await armRun();
+    await userEvent.click(screen.getByRole('button', { name: CONFIRM_RUN }));
 
     expect(await screen.findByRole('alert')).toHaveTextContent(
       /teams_provisioning_running/,
     );
+  });
+
+  it('does not leak the previous panel`s arming into the next teardown', async () => {
+    // A confirmation that stayed ticked after a completed teardown would make
+    // the NEXT one a single click.
+    render();
+    await armRun();
+    await userEvent.click(screen.getByRole('button', { name: CONFIRM_RUN }));
+    await screen.findByTestId('teams-reset-report');
+
+    await userEvent.click(screen.getByRole('button', { name: OPEN_RUN }));
+    expect(screen.getByRole('button', { name: CONFIRM_RUN })).toBeDisabled();
+    expect(within(screen.getByRole('note')).getByRole('checkbox')).not.toBeChecked();
   });
 });

--- a/web-ui/app/operator/agents/[slug]/__tests__/TeamsTargetPicker.test.tsx
+++ b/web-ui/app/operator/agents/[slug]/__tests__/TeamsTargetPicker.test.tsx
@@ -244,6 +244,25 @@ describe('TeamsTargetPicker — degrading without lying', () => {
     expect(notes[0]).toHaveTextContent(/Chat\.ReadBasic/);
   });
 
+  it('tells an EXPIRED sign-in apart from a missing one', async () => {
+    // THE FIELD-TEST BUG, from the copy's side. An operator whose tenant
+    // sign-in stood, whose account was on screen, and who was told to "sign
+    // in once" — because the middleware reported a spent access token as
+    // `sign_in_required`. The server now refreshes such a token, and reserves
+    // this code for a refresh that FAILED. The sentence has to say the
+    // sign-in expired: the action is the same button, but a person who has
+    // just used it needs to know why the first time stopped counting.
+    render(dto({ chats: { available: false, reason: 'sign_in_expired' } }));
+
+    const notes = await screen.findAllByRole('note');
+    expect(notes).toHaveLength(1);
+    expect(notes[0]).toHaveTextContent(/expired|abgelaufen/i);
+    // And it must NOT read as "nobody has signed in".
+    expect(notes[0]).not.toHaveTextContent(
+      /fehlt die Tenant-Anmeldung|no tenant sign-in/i,
+    );
+  });
+
   it('distinguishes an empty tenant from an unavailable listing', () => {
     render(dto({ teams: { available: true, items: [] } }));
 

--- a/web-ui/app/operator/agents/[slug]/_components/AgentTeamsIdentity.tsx
+++ b/web-ui/app/operator/agents/[slug]/_components/AgentTeamsIdentity.tsx
@@ -421,6 +421,7 @@ function ReadyPanel(props: {
           cannot find is a cleanup they do by hand in the Azure portal. */}
       <AgentTeamsIdentityReset
         slug={props.slug}
+        botSlug={status.identity.bot_slug}
         state={status.state}
         running={status.running}
         onDone={props.onReloaded}

--- a/web-ui/app/operator/agents/[slug]/_components/AgentTeamsIdentityReset.tsx
+++ b/web-ui/app/operator/agents/[slug]/_components/AgentTeamsIdentityReset.tsx
@@ -7,25 +7,36 @@ import { Button } from '@/app/_components/ui/Button';
 import {
   resetAgentTeamsIdentity,
   type ResetAgentTeamsIdentityResponse,
+  type TeamsResetScope,
   type TeamsResetStepDto,
 } from '@/app/_lib/agents';
 
 /**
- * Undo a Teams provisioning run — the destructive one.
+ * Undo a Teams provisioning run — the destructive controls.
  *
- * WHAT IT ACTUALLY DOES, which is why the confirmation is not a formality:
- * it deletes the agent's Entra app registration (delete AND recycle-bin
- * purge), its Azure bot service and the tenant catalog entry, then returns
- * the row to `pending`. `bot_slug` and `display_name` survive — they are the
- * only two fields a human typed, and keeping them is what makes the retry one
- * button with the same slug.
+ * TWO WAYS BACK, AND THEY ARE NOT THE SAME SIZE. Both delete the agent's
+ * Entra app registration (delete AND recycle-bin purge), its Azure bot
+ * service and the tenant catalog entry. They differ in what happens to the
+ * identity afterwards:
  *
- * THE CONFIRMATION FOLLOWS `AgentContextMemory`'s PATTERN, deliberately: an
- * inline consequences panel plus an acknowledgement checkbox that gates the
- * button. Not a `window.confirm`, which cannot list three things and cannot be
- * translated, and not a modal, which this codebase does not use for in-panel
- * actions. Two clicks minimum, and the first one only reveals what the second
- * would destroy.
+ *   * RESET THE RUN keeps `bot_slug` and `display_name` — the only two fields
+ *     a human typed — and returns the row to `pending`. The retry is one
+ *     button with the same name. This is what an operator wants when a run
+ *     died in the middle.
+ *   * DELETE THE IDENTITY removes the row as well, so the agent has no Teams
+ *     identity at all and the create form comes back empty. `bot_slug` is
+ *     `UNIQUE`, so this is the ONLY way to free a name — which is what an
+ *     operator wants when the identity itself was the mistake.
+ *
+ * TELLING THEM APART IS THIS COMPONENT'S REAL JOB. They sit side by side with
+ * different labels, and the confirmations are deliberately unequal:
+ *
+ *   * the milder one is gated by a checkbox, as it always was;
+ *   * the destructive one ALSO requires the operator to type the bot slug.
+ *     Typing the name of the thing you are about to make unrecoverable is the
+ *     one confirmation a person cannot perform by reflex, and it is
+ *     proportionate here precisely because this is the button that throws
+ *     away answers a human gave rather than identifiers Azure handed back.
  *
  * THE RESULT IS A PER-STEP REPORT, NOT A VERDICT. A teardown can genuinely
  * half-succeed — the catalog entry withdrawn, the app registration blocked
@@ -37,11 +48,14 @@ import {
 
 export interface AgentTeamsIdentityResetProps {
   readonly slug: string;
-  /** The chain state the row is in — a `pending` identity has nothing to tear
-   *  down and does not get the control at all. */
+  /** The bot slug the operator has to type to confirm the destructive
+   *  variant — and the value that variant exists to set free. */
+  readonly botSlug: string;
+  /** The chain state the row is in. A `pending` identity has nothing in Azure
+   *  to tear down, so it is offered only the identity deletion. */
   readonly state: string;
-  /** A run in flight. The server refuses in this case regardless; the button
-   *  is disabled so the operator is not invited into a 409. */
+  /** A run in flight. The server refuses in this case regardless; the buttons
+   *  are disabled so the operator is not invited into a 409. */
   readonly running: boolean;
   readonly onDone: () => void;
 }
@@ -57,32 +71,43 @@ function outcomeTone(outcome: TeamsResetStepDto['outcome']): string {
 
 export function AgentTeamsIdentityReset({
   slug,
+  botSlug,
   state,
   running,
   onDone,
 }: AgentTeamsIdentityResetProps): React.JSX.Element | null {
   const t = useTranslations('operatorAgents.teamsReset');
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState<TeamsResetScope | null>(null);
   const [acknowledged, setAcknowledged] = useState(false);
+  const [typedSlug, setTypedSlug] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [report, setReport] = useState<ResetAgentTeamsIdentityResponse | null>(
     null,
   );
 
-  // A row that never provisioned anything has nothing to remove, and offering
-  // a destructive control that would be a no-op only teaches operators that
-  // the scary button is harmless.
-  if (state === 'pending') return null;
+  // A row that never provisioned anything has nothing in Azure to remove, so
+  // the RUN reset would be a no-op — and a scary button that does nothing
+  // only teaches operators that scary buttons are harmless.
+  //
+  // The identity deletion is a different matter and stays offered: the row
+  // still holds a UNIQUE bot slug, and an operator who typed a name they
+  // regret before ever starting a run has no other way to free it.
+  const offersRunReset = state !== 'pending';
 
-  async function run(): Promise<void> {
+  function closePanel(): void {
+    setOpen(null);
+    setAcknowledged(false);
+    setTypedSlug('');
+  }
+
+  async function run(scope: TeamsResetScope): Promise<void> {
     setBusy(true);
     setError(null);
     try {
-      const res = await resetAgentTeamsIdentity(slug);
+      const res = await resetAgentTeamsIdentity(slug, scope);
       setReport(res);
-      setOpen(false);
-      setAcknowledged(false);
+      closePanel();
       onDone();
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : String(err));
@@ -91,20 +116,43 @@ export function AgentTeamsIdentityReset({
     }
   }
 
+  function toggle(scope: TeamsResetScope): void {
+    // Opening the other variant REPLACES the panel rather than stacking a
+    // second one, so there is never a moment where two confirmations with
+    // different consequences are both on screen.
+    setOpen((prev) => (prev === scope ? null : scope));
+    setAcknowledged(false);
+    setTypedSlug('');
+  }
+
+  const slugConfirmed = typedSlug.trim() === botSlug;
+  const destructive = open === 'identity';
+  const armed = acknowledged && (!destructive || slugConfirmed);
+
   return (
     <div className="mt-3 rounded border border-[color:var(--border)] p-3">
       <div className="flex flex-wrap items-center gap-2">
         <span className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[color:var(--fg-muted)]">
           {t('heading')}
         </span>
-        <div className="ml-auto">
+        <div className="ml-auto flex flex-wrap items-center gap-2">
+          {offersRunReset && (
+            <Button
+              size="sm"
+              variant="ghost"
+              disabled={running || busy}
+              onClick={() => toggle('run')}
+            >
+              {open === 'run' ? t('cancel') : t('openRun')}
+            </Button>
+          )}
           <Button
             size="sm"
             variant="ghost"
             disabled={running || busy}
-            onClick={() => setOpen((prev) => !prev)}
+            onClick={() => toggle('identity')}
           >
-            {open ? t('cancel') : t('open')}
+            {open === 'identity' ? t('cancel') : t('openIdentity')}
           </Button>
         </div>
       </div>
@@ -112,13 +160,14 @@ export function AgentTeamsIdentityReset({
         {running ? t('runningHint') : t('hint')}
       </p>
 
-      {open && (
+      {open !== null && (
         <div
           role="note"
+          data-testid={`teams-reset-confirm-${open}`}
           className="mt-3 rounded border border-[color:var(--border)] bg-[color:var(--bg)] p-3 text-xs"
         >
           <p className="mb-2 font-medium text-[color:var(--fg-strong)]">
-            {t('confirmHeading')}
+            {destructive ? t('confirmHeadingIdentity') : t('confirmHeading')}
           </p>
           {/* Named one by one rather than as "all Azure resources". An
               operator approving a deletion is entitled to the list. */}
@@ -127,11 +176,18 @@ export function AgentTeamsIdentityReset({
             <li>{t('consequenceBot')}</li>
             <li>{t('consequenceCatalog')}</li>
             <li>{t('consequenceInstalls')}</li>
+            {/* The extra thing the destructive variant throws away, spelled
+                out as its own bullet because it is the ONLY difference and
+                burying it in a paragraph is how the two get confused. */}
+            {destructive && <li>{t('consequenceIdentity')}</li>}
           </ul>
-          {/* The reassuring half, and it is load-bearing: knowing the slug
-              survives is what tells the operator this is a retry, not a
-              restart from a blank form. */}
-          <p className="mb-3 text-[color:var(--fg-muted)]">{t('keepsHint')}</p>
+          {/* The half that says what SURVIVES. Load-bearing in both
+              directions: for the run reset it tells the operator this is a
+              retry rather than a restart from a blank form, and for the
+              identity deletion it tells them the blank form is the point. */}
+          <p className="mb-3 text-[color:var(--fg-muted)]">
+            {destructive ? t('dropsHint') : t('keepsHint')}
+          </p>
           <label className="mb-3 flex cursor-pointer items-start gap-2 text-[color:var(--fg-strong)]">
             <input
               type="checkbox"
@@ -140,17 +196,39 @@ export function AgentTeamsIdentityReset({
               disabled={busy}
               onChange={(e) => setAcknowledged(e.target.checked)}
             />
-            <span>{t('acknowledge')}</span>
+            <span>{destructive ? t('acknowledgeIdentity') : t('acknowledge')}</span>
           </label>
+          {/* THE SECOND GATE, and only on the destructive variant. A checkbox
+              can be ticked without reading; the slug has to be read off the
+              panel above and typed. */}
+          {destructive && (
+            <label className="mb-3 flex flex-col gap-1 text-[color:var(--fg-strong)]">
+              <span>{t('slugConfirmLabel', { slug: botSlug })}</span>
+              <input
+                type="text"
+                autoComplete="off"
+                spellCheck={false}
+                className="w-full rounded border border-[color:var(--border)] bg-[color:var(--bg)] px-2 py-1 font-mono text-[color:var(--fg-strong)]"
+                value={typedSlug}
+                disabled={busy}
+                onChange={(e) => setTypedSlug(e.target.value)}
+              />
+              {typedSlug !== '' && !slugConfirmed && (
+                <span className="text-[color:var(--danger)]">
+                  {t('slugMismatch')}
+                </span>
+              )}
+            </label>
+          )}
           <Button
             size="sm"
             variant="secondary"
             busy={busy}
             busyLabel={t('busy')}
-            disabled={!acknowledged || busy || running}
-            onClick={() => void run()}
+            disabled={!armed || busy || running}
+            onClick={() => void run(open)}
           >
-            {t('confirm')}
+            {destructive ? t('confirmIdentity') : t('confirmRun')}
           </Button>
         </div>
       )}
@@ -171,7 +249,9 @@ export function AgentTeamsIdentityReset({
             }
           >
             {report.status === 'reset'
-              ? t('resultComplete')
+              ? report.scope === 'identity'
+                ? t('resultCompleteIdentity')
+                : t('resultComplete')
               : t('resultIncomplete', {
                   step: t(`steps.${report.stoppedAt ?? 'identity_reset'}`),
                 })}

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -2336,7 +2336,8 @@
           "sign_in_required": "Für die Teamliste fehlt die Tenant-Anmeldung. Melde dich einmal an oder trage die ID unten ein.",
           "scope_missing": "Die gespeicherte Anmeldung kennt die Berechtigung {scope} noch nicht. Eine erneute Anmeldung schaltet die Liste frei.",
           "consent_required": "Dem Tenant fehlt die Zustimmung zum Auflisten von Teams. Bis dahin trage die ID unten ein.",
-          "lookup_failed": "Die Teamliste konnte gerade nicht geladen werden. Lade die Seite neu oder trage die ID unten ein."
+          "lookup_failed": "Die Teamliste konnte gerade nicht geladen werden. Lade die Seite neu oder trage die ID unten ein.",
+          "sign_in_expired": "Die Tenant-Anmeldung ist abgelaufen und ließ sich nicht automatisch erneuern. Melde dich einmal neu an oder trage die ID unten ein."
         },
         "chats": {
           "connector_unavailable": "Ohne aktiven M365-Connector gibt es keine Chatliste — trage die ID unten von Hand ein.",
@@ -2344,7 +2345,8 @@
           "sign_in_required": "Chats lassen sich nur mit einer Tenant-Anmeldung auflisten — Graph bietet dafür keinen App-Zugriff an. Melde dich einmal an oder trage die Chat-ID unten ein.",
           "scope_missing": "Die gespeicherte Anmeldung kennt die Berechtigung {scope} noch nicht und kann sie nicht nachträglich erneuern. Eine einmalige neue Anmeldung schaltet die Chatliste frei; bis dahin trage die Chat-ID unten ein.",
           "consent_required": "Dem Tenant fehlt die Zustimmung zum Auflisten von Chats. Bis dahin trage die Chat-ID unten ein.",
-          "lookup_failed": "Die Chatliste konnte gerade nicht geladen werden. Lade die Seite neu oder trage die Chat-ID unten ein."
+          "lookup_failed": "Die Chatliste konnte gerade nicht geladen werden. Lade die Seite neu oder trage die Chat-ID unten ein.",
+          "sign_in_expired": "Die Tenant-Anmeldung ist abgelaufen und ließ sich nicht automatisch erneuern — das ist keine fehlende Anmeldung, sondern eine, die nicht mehr gilt. Melde dich einmal neu an oder trage die Chat-ID unten ein."
         }
       },
       "filter": "Tippen zum Filtern …",
@@ -2353,7 +2355,6 @@
     },
     "teamsReset": {
       "heading": "Provisionierung zurücksetzen",
-      "open": "Zurücksetzen …",
       "cancel": "Abbrechen",
       "hint": "Räumt die in Azure angelegten Objekte ab, damit ein neuer Versuch mit demselben Slug starten kann.",
       "runningHint": "Solange eine Provisionierung läuft, ist das Zurücksetzen gesperrt — warte, bis der Lauf fertig ist.",
@@ -2364,7 +2365,6 @@
       "consequenceInstalls": "Alle hier vermerkten Team- und Chat-Installationen.",
       "keepsHint": "Bot-Slug und Anzeigename bleiben erhalten — ein neuer Lauf startet direkt mit denselben Angaben.",
       "acknowledge": "Ich habe verstanden, dass diese Azure-Objekte gelöscht werden und neu angelegt werden müssen.",
-      "confirm": "Endgültig zurücksetzen",
       "busy": "Wird zurückgesetzt …",
       "resultComplete": "Zurückgesetzt. Der Agent kann jetzt erneut provisioniert werden.",
       "resultIncomplete": "Abgebrochen bei „{step}“ — alles davor ist abgeräumt, der Rest steht noch. Ein erneuter Aufruf macht dort weiter.",
@@ -2373,7 +2373,8 @@
         "catalog_removed": "Katalogeintrag",
         "bot_deleted": "Azure-Bot",
         "app_deleted": "App-Registrierung",
-        "identity_reset": "Datenbankzeile"
+        "identity_reset": "Datenbankzeile",
+        "identity_deleted": "Identität"
       },
       "outcomes": {
         "removed": "entfernt",
@@ -2389,8 +2390,21 @@
         "purge_unsupported": "Der installierte Connector kann den Papierkorb nicht leeren. Die App-Registrierung wurde deshalb absichtlich NICHT gelöscht: sie würde ihren Namen sonst 30 Tage blockieren.",
         "app_absent_unpurgeable": "Die App-Registrierung ist bereits weg, ließ sich aber nicht mehr im Papierkorb nachschlagen. Sie könnte den Namen noch bis zu 30 Tage belegen — wähle im Zweifel einen anderen Bot-Slug.",
         "app_provably_gone": "Die App-Registrierung ist weg und liegt auch nicht im Papierkorb — der Name ist wieder frei.",
-        "arm_not_configured": "Ohne ARM-Konfiguration wurde nie ein Bot-Dienst angelegt."
-      }
+        "arm_not_configured": "Ohne ARM-Konfiguration wurde nie ein Bot-Dienst angelegt.",
+        "tenant_sign_in_expired": "Die Tenant-Anmeldung ist abgelaufen und ließ sich nicht automatisch erneuern. Melde dich einmal neu an und starte das Zurücksetzen erneut — eine zusätzliche Berechtigung ist dafür nicht nötig.",
+        "app_trace_required": "Die Identität bleibt bestehen: Die App-Registrierung ließ sich nicht im Papierkorb nachschlagen, und die Zeile ist die einzige Spur zu ihr. Nutze „Lauf zurücksetzen“ oder aktualisiere den Connector, damit der Papierkorb geprüft werden kann."
+      },
+      "openRun": "Lauf zurücksetzen …",
+      "openIdentity": "Identität löschen …",
+      "confirmHeadingIdentity": "Das wird unwiderruflich gelöscht — inklusive der Identität selbst:",
+      "consequenceIdentity": "Die Teams-Identität dieses Orchestrators samt Bot-Slug und Anzeigename. Beides ist danach wieder frei wählbar.",
+      "dropsHint": "Bot-Slug und Anzeigename werden NICHT behalten. Der Orchestrator hat danach keine Teams-Identität mehr, und das Anlegen beginnt wieder mit einem leeren Formular.",
+      "acknowledgeIdentity": "Ich habe verstanden, dass zusätzlich die Identität entfernt wird und Bot-Slug und Anzeigename neu vergeben werden müssen.",
+      "confirmRun": "Lauf zurücksetzen",
+      "confirmIdentity": "Identität endgültig löschen",
+      "slugConfirmLabel": "Tippe zur Bestätigung den Bot-Slug „{slug}“ ein:",
+      "slugMismatch": "Der eingegebene Bot-Slug stimmt nicht überein.",
+      "resultCompleteIdentity": "Identität gelöscht. Der Orchestrator kann jetzt mit einem neuen Bot-Slug und Anzeigenamen angelegt werden."
     }
   },
   "builder": {

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -2336,7 +2336,8 @@
           "sign_in_required": "The team list needs the tenant sign-in. Sign in once, or type the id below.",
           "scope_missing": "The stored sign-in does not yet carry the {scope} permission. Signing in again unlocks the list.",
           "consent_required": "The tenant has not consented to listing teams. Until it does, type the id below.",
-          "lookup_failed": "The team list could not be loaded just now. Reload the page, or type the id below."
+          "lookup_failed": "The team list could not be loaded just now. Reload the page, or type the id below.",
+          "sign_in_expired": "The tenant sign-in expired and could not be renewed automatically. Sign in once more, or type the id below."
         },
         "chats": {
           "connector_unavailable": "Without an active M365 connector there is no chat list — type the id into the field below.",
@@ -2344,7 +2345,8 @@
           "sign_in_required": "Chats can only be listed with a tenant sign-in — Graph offers no app-only route for them. Sign in once, or type the chat id below.",
           "scope_missing": "The stored sign-in does not yet carry the {scope} permission and cannot pick it up by refreshing. One fresh sign-in unlocks the chat list; until then type the chat id below.",
           "consent_required": "The tenant has not consented to listing chats. Until it does, type the chat id below.",
-          "lookup_failed": "The chat list could not be loaded just now. Reload the page, or type the chat id below."
+          "lookup_failed": "The chat list could not be loaded just now. Reload the page, or type the chat id below.",
+          "sign_in_expired": "The tenant sign-in expired and could not be renewed automatically — that is not a missing sign-in but one that stopped being valid. Sign in once more, or type the chat id below."
         }
       },
       "filter": "Type to filter …",
@@ -2353,7 +2355,6 @@
     },
     "teamsReset": {
       "heading": "Reset provisioning",
-      "open": "Reset …",
       "cancel": "Cancel",
       "hint": "Clears up the objects created in Azure so a new attempt can start with the same slug.",
       "runningHint": "While a provisioning run is in flight the reset is locked — wait for the run to finish.",
@@ -2364,7 +2365,6 @@
       "consequenceInstalls": "Every team and chat install recorded here.",
       "keepsHint": "Bot slug and display name are kept — a new run starts from the same answers.",
       "acknowledge": "I understand these Azure objects are deleted and will have to be created again.",
-      "confirm": "Reset for good",
       "busy": "Resetting …",
       "resultComplete": "Reset. The agent can be provisioned again now.",
       "resultIncomplete": "Stopped at “{step}” — everything before it is cleared, the rest is still there. Calling it again picks up from that point.",
@@ -2373,7 +2373,8 @@
         "catalog_removed": "Catalog entry",
         "bot_deleted": "Azure bot",
         "app_deleted": "App registration",
-        "identity_reset": "Database row"
+        "identity_reset": "Database row",
+        "identity_deleted": "Identity"
       },
       "outcomes": {
         "removed": "removed",
@@ -2389,8 +2390,21 @@
         "purge_unsupported": "The installed connector cannot empty the recycle bin. The app registration was therefore deliberately NOT deleted: it would block its own name for 30 days.",
         "app_absent_unpurgeable": "The app registration is already gone but could no longer be looked up in the recycle bin. It may still hold the name for up to 30 days — pick a different bot slug if in doubt.",
         "app_provably_gone": "The app registration is gone and is not in the recycle bin either — the name is free again.",
-        "arm_not_configured": "Without ARM configured, no bot service was ever created."
-      }
+        "arm_not_configured": "Without ARM configured, no bot service was ever created.",
+        "tenant_sign_in_expired": "The tenant sign-in expired and could not be renewed automatically. Sign in once more and start the reset again — no extra permission is needed for it.",
+        "app_trace_required": "The identity is kept: the app registration could not be looked up in the recycle bin, and this row is the only trace of it. Use \"reset the run\", or upgrade the connector so the recycle bin can be searched."
+      },
+      "openRun": "Reset the run …",
+      "openIdentity": "Delete the identity …",
+      "confirmHeadingIdentity": "This is deleted for good — the identity itself included:",
+      "consequenceIdentity": "This orchestrator's Teams identity, bot slug and display name included. Both are freely choosable again afterwards.",
+      "dropsHint": "Bot slug and display name are NOT kept. The orchestrator has no Teams identity afterwards, and creating one starts from an empty form again.",
+      "acknowledgeIdentity": "I understand that the identity is removed as well, and that a bot slug and display name have to be chosen again.",
+      "confirmRun": "Reset the run",
+      "confirmIdentity": "Delete the identity for good",
+      "slugConfirmLabel": "Type the bot slug \"{slug}\" to confirm:",
+      "slugMismatch": "That is not the bot slug of this identity.",
+      "resultCompleteIdentity": "Identity deleted. The orchestrator can be created again with a new bot slug and display name."
     }
   },
   "builder": {


### PR DESCRIPTION
An operator who was signed in was told to sign in. The message was not badly worded — it was the wrong branch, and the right one was unreachable.

## Why the wrong message won

The classifier in `teamsTargetDirectoryService.ts` puts `scope_missing` first, ahead of `sign_in_required`. That ordering is correct and it never mattered: **ordering cannot choose between errors that are never thrown, and only one error was ever thrown.**

1. The token store does not refuse an expired token set — it parses the envelope and hands the tokens over. So the chat listing really was called *with* the operator's credentials; "no tokens" was never the case.
2. The connector validates a token before it considers what that token is *allowed* to do. A credential it cannot authenticate with never reaches a scope check, so it raised `DelegatedTokenExpiredError` — not `DelegatedScopeRequiredError`.
3. That was mapped to `sign_in_required`, and the UI rendered "sign in once".

So the expiry masked the scope problem entirely, and `scope_missing` — whose copy existed and was accurate — had nothing that could route to it.

**The fix is the refresh, not a reclassification.** With a live access token the connector gets far enough to notice the missing `Chat.ReadBasic`, raises `DelegatedScopeRequiredError`, and the operator finally reads the true statement: a permission is missing, sign in once more. Pinned by a test that is red without the fix.

## One refresh, three call sites

`platform/teamsDelegatedRefresh.ts` now holds the arithmetic once: proactive refresh on the clock, reactive refresh-and-retry-once on Microsoft's verdict, every rotation persisted immediately. The provisioning job uses it instead of owning the only correct copy — behaviour-preserving, its 100 tests unchanged.

Two policies are encoded there rather than at each caller. A failing *proactive* refresh is swallowed and the stored token is used anyway, because our clock is the more likely thing to be wrong. And **no write port means no refresh at all**: a rotation the vault never sees is a spent refresh token and a tenant that is silently signed out at the next call.

`sign_in_required` now means only "nobody is signed in". A refresh that fails is the new `sign_in_expired`, which is a different sentence because it needs a different action.

**A third site had the same confusion, and it is the one this operator hit.** `removeCatalogEntry` runs first in the reset and halts everything, so a spent token aborted an entire teardown behind raw `catalog_removal_failed:` prose. It now refreshes, and reports `tenant_sign_in_expired` as `blocked` rather than `failed` when that cannot help.

## The full reset

`scope: 'run' | 'identity'` on the reset endpoint, defaulting to `run`. **Both are kept**, because the wrong one is expensive in each direction: `run` on a badly chosen slug leaves an operator unable to change it, and `identity` on a run that died mid-chain makes them retype two fields they had right. The cost is one enum value and one confirmation variant — the three Azure steps are literally the same code.

The price of keeping both is distinguishability, so: separate labelled buttons, only one panel open at a time, and the destructive variant requires **typing the bot slug** in addition to the checkbox.

### Not leaving corpses behind

Steps 1–3 already halted on `failed` and `blocked`. The hole was `app_absent_unpurgeable`, reported as a *success* while actually meaning "I could not look". Since `app_id` is the only input `findDeletedAppRegistration` accepts, dropping the row there strands a tombstone that holds the `uniqueName` for 30 days with nothing left able to name it.

The full reset now stops there with `app_trace_required` and keeps the row. The milder reset still completes, because it keeps the row regardless.

No migration needed: a plain `DELETE`, and migration 0051 already documents identity deletion as the way to unprovision. The events timeline is removed explicitly rather than as a swallowed FK cascade.

## Verification

middleware: **8083 tests, 8067 pass, 0 fail**; typecheck, `typecheck:test` (ratchet 370, no regressions), lint and build all clean. web-ui: **1112 pass, 0 fail** across 119 files; typecheck, lint and `i18n:check` (4348 keys) clean.

The seven new listing tests were confirmed red before the fix, with the fourteen pre-existing ones green throughout.

## Known limits

Connector 0.8.0 could not be read locally — the checkout sits at 0.2.4 — so step 2 above is inferred from the middleware code plus the symptom. The symptom is itself the evidence: had the connector checked scopes first, the operator would already have seen `scope_missing`.

`TeamsTargetPicker` passes a hardcoded `Chat.ReadBasic` into the *teams* half too, which is wrong for a team-listing failure. Pre-existing, untouched here. A stale `teams_bots` entry in the channel-teams config survives a full reset — the same pre-existing gap the milder reset has.

Refs #860, #924.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790744113&installation_model_id=428086&pr_number=962&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F962&signature=902218c08665fb4a4875cc959ab121e13607c73a43f422a1c3e9c7d0e0b97b24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->