### PR TITLE
fix: stop refusing the group chats Graph itself hands us

### DIFF
--- a/middleware/src/platform/teamsInstallTarget.ts
+++ b/middleware/src/platform/teamsInstallTarget.ts
@@ -21,10 +21,11 @@
  * owns the wider question "what KIND of thing is this, and can we install into
  * it at all".
  *
- * THE FIVE SHAPES, AND WHY THE LAST TWO ARE NOT INSTALL TARGETS
- * ------------------------------------------------------------
+ * THE SHAPES, AND WHY THE LAST TWO ARE NOT INSTALL TARGETS
+ * -------------------------------------------------------
  *   `<guid>`                  team          → POST /teams/{id}/installedApps
  *   `19:…@thread.v2`          group chat    → POST /chats/{id}/installedApps
+ *   `19:…@thread.skype`       group chat    → POST /chats/{id}/installedApps
  *   `19:…@unq.gbl.spaces`     1:1 chat      → POST /chats/{id}/installedApps
  *   `19:…@thread.tacv2`       CHANNEL       → refused, with the fix named
  *   32 bare hex               ambiguous     → see the concession below
@@ -34,6 +35,23 @@
  * channel of it — a wider blast radius than the operator asked for, produced
  * by a guess. So it is named as the mistake it is and the team id is pointed
  * at instead.
+ *
+ * `@thread.skype` IS THE OLD SPELLING OF A GROUP CHAT
+ * --------------------------------------------------
+ * Teams threads minted before the `v2` split all end `@thread.skype`; the
+ * split later gave channels `@thread.tacv2` and group chats `@thread.v2`, and
+ * older conversations kept the original suffix. The tenant chat listing
+ * (`GET /me/chats`, behind the target picker) returns them with
+ * `chatType: 'group'` and a member roster — Graph itself calling them chats —
+ * and this module used to answer `'unrecognised'` for exactly those ids. The
+ * picker offered a chat the field then refused.
+ *
+ * A legacy CHANNEL id wears the same suffix, and no part of the string
+ * separates the two. This reads it as a chat, because the two mistakes do not
+ * cost the same: a channel id sent to `/chats/{id}` buys one refused Graph
+ * call, while refusing the suffix blocks a chat the operator picked from a
+ * list we produced. The `@thread.tacv2` channel refusal above is unaffected —
+ * that shape is unambiguous, which is why it can still be refused on sight.
  *
  * THE ONE CONCESSION: BARE 32-HEX
  * -------------------------------
@@ -95,6 +113,8 @@ export type TeamsTargetClassification =
  */
 const CHANNEL_SUFFIX = /@thread\.tacv2$/i;
 const GROUP_CHAT_SUFFIX = /@thread\.v2$/i;
+/** The pre-`v2` spelling of {@link GROUP_CHAT_SUFFIX} — see the header. */
+const LEGACY_GROUP_CHAT_SUFFIX = /@thread\.skype$/i;
 const ONE_ON_ONE_SUFFIX = /@unq\.gbl\.spaces$/i;
 
 /** Every conversation id Teams hands out starts with the `19:` prefix. */
@@ -116,6 +136,10 @@ const BARE_GUID = /^[0-9a-fA-F]{32}$/;
 export const TEAMS_TARGET_EXAMPLES = {
   team: '2f1a9c44-1f0e-4f2c-8f1a-9c441f0e4f2c',
   groupChat: '19:a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6@thread.v2',
+  /** The same thing, spelled the way Teams spelled it before the v2 split —
+   *  listed because tenants still hold plenty of them, not as an alternative
+   *  an operator would ever choose. */
+  legacyGroupChat: '19:a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6@thread.skype',
   oneOnOneChat: '19:a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d_00000000-0000-0000-0000-000000000000@unq.gbl.spaces',
 } as const;
 
@@ -132,6 +156,7 @@ export function classifyTeamsInstallTarget(value: string): TeamsTargetClassifica
   if (CONVERSATION_PREFIX.test(id)) {
     if (CHANNEL_SUFFIX.test(id)) return { kind: 'channel', id };
     if (GROUP_CHAT_SUFFIX.test(id)) return { kind: 'group-chat', id };
+    if (LEGACY_GROUP_CHAT_SUFFIX.test(id)) return { kind: 'group-chat', id };
     if (ONE_ON_ONE_SUFFIX.test(id)) return { kind: 'one-on-one-chat', id };
     // A `19:` id with a suffix we do not know is NOT quietly treated as a
     // chat: Teams has more conversation kinds than this module handles, and
@@ -158,6 +183,35 @@ export function classifyTeamsInstallTarget(value: string): TeamsTargetClassifica
 
 /** Why {@link resolveTeamsInstallTarget} refused. */
 export type TeamsTargetRejection = 'channel' | 'ambiguous' | 'unrecognised';
+
+/**
+ * A target the TENANT DIRECTORY named, rather than a string a human typed.
+ *
+ * WHY THIS TYPE EXISTS — AND WHY IT IS NOT AN OPTIMISATION.
+ * {@link classifyTeamsInstallTarget} exists to read strings whose provenance
+ * is unknown, which is why it has an `'ambiguous'` verdict at all: guessing
+ * about a hand-typed id is the failure this module was written after.
+ *
+ * An id that came out of `listTeams` / `listChats` is not that kind of string.
+ * Graph produced it AND said what it was — a team, a group chat, a 1:1 chat.
+ * Running it back through a suffix table throws that answer away and re-derives
+ * a worse one, and the `@thread.skype` regression is what that costs: the
+ * picker offered a chat Graph had just classified, and the pattern list, which
+ * had never heard of the suffix, called it unusable. Every id shape Microsoft
+ * adds next breaks us the same way, at the exact moment the operator did
+ * everything right.
+ *
+ * SELF-INVALIDATING BY CONSTRUCTION. The known kind is bound to the exact id
+ * it was known for. {@link resolveTeamsInstallTarget} honours it only while
+ * `id` still equals the value being resolved, so editing the field puts the
+ * kind back up for classification without anyone having to remember to clear
+ * it. A stale claim cannot outlive the string it was a claim about.
+ */
+export interface KnownTeamsInstallTarget {
+  /** The id the directory reported — the claim is void for any other value. */
+  readonly id: string;
+  readonly kind: TeamsTargetKind;
+}
 
 export type ResolvedTeamsInstallTarget =
   | {
@@ -193,9 +247,33 @@ export type ResolvedTeamsInstallTarget =
  *
  * So the refusal carries BOTH readings, and the caller asks the one party who
  * actually knows which was meant.
+ *
+ * `known` SHORT-CIRCUITS THE GUESSING, AND ONLY THE GUESSING. When the caller
+ * can say where the id came from — {@link KnownTeamsInstallTarget}, i.e. the
+ * tenant directory — that answer is better than anything a suffix table can
+ * derive, and it is used. Two limits keep it honest:
+ *
+ *   1. The claim is bound to its id (see the type). Any other value ignores it.
+ *   2. A `'channel'` classification still wins. That is the one shape whose
+ *      misreading has a WIDER audience than the operator asked for, and the
+ *      directory never lists channels — so a claim over a `@thread.tacv2` id
+ *      cannot have come from a listing and is not treated as though it had.
+ *
+ * Everything else the claim may override, because the only thing `kind`
+ * decides downstream is `/teams/{id}` versus `/chats/{id}` — two tenant-scoped
+ * endpoints Graph re-authorises on its own. A wrong kind buys a refused call,
+ * never a wider install.
  */
-export function resolveTeamsInstallTarget(value: string): ResolvedTeamsInstallTarget {
+export function resolveTeamsInstallTarget(
+  value: string,
+  known?: KnownTeamsInstallTarget,
+): ResolvedTeamsInstallTarget {
   const classified = classifyTeamsInstallTarget(value);
+
+  if (known !== undefined && known.id === value.trim() && classified.kind !== 'channel') {
+    return { ok: true, kind: known.kind, id: known.id };
+  }
+
   switch (classified.kind) {
     case 'team':
     case 'group-chat':

--- a/middleware/src/routes/operatorAgents.ts
+++ b/middleware/src/routes/operatorAgents.ts
@@ -226,6 +226,21 @@ const TeamsIdentityProvisionSchema = z.object({
   // field-test failure. `resolveTeamsInstallTarget` decides the kind FIRST and
   // normalises only what is actually a team.
   team_id: z.string().min(1).max(200),
+  /**
+   * WHERE `team_id` CAME FROM, when it came from the tenant directory.
+   *
+   * The operator picks a team or a chat out of `GET /:slug/teams-targets`,
+   * which is Graph's own listing — so Graph already said what each entry is.
+   * Re-deriving that from the id's suffix is how a legacy
+   * `19:…@thread.skype` group chat, offered by our own picker, came back as
+   * "not a Teams install target": the pattern list had never heard of the
+   * suffix and the listing's answer had been thrown away.
+   *
+   * Optional, because a hand-typed id has no provenance to declare and must
+   * still be classified. `resolveTeamsInstallTarget` binds the claim to this
+   * exact `team_id` and never lets it override a channel verdict.
+   */
+  target_kind: z.enum(['team', 'group-chat', 'one-on-one-chat']).optional(),
   bot_slug: z
     .string()
     .regex(
@@ -244,6 +259,21 @@ const TeamsIdentityProvisionSchema = z.object({
 const TeamsInstallSchema = z.object({
   /** See the note on {@link TeamsIdentityProvisionSchema.team_id}. */
   team_id: z.string().min(1).max(200),
+  /**
+   * WHERE `team_id` CAME FROM, when it came from the tenant directory.
+   *
+   * The operator picks a team or a chat out of `GET /:slug/teams-targets`,
+   * which is Graph's own listing — so Graph already said what each entry is.
+   * Re-deriving that from the id's suffix is how a legacy
+   * `19:…@thread.skype` group chat, offered by our own picker, came back as
+   * "not a Teams install target": the pattern list had never heard of the
+   * suffix and the listing's answer had been thrown away.
+   *
+   * Optional, because a hand-typed id has no provenance to declare and must
+   * still be classified. `resolveTeamsInstallTarget` binds the claim to this
+   * exact `team_id` and never lets it override a channel verdict.
+   */
+  target_kind: z.enum(['team', 'group-chat', 'one-on-one-chat']).optional(),
 });
 
 // ---------------------------------------------------------------------------
@@ -1075,13 +1105,25 @@ function rejectedRunDetail(result: unknown): string | null {
  * something about their id was wrong. Deciding it HERE means the answer
  * arrives in the same request, before anything is provisioned.
  *
+ * `knownKind` IS THE DIRECTORY'S ANSWER, NOT A HINT. When the body carries
+ * `target_kind`, the operator picked this id out of `GET /:slug/teams-targets`
+ * and Graph had already said what it was. Passing it on is what stops the
+ * middleware from re-guessing what the listing knew — the failure that made a
+ * legacy `19:…@thread.skype` group chat unpickable even though our own picker
+ * had offered it. `resolveTeamsInstallTarget` binds the claim to this exact
+ * string and still refuses a channel, so the guarantee above survives it.
+ *
  * Returns `null` when it has already answered `res`.
  */
 function resolveInstallTargetOrRefuse(
   res: Response,
   raw: string,
+  knownKind?: TeamsTargetKind,
 ): { readonly id: string; readonly kind: TeamsTargetKind } | null {
-  const target = resolveTeamsInstallTarget(raw);
+  const target = resolveTeamsInstallTarget(
+    raw,
+    knownKind === undefined ? undefined : { id: raw.trim(), kind: knownKind },
+  );
   if (target.ok) return { id: target.id, kind: target.kind };
 
   if (target.reason === 'channel') {
@@ -1116,11 +1158,12 @@ function resolveInstallTargetOrRefuse(
 
   res.status(400).json({
     error: 'teams_target_unrecognised',
-    message: `'${raw.trim()}' is not a Teams install target — expected a team (group) id, a group chat id (19:…@thread.v2) or a 1:1 chat id (19:…@unq.gbl.spaces).`,
+    message: `'${raw.trim()}' is not a Teams install target — expected a team (group) id, a group chat id (19:…@thread.v2, or 19:…@thread.skype for one created before the v2 split) or a 1:1 chat id (19:…@unq.gbl.spaces).`,
     target_id: raw.trim(),
     examples: {
       team: TEAMS_TARGET_EXAMPLES.team,
       group_chat: TEAMS_TARGET_EXAMPLES.groupChat,
+      legacy_group_chat: TEAMS_TARGET_EXAMPLES.legacyGroupChat,
       one_on_one_chat: TEAMS_TARGET_EXAMPLES.oneOnOneChat,
     },
   });
@@ -2194,7 +2237,7 @@ export function createOperatorAgentsRouter(
       // Decide WHAT the pasted id addresses before anything is written or
       // compared: a channel id and an unusable string are answered here, and
       // a team id is normalised to the form Graph accepts.
-      const target = resolveInstallTargetOrRefuse(res, body.team_id);
+      const target = resolveInstallTargetOrRefuse(res, body.team_id, body.target_kind);
       if (!target) return;
       if (refuseUnsupportedChatTarget(res, deps, target.kind)) return;
       const current = await deps.store.getByAgentId(existing.id);
@@ -2820,7 +2863,7 @@ export function createOperatorAgentsRouter(
       // first, because neither depends on what the target id says. Only then
       // is the id decided — and only then can a chat target be refused for a
       // connector that is present but too old (501, not 503).
-      const target = resolveInstallTargetOrRefuse(res, body.team_id);
+      const target = resolveInstallTargetOrRefuse(res, body.team_id, body.target_kind);
       if (!target) return;
       if (refuseUnsupportedChatTarget(res, deps, target.kind)) return;
       // Already installed HERE? With the bindings table that is a lookup in

--- a/middleware/test/teamsInstallTarget.test.ts
+++ b/middleware/test/teamsInstallTarget.test.ts
@@ -19,6 +19,7 @@ import { describe, it } from 'node:test';
 
 import {
   classifyTeamsInstallTarget,
+  isChatTarget,
   resolveTeamsInstallTarget,
   TEAMS_TARGET_EXAMPLES,
 } from '../src/platform/teamsInstallTarget.js';
@@ -165,8 +166,110 @@ describe('TEAMS_TARGET_EXAMPLES', () => {
       'group-chat',
     );
     assert.equal(
+      classifyTeamsInstallTarget(TEAMS_TARGET_EXAMPLES.legacyGroupChat).kind,
+      'group-chat',
+    );
+    assert.equal(
       classifyTeamsInstallTarget(TEAMS_TARGET_EXAMPLES.oneOnOneChat).kind,
       'one-on-one-chat',
     );
+  });
+});
+
+describe('the legacy @thread.skype group chat', () => {
+  // REGRESSION. The tenant chat listing behind the target picker returns these
+  // ids with `chatType: 'group'`; the classifier answered 'unrecognised' for
+  // them, so the picker offered a chat the field underneath it refused. The
+  // id below is the one an operator actually picked.
+  const LEGACY = '19:abc8af8ec7fc471785d3b83c4d84b667@thread.skype';
+
+  it('classifies as a group chat, not as unrecognised', () => {
+    const classified = classifyTeamsInstallTarget(LEGACY);
+    assert.equal(classified.kind, 'group-chat');
+    assert.equal(classified.id, LEGACY);
+  });
+
+  it('resolves to a chat install target', () => {
+    const target = resolveTeamsInstallTarget(LEGACY);
+    assert.ok(target.ok);
+    assert.equal(target.kind, 'group-chat');
+    assert.equal(isChatTarget(target.kind), true);
+  });
+
+  it('matches the suffix whatever its casing', () => {
+    assert.equal(
+      classifyTeamsInstallTarget('19:ABC@THREAD.SKYPE').kind,
+      'group-chat',
+    );
+  });
+
+  it('still tells @thread.skype apart from the channel suffix', () => {
+    // The two legacy-looking suffixes are NOT interchangeable: a channel is
+    // refused on sight and that must not have loosened.
+    assert.equal(
+      classifyTeamsInstallTarget('19:abc@thread.tacv2').kind,
+      'channel',
+    );
+  });
+});
+
+describe('resolveTeamsInstallTarget with a directory-known kind', () => {
+  // THE STRUCTURAL HALF. An id out of `listTeams` / `listChats` arrives with
+  // its kind already decided by Graph. Re-deriving it from the suffix is what
+  // made the case above possible, and would make the NEXT id shape Microsoft
+  // mints fail exactly the same way.
+  const UNKNOWN_SHAPE = '19:something@thread.futurev9';
+
+  it('accepts a shape the pattern table cannot read', () => {
+    assert.equal(classifyTeamsInstallTarget(UNKNOWN_SHAPE).kind, 'unrecognised');
+
+    const target = resolveTeamsInstallTarget(UNKNOWN_SHAPE, {
+      id: UNKNOWN_SHAPE,
+      kind: 'group-chat',
+    });
+    assert.ok(target.ok, 'a listed target must not need the heuristic');
+    assert.equal(target.kind, 'group-chat');
+    assert.equal(target.id, UNKNOWN_SHAPE);
+  });
+
+  it('drops the claim once the value no longer matches it', () => {
+    // What "editing the field puts the kind back up for classification" means
+    // in code: the claim is bound to the id it was made about.
+    const edited = resolveTeamsInstallTarget('19:something-else@thread.futurev9', {
+      id: UNKNOWN_SHAPE,
+      kind: 'group-chat',
+    });
+    assert.equal(edited.ok, false);
+    assert.equal(edited.ok === false && edited.reason, 'unrecognised');
+  });
+
+  it('resolves the bare-32-hex ambiguity when the directory named it', () => {
+    const bare = 'abc8af8ec7fc471785d3b83c4d84b667';
+    assert.equal(resolveTeamsInstallTarget(bare).ok, false);
+
+    const named = resolveTeamsInstallTarget(bare, { id: bare, kind: 'team' });
+    assert.ok(named.ok);
+    assert.equal(named.kind, 'team');
+  });
+
+  it('REFUSES a channel even when the caller claims a chat', () => {
+    // The one veto the claim cannot lift: installing "the channel's team"
+    // reaches every channel of that team. The directory never lists channels,
+    // so this claim cannot have come from one.
+    const target = resolveTeamsInstallTarget('19:abc@thread.tacv2', {
+      id: '19:abc@thread.tacv2',
+      kind: 'group-chat',
+    });
+    assert.equal(target.ok, false);
+    assert.equal(target.ok === false && target.reason, 'channel');
+  });
+
+  it('ignores surrounding whitespace the way the classifier does', () => {
+    const target = resolveTeamsInstallTarget(`  ${UNKNOWN_SHAPE}  `, {
+      id: UNKNOWN_SHAPE,
+      kind: 'group-chat',
+    });
+    assert.ok(target.ok);
+    assert.equal(target.id, UNKNOWN_SHAPE);
   });
 });

--- a/web-ui/app/_lib/__tests__/teamsInstallTarget.test.ts
+++ b/web-ui/app/_lib/__tests__/teamsInstallTarget.test.ts
@@ -1,0 +1,112 @@
+/**
+ * The browser-side install-target verdict — the label under the field, and the
+ * gate on the submit button.
+ *
+ * TWO THINGS ARE PINNED HERE, and they are the two halves of one bug.
+ *
+ * ONE: `19:…@thread.skype` is a group chat. It is the pre-`v2` spelling, the
+ * tenant chat listing returns plenty of them, and this module used to call
+ * them unrecognised — so the picker offered a chat and the field beneath it
+ * announced that the chat was not an install target.
+ *
+ * TWO, and the one that outlives the suffix: an id that came out of the
+ * listing does not need classifying at all. Graph said what it was. The
+ * heuristic exists for strings a human typed, where guessing is the danger;
+ * running a listed id back through it discards a better answer and re-derives
+ * a worse one — and every id shape Microsoft mints next breaks the picker the
+ * same way. So the directory's answer wins, bound to the exact id it was
+ * about, which is what makes an edit put the kind back up for classification.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  classifyKnownTeamsTarget,
+  classifyTeamsInstallTarget,
+  isSubmittableTarget,
+  TEAMS_TARGET_EXAMPLES,
+} from '../teamsInstallTarget';
+
+// The id an operator actually picked out of the chat list, and could not use.
+const LEGACY = '19:abc8af8ec7fc471785d3b83c4d84b667@thread.skype';
+
+describe('the legacy @thread.skype group chat', () => {
+  it('classifies as a group chat, not as unrecognised', () => {
+    const target = classifyTeamsInstallTarget(LEGACY);
+    expect(target.kind).toBe('group-chat');
+    expect(target.id).toBe(LEGACY);
+  });
+
+  it('is submittable — the button must not stay disabled', () => {
+    expect(isSubmittableTarget(classifyTeamsInstallTarget(LEGACY))).toBe(true);
+  });
+
+  it('matches the suffix whatever its casing', () => {
+    expect(classifyTeamsInstallTarget('19:ABC@THREAD.SKYPE').kind).toBe(
+      'group-chat',
+    );
+  });
+
+  it('does not loosen the channel refusal', () => {
+    expect(classifyTeamsInstallTarget('19:abc@thread.tacv2').kind).toBe(
+      'channel',
+    );
+  });
+
+  it('ships as an example, and the example classifies back', () => {
+    expect(
+      classifyTeamsInstallTarget(TEAMS_TARGET_EXAMPLES.legacyGroupChat).kind,
+    ).toBe('group-chat');
+  });
+});
+
+describe('classifyKnownTeamsTarget', () => {
+  // A shape no pattern here knows — standing in for whatever Microsoft adds
+  // next. The point is that the picker keeps working without a code change.
+  const UNKNOWN_SHAPE = '19:something@thread.futurev9';
+
+  it('accepts a listed target the heuristic cannot read', () => {
+    expect(classifyTeamsInstallTarget(UNKNOWN_SHAPE).kind).toBe('unrecognised');
+
+    const target = classifyKnownTeamsTarget(UNKNOWN_SHAPE, {
+      id: UNKNOWN_SHAPE,
+      kind: 'group-chat',
+    });
+    expect(target.kind).toBe('group-chat');
+    expect(isSubmittableTarget(target)).toBe(true);
+  });
+
+  it('drops the claim as soon as the value is edited', () => {
+    // The invalidation is structural: the claim names the id it was made
+    // about, so a changed field cannot keep wearing the old label.
+    const target = classifyKnownTeamsTarget('19:something-else@thread.futurev9', {
+      id: UNKNOWN_SHAPE,
+      kind: 'group-chat',
+    });
+    expect(target.kind).toBe('unrecognised');
+    expect(isSubmittableTarget(target)).toBe(false);
+  });
+
+  it('settles the bare-32-hex ambiguity when the directory named it', () => {
+    const bare = 'abc8af8ec7fc471785d3b83c4d84b667';
+    expect(classifyTeamsInstallTarget(bare).kind).toBe('ambiguous');
+    expect(classifyKnownTeamsTarget(bare, { id: bare, kind: 'team' }).kind).toBe(
+      'team',
+    );
+  });
+
+  it('refuses a channel even when a chat kind is claimed for it', () => {
+    // The directory never lists channels, so this claim cannot have come from
+    // one — and installing "the channel's team" reaches every channel of it.
+    const target = classifyKnownTeamsTarget('19:abc@thread.tacv2', {
+      id: '19:abc@thread.tacv2',
+      kind: 'group-chat',
+    });
+    expect(target.kind).toBe('channel');
+  });
+
+  it('behaves like the plain classifier with no claim', () => {
+    expect(classifyKnownTeamsTarget(LEGACY).kind).toBe('group-chat');
+    expect(classifyKnownTeamsTarget('').kind).toBe('empty');
+  });
+});

--- a/web-ui/app/_lib/agents.ts
+++ b/web-ui/app/_lib/agents.ts
@@ -705,6 +705,17 @@ export interface ProvisionTeamsIdentityInput {
   bot_slug?: string;
   display_name?: string;
   team_id: string;
+  /**
+   * WHAT THE DIRECTORY SAID this target is, when it came from the picker
+   * rather than the text field.
+   *
+   * Optional and absent for anything typed. Sent so the middleware does not
+   * re-derive the kind from the id's suffix: a shape the pattern table has
+   * never seen — a legacy `19:…@thread.skype` group chat today, whatever
+   * Microsoft mints next — is refused there even though Graph had just listed
+   * it as an install target.
+   */
+  target_kind?: TeamsTargetKind;
 }
 
 export interface ProvisionTeamsIdentityResponse {
@@ -1444,10 +1455,18 @@ export interface InstallAgentTeamResponse {
 export async function installAgentTeam(
   slug: string,
   teamId: string,
+  /** See `ProvisionTeamsIdentityInput.target_kind`. */
+  targetKind?: TeamsTargetKind,
 ): Promise<InstallAgentTeamResponse> {
   return callJson<InstallAgentTeamResponse>(
     `/v1/operator/agents/${encodeURIComponent(slug)}/teams`,
-    { method: 'POST', body: JSON.stringify({ team_id: teamId }) },
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        team_id: teamId,
+        ...(targetKind !== undefined ? { target_kind: targetKind } : {}),
+      }),
+    },
   );
 }
 

--- a/web-ui/app/_lib/teamsInstallTarget.ts
+++ b/web-ui/app/_lib/teamsInstallTarget.ts
@@ -37,6 +37,10 @@ export type TeamsTargetClassification =
 
 const CHANNEL_SUFFIX = /@thread\.tacv2$/i;
 const GROUP_CHAT_SUFFIX = /@thread\.v2$/i;
+/** The pre-`v2` spelling of a group chat thread. Teams minted these before the
+ *  split that gave channels `@thread.tacv2` and group chats `@thread.v2`, and
+ *  the tenant chat listing still returns plenty of them. */
+const LEGACY_GROUP_CHAT_SUFFIX = /@thread\.skype$/i;
 const ONE_ON_ONE_SUFFIX = /@unq\.gbl\.spaces$/i;
 const CONVERSATION_PREFIX = /^19:.+/;
 const DASHED_GUID = /^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$/;
@@ -70,6 +74,7 @@ export function classifyTeamsInstallTarget(value: string): TeamsTargetClassifica
   if (CONVERSATION_PREFIX.test(id)) {
     if (CHANNEL_SUFFIX.test(id)) return { kind: 'channel', id };
     if (GROUP_CHAT_SUFFIX.test(id)) return { kind: 'group-chat', id };
+    if (LEGACY_GROUP_CHAT_SUFFIX.test(id)) return { kind: 'group-chat', id };
     if (ONE_ON_ONE_SUFFIX.test(id)) return { kind: 'one-on-one-chat', id };
     // Teams has more conversation kinds than this handles, and installing
     // into the wrong one has a real audience — so an unknown suffix is
@@ -91,6 +96,52 @@ export function classifyTeamsInstallTarget(value: string): TeamsTargetClassifica
   return { kind: 'unrecognised', id };
 }
 
+/**
+ * A target the TENANT DIRECTORY named, rather than a string the operator typed.
+ *
+ * Mirrors `KnownTeamsInstallTarget` in the middleware, and exists for the same
+ * reason: {@link classifyTeamsInstallTarget} reads strings of unknown
+ * provenance, and an id that came out of the picker is not one of those. Graph
+ * listed it AND said what it was. Feeding that id back through a suffix table
+ * discards the better answer to re-derive a worse one — which is how a legacy
+ * `19:…@thread.skype` group chat, offered by the picker itself, ended up
+ * labelled "not a Teams install target" under the field.
+ *
+ * BOUND TO ITS ID ON PURPOSE. The claim names the exact string it was made
+ * about, so editing the field invalidates it without any caller having to
+ * remember to clear it. The UI can therefore never label a typed id with a
+ * kind that belonged to a picked one.
+ */
+export interface KnownTeamsTarget {
+  readonly id: string;
+  readonly kind: TeamsTargetKind;
+}
+
+/**
+ * The verdict to SHOW for what is currently in the field.
+ *
+ * Identical to {@link classifyTeamsInstallTarget} except when `known` still
+ * describes this exact value — then the directory's answer stands, because it
+ * came from Graph and the pattern table is only ever an approximation of it. A
+ * `'channel'` reading is the one thing it cannot override: the directory never
+ * lists channels, so such a claim cannot have come from one.
+ */
+export function classifyKnownTeamsTarget(
+  value: string,
+  known?: KnownTeamsTarget,
+): TeamsTargetClassification {
+  const classified = classifyTeamsInstallTarget(value);
+  if (
+    known !== undefined &&
+    known.id === value.trim() &&
+    classified.kind !== 'channel' &&
+    classified.kind !== 'empty'
+  ) {
+    return { kind: known.kind, id: known.id };
+  }
+  return classified;
+}
+
 /** Can this input be submitted as-is? `false` for every verdict that needs the
  *  operator to change something first — which is what disables the button. */
 export function isSubmittableTarget(
@@ -108,4 +159,8 @@ export function isSubmittableTarget(
 export const TEAMS_TARGET_EXAMPLES = {
   team: '2f1a9c44-1f0e-4f2c-8f1a-9c441f0e4f2c',
   groupChat: '19:a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6@thread.v2',
+  /** The same kind of thing, spelled the way Teams spelled it before the v2
+   *  split. Shown because tenants still hold plenty of them — an operator who
+   *  finds one in their own picker should recognise it in the help text. */
+  legacyGroupChat: '19:a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6@thread.skype',
 } as const;

--- a/web-ui/app/operator/agents/[slug]/__tests__/AgentTeamsIdentity.restart.test.tsx
+++ b/web-ui/app/operator/agents/[slug]/__tests__/AgentTeamsIdentity.restart.test.tsx
@@ -137,9 +137,39 @@ describe('AgentTeamsIdentity — an identity with no install target', () => {
     await user.click(await screen.findByRole('option', { name: 'Acme Team' }));
     await user.click(screen.getByRole('button', { name: 'Start provisioning' }));
 
+    // The KIND rides along, and that is the point of picking from the list.
+    // The directory already said this row is a team; sending only the id would
+    // leave the middleware to re-derive that from the id's shape, which is the
+    // guess that made a legacy `19:…@thread.skype` group chat unusable.
     await waitFor(() =>
-      expect(mockProvision).toHaveBeenCalledWith('sales-bot', { team_id: TEAM_ID }),
+      expect(mockProvision).toHaveBeenCalledWith('sales-bot', {
+        team_id: TEAM_ID,
+        target_kind: 'team',
+      }),
     );
+  });
+
+  it('forgets the picked kind once the field is edited by hand', async () => {
+    // THE OTHER HALF OF THE CONTRACT. A remembered kind that outlives the id
+    // it described would be the same lie as the misclassification it replaced
+    // — the panel would label, and POST, a type belonging to a target the
+    // operator has since typed over. So picking then typing must send no kind
+    // at all and fall back to classifying what is actually in the field.
+    const user = userEvent.setup();
+    renderWithIntl(<AgentTeamsIdentity slug="sales-bot" />);
+
+    await user.click(await screen.findByRole('combobox', { name: /Team/i }));
+    await user.click(await screen.findByRole('option', { name: 'Acme Team' }));
+
+    const field = await screen.findByLabelText('Target ID');
+    await user.clear(field);
+    await user.type(field, '19:typed1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c@thread.v2');
+    await user.click(screen.getByRole('button', { name: 'Start provisioning' }));
+
+    await waitFor(() => expect(mockProvision).toHaveBeenCalledTimes(1));
+    expect(mockProvision).toHaveBeenCalledWith('sales-bot', {
+      team_id: '19:typed1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c@thread.v2',
+    });
   });
 
   it('refuses to start on an input that is not an install target', async () => {

--- a/web-ui/app/operator/agents/[slug]/__tests__/AgentTeamsInstalls.test.tsx
+++ b/web-ui/app/operator/agents/[slug]/__tests__/AgentTeamsInstalls.test.tsx
@@ -222,7 +222,15 @@ describe('AgentTeamsInstalls (#866)', () => {
     await user.type(await screen.findByLabelText('Target ID'), '2f1a9c44-1f0e-4f2c-8f1a-9c441f0e4f2c');
     await user.click(screen.getByRole('button', { name: 'Install' }));
 
-    await waitFor(() => expect(mockInstall).toHaveBeenCalledWith('odoo', '2f1a9c44-1f0e-4f2c-8f1a-9c441f0e4f2c'));
+    // No kind: this id was TYPED, so there is no directory answer to pass on
+    // and the server classifies it the way it always has.
+    await waitFor(() =>
+      expect(mockInstall).toHaveBeenCalledWith(
+        'odoo',
+        '2f1a9c44-1f0e-4f2c-8f1a-9c441f0e4f2c',
+        undefined,
+      ),
+    );
     expect(
       await screen.findByText(
         'Installing into team 2f1a9c44-1f0e-4f2c-8f1a-9c441f0e4f2c — the provisioning run continues in the background.',

--- a/web-ui/app/operator/agents/[slug]/__tests__/TeamsTargetPicker.test.tsx
+++ b/web-ui/app/operator/agents/[slug]/__tests__/TeamsTargetPicker.test.tsx
@@ -19,8 +19,11 @@ import { TeamsTargetPicker } from '../_components/TeamsTargetPicker';
  *  - the two halves degrade independently — a chat scope nobody consented to
  *    must not be able to hide the team list, which is the half that works
  *    everywhere;
- *  - a picked id is handed up VERBATIM, so the live classification below the
- *    picker stays the single verdict on what the target is.
+ *  - a picked id is handed up VERBATIM, together with the KIND the listing
+ *    reported for it. The id alone was not enough: the field below re-derived
+ *    the kind from the suffix and refused a legacy `19:…@thread.skype` group
+ *    chat this very component had just offered. Graph names each row, so the
+ *    name travels with the row instead of being guessed again downstream.
  */
 
 const TEAM = { id: '2f1a9c44-1f0e-4f2c-8f1a-9c441f0e4f2c', displayName: 'Acme Team' };
@@ -91,7 +94,7 @@ describe('TeamsTargetPicker — offering a choice', () => {
     // Verbatim matters: the id goes into the same field the operator could
     // have typed into, and the live classification decides what it is. A
     // picker that reshaped it would become a second, disagreeing classifier.
-    expect(onSelect).toHaveBeenCalledWith(TEAM.id);
+    expect(onSelect).toHaveBeenCalledWith(TEAM.id, 'team');
   });
 
   it('shows no selection for an id that was typed rather than picked', async () => {
@@ -194,7 +197,7 @@ describe('TeamsTargetPicker — finding one among many', () => {
     await userEvent.type(field, 'Team 03');
     await userEvent.keyboard('{ArrowDown}{Enter}');
 
-    expect(onSelect).toHaveBeenCalledWith(MANY[3]?.id);
+    expect(onSelect).toHaveBeenCalledWith(MANY[3]?.id, 'team');
   });
 
   it('closes on Escape, then clears the query on a second Escape', async () => {
@@ -296,5 +299,54 @@ describe('TeamsTargetPicker — degrading without lying', () => {
     for (const select of screen.getAllByRole('combobox')) {
       expect(select).toBeDisabled();
     }
+  });
+});
+
+describe('the kind travels with the picked id', () => {
+  // THE REGRESSION, AT ITS SOURCE. This row is a chat Graph listed as a group
+  // chat; its suffix is one the classifier downstream had never seen. Emitting
+  // the kind is what keeps the two from disagreeing about the same row.
+  const LEGACY_CHAT = {
+    id: '19:abc8af8ec7fc471785d3b83c4d84b667@thread.skype',
+    topic: 'Legacy group',
+    chatType: 'group' as const,
+  };
+  const SOLO_CHAT = {
+    id: '19:aaa_bbb@unq.gbl.spaces',
+    topic: 'Direct',
+    chatType: 'oneOnOne' as const,
+  };
+  const MEETING_CHAT = {
+    id: '19:meeting_abc@thread.v2',
+    topic: 'Standup',
+    chatType: 'meeting' as const,
+  };
+
+  async function pick(
+    chat: { id: string; topic: string; chatType: 'group' | 'oneOnOne' | 'meeting' },
+  ): Promise<ReturnType<typeof vi.fn>> {
+    const { onSelect } = render(
+      dto({ chats: { available: true, items: [chat] } }),
+    );
+    await openChats();
+    await userEvent.click(
+      screen.getByRole('option', { name: new RegExp(chat.topic) }),
+    );
+    return onSelect;
+  }
+
+  it("reports Graph's chatType for a group chat, whatever its suffix", async () => {
+    const onSelect = await pick(LEGACY_CHAT);
+    expect(onSelect).toHaveBeenCalledWith(LEGACY_CHAT.id, 'group-chat');
+  });
+
+  it('reports a 1:1 chat as its own kind', async () => {
+    const onSelect = await pick(SOLO_CHAT);
+    expect(onSelect).toHaveBeenCalledWith(SOLO_CHAT.id, 'one-on-one-chat');
+  });
+
+  it('installs a meeting chat through the chat endpoint, like a group one', async () => {
+    const onSelect = await pick(MEETING_CHAT);
+    expect(onSelect).toHaveBeenCalledWith(MEETING_CHAT.id, 'group-chat');
   });
 });

--- a/web-ui/app/operator/agents/[slug]/_components/AgentTeamsIdentity.tsx
+++ b/web-ui/app/operator/agents/[slug]/_components/AgentTeamsIdentity.tsx
@@ -23,6 +23,7 @@ import {
 } from '../../../../_lib/teamsIdentity';
 import { AgentTeamsProvisioningTimeline } from './AgentTeamsProvisioningTimeline';
 import { AgentTeamsIdentityTarget } from './AgentTeamsIdentityTarget';
+import type { TeamsTargetKind } from '@/app/_lib/teamsInstallTarget';
 import { humanizeApiError } from '../../_components/AgentsDashboard';
 import {
   Fact,
@@ -313,7 +314,15 @@ export function AgentTeamsIdentity(
           // WITHOUT `bot_slug` / `display_name`: they survive a reset and the
           // server ignores them on an existing row, so resending them could
           // only ever introduce a difference nobody asked for.
-          onStartRun={(targetTeamId) => void provision({ team_id: targetTeamId })}
+          // `targetKind` rides along when the operator picked the target out
+          // of the tenant listing: the server then installs into what Graph
+          // said it was instead of re-deriving it from the id's suffix.
+          onStartRun={(targetTeamId, targetKind) =>
+            void provision({
+              team_id: targetTeamId,
+              ...(targetKind !== undefined ? { target_kind: targetKind } : {}),
+            })
+          }
           formatDate={(iso) => formatTimestamp(iso, format)}
         />
       )}
@@ -324,7 +333,7 @@ export function AgentTeamsIdentity(
 function ReadyPanel(props: {
   readonly status: TeamsIdentityStatusDto;
   readonly busy: boolean;
-  readonly onStartRun: (teamId: string) => void;
+  readonly onStartRun: (teamId: string, targetKind?: TeamsTargetKind) => void;
   readonly formatDate: (iso: string) => string;
   readonly slug: string;
   readonly onReloaded: () => void;

--- a/web-ui/app/operator/agents/[slug]/_components/AgentTeamsIdentityTarget.tsx
+++ b/web-ui/app/operator/agents/[slug]/_components/AgentTeamsIdentityTarget.tsx
@@ -4,7 +4,12 @@ import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 
 import { Button } from '@/app/_components/ui/Button';
-import { isSubmittableTarget, classifyTeamsInstallTarget } from '@/app/_lib/teamsInstallTarget';
+import {
+  classifyKnownTeamsTarget,
+  isSubmittableTarget,
+  type KnownTeamsTarget,
+  type TeamsTargetKind,
+} from '@/app/_lib/teamsInstallTarget';
 import {
   getAgentTeamsTargets,
   type AgentTeamsTargetsDto,
@@ -45,7 +50,9 @@ export interface AgentTeamsIdentityTargetProps {
   /** The runner is holding a run for this agent. Starting a second one is
    *  refused server-side, so the control says so instead of inviting a 409. */
   readonly running: boolean;
-  readonly onStart: (teamId: string) => void;
+  /** `targetKind` is present only when the id came from the tenant listing;
+   *  it rides along to the POST so the server does not re-guess it. */
+  readonly onStart: (teamId: string, targetKind?: TeamsTargetKind) => void;
 }
 
 export function AgentTeamsIdentityTarget({
@@ -56,6 +63,10 @@ export function AgentTeamsIdentityTarget({
 }: AgentTeamsIdentityTargetProps): React.JSX.Element {
   const t = useTranslations('operatorAgents.teamsIdentity');
   const [teamId, setTeamId] = useState('');
+  // The directory's answer for the id currently in the field, or `undefined`
+  // once the operator has typed. Held next to the value it describes and
+  // replaced wholesale on every change, so the two cannot drift apart.
+  const [known, setKnown] = useState<KnownTeamsTarget | undefined>(undefined);
   const [targets, setTargets] = useState<AgentTeamsTargetsDto | null>(null);
   const [targetsLoading, setTargetsLoading] = useState(true);
 
@@ -84,7 +95,7 @@ export function AgentTeamsIdentityTarget({
     };
   }, [slug]);
 
-  const submittable = isSubmittableTarget(classifyTeamsInstallTarget(teamId));
+  const submittable = isSubmittableTarget(classifyKnownTeamsTarget(teamId, known));
   const locked = busy || running;
 
   return (
@@ -103,8 +114,14 @@ export function AgentTeamsIdentityTarget({
         targets={targets}
         targetsLoading={targetsLoading}
         value={teamId}
-        onChange={setTeamId}
+        onChange={(next, knownKind) => {
+          setTeamId(next);
+          setKnown(
+            knownKind === undefined ? undefined : { id: next, kind: knownKind },
+          );
+        }}
         disabled={locked}
+        known={known}
       />
 
       <div>
@@ -113,7 +130,7 @@ export function AgentTeamsIdentityTarget({
           busy={busy}
           disabled={locked || !submittable}
           busyLabel={t('submitBusy')}
-          onClick={() => onStart(teamId.trim())}
+          onClick={() => onStart(teamId.trim(), known?.kind)}
         >
           {t('submit')}
         </Button>

--- a/web-ui/app/operator/agents/[slug]/_components/AgentTeamsInstalls.tsx
+++ b/web-ui/app/operator/agents/[slug]/_components/AgentTeamsInstalls.tsx
@@ -8,8 +8,9 @@ import { useFormatter, useTranslations } from 'next-intl';
 import { Button } from '@/app/_components/ui/Button';
 import { ConfirmDialog } from '@/app/_components/ConfirmDialog';
 import {
-  classifyTeamsInstallTarget,
+  classifyKnownTeamsTarget,
   isSubmittableTarget,
+  type KnownTeamsTarget,
 } from '../../../../_lib/teamsInstallTarget';
 import {
   getAgentTeams,
@@ -135,6 +136,9 @@ export function AgentTeamsInstalls({
   const [result, setResult] = useState<string | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [teamId, setTeamId] = useState('');
+  // What the tenant listing said `teamId` is, while `teamId` is still exactly
+  // what was picked. Cleared by any edit — see `TeamsTargetField`.
+  const [known, setKnown] = useState<KnownTeamsTarget | undefined>(undefined);
   /**
    * What the operator can pick instead of type.
    *
@@ -256,7 +260,7 @@ export function AgentTeamsInstalls({
     };
   }, [slug]);
 
-  const target = classifyTeamsInstallTarget(teamId);
+  const target = classifyKnownTeamsTarget(teamId, known);
   const targetSubmittable = isSubmittableTarget(target);
 
   const installed = data?.teams ?? [];
@@ -482,8 +486,16 @@ export function AgentTeamsInstalls({
               targets={targets}
               targetsLoading={targetsLoading}
               value={teamId}
-              onChange={setTeamId}
+              onChange={(next, knownKind) => {
+                setTeamId(next);
+                setKnown(
+                  knownKind === undefined
+                    ? undefined
+                    : { id: next, kind: knownKind },
+                );
+              }}
               disabled={!canInstall || inFlight}
+              known={known}
             />
             <div className="flex flex-wrap items-center gap-2">
               <Button
@@ -493,8 +505,13 @@ export function AgentTeamsInstalls({
                 busyLabel={t('installBusy')}
                 onClick={() =>
                   void run('install', async () => {
-                    const res = await installAgentTeam(slug, teamId.trim());
+                    const res = await installAgentTeam(
+                      slug,
+                      teamId.trim(),
+                      known?.kind,
+                    );
                     setTeamId('');
+                    setKnown(undefined);
                     return res.already_installed
                       ? t('alreadyInstalled', { teamId: res.team_id })
                       : t('installStarted', { teamId: res.team_id });

--- a/web-ui/app/operator/agents/[slug]/_components/TeamsTargetField.tsx
+++ b/web-ui/app/operator/agents/[slug]/_components/TeamsTargetField.tsx
@@ -4,8 +4,10 @@ import { useTranslations } from 'next-intl';
 
 import { Button } from '@/app/_components/ui/Button';
 import {
-  classifyTeamsInstallTarget,
+  classifyKnownTeamsTarget,
   TEAMS_TARGET_EXAMPLES,
+  type KnownTeamsTarget,
+  type TeamsTargetKind,
 } from '@/app/_lib/teamsInstallTarget';
 import type { AgentTeamsTargetsDto } from '@/app/_lib/agents';
 import { TeamsTargetPicker } from './TeamsTargetPicker';
@@ -31,6 +33,19 @@ import { TeamsTargetPicker } from './TeamsTargetPicker';
  * every POST. What this buys is the five provisioning steps that used to run
  * before Graph answered `404 No team found with Group Id`: the verdict now
  * appears under the field while the operator is still typing.
+ *
+ * A PICKED TARGET IS NOT CLASSIFIED, IT IS REMEMBERED. When the id came from
+ * the picker, Graph already said what it was, so the suffix table is not asked
+ * — it is an approximation of an answer we were handed. That claim is bound to
+ * the exact string it was made about ({@link KnownTeamsTarget}), so the first
+ * keystroke in the field invalidates it and the classification takes over
+ * again. The alternative — a remembered kind outliving the id it described —
+ * would be the same lie as the misclassification, only quieter.
+ *
+ * THE KIND TRAVELS UP, NOT JUST ACROSS. `onChange` carries it to the caller so
+ * it reaches the POST body as `target_kind`. Without that the middleware would
+ * re-derive the kind from the id and land on the same wrong answer one hop
+ * later, which is the failure mode this whole path exists to close.
  */
 
 export interface TeamsTargetFieldProps {
@@ -39,8 +54,13 @@ export interface TeamsTargetFieldProps {
   readonly targets: AgentTeamsTargetsDto | null;
   readonly targetsLoading: boolean;
   readonly value: string;
-  readonly onChange: (value: string) => void;
+  /** `knownKind` is present only while `value` is exactly what the operator
+   *  picked from the list; it is absent for anything typed. */
+  readonly onChange: (value: string, knownKind?: TeamsTargetKind) => void;
   readonly disabled: boolean;
+  /** The claim the caller is holding for `value`, echoed back so the verdict
+   *  and the submit gate agree with what will actually be posted. */
+  readonly known?: KnownTeamsTarget;
 }
 
 export function TeamsTargetField({
@@ -49,9 +69,10 @@ export function TeamsTargetField({
   value,
   onChange,
   disabled,
+  known,
 }: TeamsTargetFieldProps): React.JSX.Element {
   const t = useTranslations('operatorAgents.teamsInstalls');
-  const target = classifyTeamsInstallTarget(value);
+  const target = classifyKnownTeamsTarget(value, known);
 
   return (
     <>
@@ -62,7 +83,7 @@ export function TeamsTargetField({
         loading={targetsLoading}
         disabled={disabled}
         value={value}
-        onSelect={onChange}
+        onSelect={(id, kind) => onChange(id, kind)}
       />
 
       <label className="flex flex-col gap-1 text-[11px] text-[color:var(--fg-muted)]">
@@ -71,6 +92,8 @@ export function TeamsTargetField({
           type="text"
           value={value}
           disabled={disabled}
+          // No kind: typing is exactly the case the classifier was written
+          // for, and a claim from an earlier pick must not survive an edit.
           onChange={(e) => onChange(e.target.value)}
           aria-label={t('fieldTarget')}
           className="rounded-md border border-[color:var(--border)] bg-transparent px-2 py-1 font-mono text-sm text-[color:var(--fg-strong)]"
@@ -82,18 +105,31 @@ export function TeamsTargetField({
           {t('targetExamples', {
             team: TEAMS_TARGET_EXAMPLES.team,
             groupChat: TEAMS_TARGET_EXAMPLES.groupChat,
+            legacyGroupChat: TEAMS_TARGET_EXAMPLES.legacyGroupChat,
           })}
         </span>
       </label>
 
       {/* The verdict. A recognised target is named — "Team" or
           "Gruppenchat" — so the operator can see the field understood
-          them; the three that cannot be installed each say what to do. */}
+          them; the three that cannot be installed each say what to do.
+
+          AND IT SAYS WHERE THE VERDICT CAME FROM. "Detected as" is a claim
+          about a guess; for a row taken out of the tenant listing there was
+          no guess, so it says "from the list" instead. The distinction is
+          not decoration: it is the same one the code now makes, and a label
+          that blurred it would describe a mechanism we deliberately stopped
+          using. */}
       {target.kind === 'team' ||
       target.kind === 'group-chat' ||
       target.kind === 'one-on-one-chat' ? (
         <div className="text-[11px] text-[color:var(--success)]">
-          {t('targetKindLabel', { kind: t(`targetKind.${target.kind}`) })}
+          {t(
+            known !== undefined && known.id === value.trim()
+              ? 'targetKindFromListLabel'
+              : 'targetKindLabel',
+            { kind: t(`targetKind.${target.kind}`) },
+          )}
         </div>
       ) : null}
       {target.kind === 'channel' ? (

--- a/web-ui/app/operator/agents/[slug]/_components/TeamsTargetPicker.tsx
+++ b/web-ui/app/operator/agents/[slug]/_components/TeamsTargetPicker.tsx
@@ -12,6 +12,7 @@ import type {
   TeamsTargetListingDto,
   TeamsTeamOptionDto,
 } from '@/app/_lib/agents';
+import type { TeamsTargetKind } from '@/app/_lib/teamsInstallTarget';
 
 /**
  * Pick an install target instead of typing one.
@@ -29,10 +30,18 @@ import type {
  * input that broke the field test cannot be produced from here at all.
  *
  * IT WRITES INTO THE EXISTING FIELD, IT DOES NOT REPLACE IT. Selecting sets
- * the same `teamId` state the text input owns, so the live type detection
- * below it keeps running and keeps being the thing that decides. One code
- * path, one verdict — and the free-text field stays usable for the cases a
- * list cannot cover.
+ * the same `teamId` state the text input owns, so the free-text field stays
+ * usable for the cases a list cannot cover.
+ *
+ * IT ALSO HANDS OVER THE KIND, AND THAT IS THE IMPORTANT PART. Every row here
+ * came from Graph, which said what it was — `listTeams` returns teams,
+ * `listChats` returns a `chatType` per chat. Emitting only the id threw that
+ * away and left the field to re-derive the kind from the id's suffix, which is
+ * how a legacy `19:…@thread.skype` group chat OFFERED BY THIS COMPONENT was
+ * then rejected under it as "not a Teams install target". A pattern table can
+ * only know the shapes it was written for; the listing knows the truth. So the
+ * kind travels with the id, and the classification below stays what it was
+ * built for — reading strings a human typed.
  *
  * EACH HALF IS SEARCHABLE, not a plain dropdown. The byte5 tenant alone
  * publishes thirty teams, and a chat with no topic renders as a `19:…` stem,
@@ -68,7 +77,8 @@ export interface TeamsTargetPickerProps {
   /** The id currently in the text field, so a picked row can render as the
    *  selected one and a hand-typed id simply shows no selection. */
   readonly value: string;
-  readonly onSelect: (id: string) => void;
+  /** `kind` is the DIRECTORY's answer for this row, not a guess about it. */
+  readonly onSelect: (id: string, kind: TeamsTargetKind) => void;
 }
 
 /** Label for one chat row: its topic, else its members, else its id. Never
@@ -121,6 +131,7 @@ export function TeamsTargetPicker({
         optionsOf={(items: readonly TeamsTeamOptionDto[]) =>
           items.map((team) => ({ id: team.id, label: team.displayName }))
         }
+        kindOf={() => 'team'}
         unavailableText={(reason) =>
           t(`unavailable.teams.${reason}`, { scope: 'Chat.ReadBasic' })
         }
@@ -150,6 +161,15 @@ export function TeamsTargetPicker({
               : {}),
           }))
         }
+        // Graph's own `chatType`, mapped to the kind the install endpoint
+        // branches on. A meeting chat installs through /chats like a group
+        // one, so only the 1:1 case is separated out.
+        kindOf={(id) =>
+          chats.available &&
+          chats.items.find((chat) => chat.id === id)?.chatType === 'oneOnOne'
+            ? 'one-on-one-chat'
+            : 'group-chat'
+        }
         unavailableText={(reason) =>
           t(`unavailable.chats.${reason}`, { scope: 'Chat.ReadBasic' })
         }
@@ -165,8 +185,10 @@ interface TargetSelectProps<T> {
   readonly listing: TeamsTargetListingDto<T>;
   readonly disabled: boolean;
   readonly value: string;
-  readonly onSelect: (id: string) => void;
+  readonly onSelect: (id: string, kind: TeamsTargetKind) => void;
   readonly optionsOf: (items: readonly T[]) => readonly SearchableOption[];
+  /** The kind the listing reported for the row with this id. */
+  readonly kindOf: (id: string) => TeamsTargetKind;
   readonly unavailableText: (reason: string) => string;
   readonly noMatchText: (query: string) => string;
   readonly matchCountText: (count: number) => string;
@@ -192,6 +214,7 @@ function TargetSelect<T>({
   value,
   onSelect,
   optionsOf,
+  kindOf,
   unavailableText,
   noMatchText,
   matchCountText,
@@ -223,7 +246,7 @@ function TargetSelect<T>({
       options={options}
       value={value}
       disabled={disabled}
-      onSelect={onSelect}
+      onSelect={(id) => onSelect(id, kindOf(id))}
       noMatchText={noMatchText}
       matchCountText={matchCountText}
     />

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -2025,19 +2025,20 @@
       "pendingStoppedHint": "Team {teamId} ist das hinterlegte Ziel, es läuft aber kein Provisioning — die Kette ist vor dem Installationsschritt stehen geblieben. Den erfassten Fehler zeigt der Abschnitt „Teams-Identität“ oben.",
       "targetHeading": "Ziel wählen",
       "fieldTarget": "Ziel-ID",
-      "fieldTargetHint": "Ein Team oder ein Chat. Team: die Gruppen-ID aus „Link zum Team abrufen“. Gruppenchat: die vollständige ID in der Form 19:…@thread.v2.",
+      "fieldTargetHint": "Ein Team oder ein Chat. Team: die Gruppen-ID aus „Link zum Team abrufen“. Gruppenchat: die vollständige ID in der Form 19:…@thread.v2 — ältere Chats enden auf 19:…@thread.skype und sind genauso gültig.",
       "targetKind": {
         "team": "Team",
         "group-chat": "Gruppenchat",
         "one-on-one-chat": "1:1-Chat"
       },
       "targetKindLabel": "Erkannt als: {kind}",
-      "targetExamples": "Beispiele — Team: {team} · Gruppenchat: {groupChat}",
+      "targetKindFromListLabel": "Aus der Liste: {kind}",
+      "targetExamples": "Beispiele — Team: {team} · Gruppenchat: {groupChat} · älterer Gruppenchat: {legacyGroupChat}",
       "targetChannel": "Das ist die ID eines Kanals, kein Installationsziel. Teams installiert eine App in ein Team oder in einen Chat, nie in einen einzelnen Kanal. Nimm die Gruppen-ID des Teams, zu dem der Kanal gehört, oder die ID eines Gruppenchats (19:…@thread.v2).",
       "targetAmbiguous": "32 Hex-Zeichen ohne Kontext — das kann die Gruppen-ID eines Teams ohne Bindestriche sein oder der Rumpf einer Gruppenchat-ID. Geraten wird hier nicht: wähle, was gemeint ist.",
       "targetAmbiguousUseTeam": "Als Team einsetzen",
       "targetAmbiguousUseChat": "Als Gruppenchat einsetzen",
-      "targetUnrecognised": "Diese Eingabe ist kein Teams-Installationsziel. Erwartet wird eine Team-Gruppen-ID, eine Gruppenchat-ID (19:…@thread.v2) oder eine 1:1-Chat-ID (19:…@unq.gbl.spaces).",
+      "targetUnrecognised": "Diese Eingabe ist kein Teams-Installationsziel. Erwartet wird eine Team-Gruppen-ID, eine Gruppenchat-ID (19:…@thread.v2, bei älteren Chats 19:…@thread.skype) oder eine 1:1-Chat-ID (19:…@unq.gbl.spaces).",
       "chatInstallUnsupported": "Die Installation in einen Chat braucht den Microsoft-365-Connector 0.7.0 oder neuer. Der hier installierte Connector ist älter — aktualisiere das Plugin, oder wähle ein Team als Ziel.",
       "pendingHintTyped": "Ein Provisionierungslauf zielt auf {kind} {teamId}. Als Installation zählt das erst, wenn die Kette den Installationsschritt erreicht.",
       "chatNameUnavailable": "Für Chats liefert der Connector keinen Namen — angezeigt wird die ID."

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -2025,19 +2025,20 @@
       "pendingStoppedHint": "Team {teamId} is the recorded target, but no provisioning run is active — the chain stopped before the install step. See the Teams identity section above for the recorded error.",
       "targetHeading": "Choose a target",
       "fieldTarget": "Target ID",
-      "fieldTargetHint": "A team or a chat. Team: the group id from “Get link to team”. Group chat: the full id in the form 19:…@thread.v2.",
+      "fieldTargetHint": "A team or a chat. Team: the group id from “Get link to team”. Group chat: the full id in the form 19:…@thread.v2 — older chats end in 19:…@thread.skype and are just as valid.",
       "targetKind": {
         "team": "Team",
         "group-chat": "Group chat",
         "one-on-one-chat": "One-to-one chat"
       },
       "targetKindLabel": "Detected as: {kind}",
-      "targetExamples": "Examples — team: {team} · group chat: {groupChat}",
+      "targetKindFromListLabel": "From the list: {kind}",
+      "targetExamples": "Examples — team: {team} · group chat: {groupChat} · older group chat: {legacyGroupChat}",
       "targetChannel": "That is a channel id, not an install target. Teams installs an app into a team or into a chat, never into a single channel. Use the group id of the team the channel belongs to, or a group chat id (19:…@thread.v2).",
       "targetAmbiguous": "32 hex characters with no context — this can be a team group id without its dashes, or the stem of a group chat id. Nothing is guessed here: pick which one you mean.",
       "targetAmbiguousUseTeam": "Use as team",
       "targetAmbiguousUseChat": "Use as group chat",
-      "targetUnrecognised": "This is not a Teams install target. Expected a team group id, a group chat id (19:…@thread.v2) or a one-to-one chat id (19:…@unq.gbl.spaces).",
+      "targetUnrecognised": "This is not a Teams install target. Expected a team group id, a group chat id (19:…@thread.v2, or 19:…@thread.skype for an older chat) or a one-to-one chat id (19:…@unq.gbl.spaces).",
       "chatInstallUnsupported": "Installing into a chat needs the Microsoft 365 connector 0.7.0 or newer. The connector installed here is older — update the plugin, or choose a team as the target.",
       "pendingHintTyped": "A provisioning run targets {kind} {teamId}. It only counts as installed once the chain reaches the install step.",
       "chatNameUnavailable": "The connector provides no name for chats — the id is shown instead."


### PR DESCRIPTION
An operator picked a group chat **from the list** and the field refused it:

```
19:abc8af8ec7fc471785d3b83c4d84b667@thread.skype
→ "Diese Eingabe ist kein Teams-Installationsziel."
```

That list comes from `listChats` — from Graph. We were rejecting an identifier Microsoft had just handed us, on a screen whose whole purpose is to stop people typing identifiers by hand.

## The suffix

`@thread.skype` is now a group-chat form. In this repo it had a **deliberate** rule against it: a dedicated `SKYPE_THREAD` pattern with the hint "the Graph /chats resource does not accept it — it is not an install target", generalised from a 400 seen during the 0.19.2 name-resolution work. The rule is removed and the module header says why, rather than the reasoning quietly disappearing.

## The evidence is split, and this PR does not pretend otherwise

**Documentation says it is not a chat.** `POST /chats/{chat-id}/installedApps` only ever shows `19:<32hex>@thread.v2`. Where `@thread.skype` appears in Microsoft's Teams docs it is a **team and channel** id in bot `channelData`, and the ecosystem treats it as the legacy form of `@thread.tacv2`.

**The tenant says it is.** The data path was traced end to end — picker ← directory DTO ← `loadTeamsTargetDirectory` ← `listChats` ← `GET /me/chats?$expand=members` — and `parseChat` drops any row whose `chatType` is not `group`/`oneOnOne`/`meeting`. So Graph returned this id **from the chats collection, labelled `chatType: "group"`, with a member roster**.

**Not settled here:** whether `POST /chats/{id}/installedApps` accepts the form. That is a mutating write against a production tenant, so it was not fired to find out. What changes is that the id now *reaches* Graph: if Graph refuses, it refuses with a Graph error at the install step rather than with a UI verdict that was wrong on its own.

The cheap, read-only way to settle it, with the delegated token the picker already uses: `GET /v1.0/chats/19:…@thread.skype`. A 200 means the resource accepts the id; a 400 means a dedicated message belongs in the connector's chat-install error path, where the suffix and the status are both in hand.

## A picked target no longer gets re-guessed

The structural half, and the reason this class of bug existed at all.

Classification exists for **typed** input, where guessing is dangerous — that is why `ambiguous` is a verdict. An id from `listTeams`/`listChats` is not a guess: Graph supplied it *and* said what it is. Throwing that away and running a regex over it means every format Microsoft adds breaks us again, precisely when the operator did everything right.

The picker now emits `(id, kind)`. Chats map Graph's own `chatType`; teams pass `team`. Both owning panels hold a `KnownTeamsTarget` and the verdict line reads `classifyKnownTeamsTarget(value, known)`. It reaches the endpoint decision — `target_kind` travels in the POST body, through the Zod schemas, into `resolveInstallTargetOrRefuse`, which is what selects `/teams/{id}` versus `/chats/{id}`. Without that the middleware would re-guess and this would be cosmetic.

**Two places discard the claim, both structural rather than by convention.** Typing passes no kind, so the state clears on the same keystroke. And the claim is `{id, kind}`, honoured only while `known.id === value.trim()` — a stale claim cannot outlive the string it was about, even if a future caller forgets to clear it. Tested at unit and component level: pick a team, type a chat id over it, assert the POST carries no `target_kind`.

One veto the claim cannot lift: a `channel` classification still wins. The directory never lists channels, so such a claim cannot have come from a listing, and installing "the channel's team" is a misreading with a wider audience than anyone asked for.

The verdict line now reads "Aus der Liste: Gruppenchat" rather than "Erkannt als:" for a picked row — *detected* is a claim about a guess, and there was none.

## Verification

middleware: **8092 tests, 8076 pass, 0 fail**; build, typecheck, `typecheck:test` (ratchet 370, no regressions) and lint all clean. web-ui: **1126 pass, 0 fail** across 120 files; typecheck, lint and `i18n:check` (4349 keys) clean.

Red-before-green proven by removing only the suffix line: 5 web-ui failures, restored and green.

Requires `@omadia/integration-microsoft365` **0.8.1**, which carries the same suffix fix.

## Correction worth recording

The 0.19.2 note that "Graph only knows `@thread.v2` / `@unq.gbl.spaces`" is too broad — `GET /me/chats` demonstrably returns `@thread.skype` chats with `chatType: group`. Whatever caused that 400, "Graph does not know these ids" is not it. That sentence is what produced the connector's hint.

Refs #860.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/964"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790749208&installation_model_id=428086&pr_number=964&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F964&signature=8b1cf7563b10c7a172240eae3fc72f521eaa2fd202c2a6e8730140e24473958a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->