### PR TITLE
fix: let Teams reach the per-bot messaging endpoints

### DIFF
--- a/middleware/src/auth/publicPaths.ts
+++ b/middleware/src/auth/publicPaths.ts
@@ -19,6 +19,7 @@
 
 import { CIMD_METADATA_PATH } from '../services/mcpCimd.js';
 import { PUBLIC_MCP_PATH } from '../mcp/publicMcpPath.js';
+import { TEAMS_MESSAGING_PATH_RE } from '../platform/teamsMessagingPath.js';
 
 /** Escape a literal path for embedding in a RegExp, so the shared constant —
  *  not a hand-retyped pattern — is what the allowlist actually matches. */
@@ -39,6 +40,30 @@ export const STATIC_PUBLIC_PATHS: readonly RegExp[] = [
   // Bot Framework webhook for channel-teams: the adapter validates the
   // Bot-issued JWT inside the handler; Teams never sends a session cookie.
   /^\/api\/messages(?:\/|$|\?)/,
+  // The SAME Bot Framework webhook, reached by its slug-addressed spellings —
+  // `/api/teams/messages` (default-bot alias) and `/api/teams/<botSlug>/messages`
+  // (that one bot's own credentials), both shipped in channel-teams 0.20.0.
+  //
+  // The entry above was written when `/api/messages` was the only webhook there
+  // was. The multi-bot routes arrived without it being extended, so every
+  // PROVISIONED bot 401'd here — `auth.missing`, the blanket OB-106 guard
+  // refusing a Bot-Framework bearer token because it is not an operator session
+  // cookie — before its handler ever ran, while the legacy bot on
+  // `/api/messages` kept working. That is the whole reason a freshly
+  // provisioned Teams bot was silent.
+  //
+  // Its authentication is the Bot Framework's, not this list's absence: the
+  // handler calls `adapter.process`, which validates the Bot-issued JWT against
+  // exactly that bot's app id and password before any turn runs. An anonymous
+  // POST gets the adapter's own "Unauthorized Access. Request is not
+  // authorized" 401 — the same answer `/api/messages` has always given.
+  //
+  // Built from the SHARED pattern, per the NOTE above and for the same reason as
+  // CIMD_METADATA_PATH / PUBLIC_MCP_PATH: the URL core hands to Azure
+  // (`buildTeamsBotMessagingEndpoint`) and the URL core exempts are now one
+  // definition and cannot drift apart again. It admits the two messaging shapes
+  // and NOT the `/api/teams` namespace — see `platform/teamsMessagingPath.ts`.
+  TEAMS_MESSAGING_PATH_RE,
   // Epic #459 W9 — generic MCP-server OAuth callback (bugfix). Same shape as
   // the spec-005 kernel OAuth broker callback above: the provider (Notion,
   // etc.) redirects the operator's browser back here after consent, and the

--- a/middleware/src/platform/teamsMessagingPath.ts
+++ b/middleware/src/platform/teamsMessagingPath.ts
@@ -1,0 +1,102 @@
+/**
+ * The ONE definition of the Teams bot messaging wire paths.
+ *
+ * Its own module, dependency-free on purpose — the same reason
+ * `mcp/publicMcpPath.ts` exists: `auth/publicPaths.ts` imports this to build
+ * the requireAuth exemption, and `platform/teamsProvisionerService.ts` imports
+ * it to build the endpoint URL handed to Azure. If the definition lived next
+ * to the provisioner, importing it would drag the whole provisioning contract
+ * into `publicPaths.ts`'s import graph — and into every test that asserts
+ * against the allowlist — for the sake of one path shape.
+ *
+ * WHY THIS MODULE EXISTS AT ALL
+ * -----------------------------
+ * It is the fix for a specific, shipped outage. Before channel-teams 0.20.0
+ * there was exactly one Bot Framework webhook, `/api/messages`, and exactly one
+ * static exemption for it in `auth/publicPaths.ts`. 0.20.0 added the per-bot
+ * route `/api/teams/<botSlug>/messages` and the no-slug alias
+ * `/api/teams/messages`; the provisioner was taught to hand Azure the new URL
+ * (`buildTeamsBotMessagingEndpoint`) and the exemption was NOT extended to
+ * match. Every provisioned bot then answered Teams with the middleware's
+ * `401 {"code":"auth.missing"}` — the blanket OB-106 `/api` guard rejecting a
+ * Bot-Framework bearer token because it is not an operator session cookie —
+ * before the bot handler was ever reached. The bots were silent, and every
+ * other link in the chain (app registration, catalog app, Teams channel, chat
+ * install, endpoint URL) was correct.
+ *
+ * The drift was therefore between two things CORE owns and core alone: the URL
+ * core PROVISIONS and the URL core EXEMPTS. Those are now derived from the
+ * constants below, so extending one extends the other. That is the whole point
+ * of this module — a second, hand-retyped copy of the path is exactly the bug
+ * it exists to make unrepresentable.
+ */
+
+/** Root under which channel-teams serves its slug-addressed webhooks. */
+export const TEAMS_MESSAGING_ROOT = '/api/teams';
+
+/** The terminal segment of every messaging route. */
+export const TEAMS_MESSAGING_SEGMENT = 'messages';
+
+/**
+ * The bot-slug charset, as a RegExp SOURCE fragment so it can be embedded in
+ * the exemption pattern below as well as anchored on its own.
+ *
+ * Deliberately conservative: a slug lands verbatim in the Azure bot's
+ * messaging endpoint and in channel-teams' `:botSlug` route, so it may contain
+ * nothing that could re-shape a path. Every character here is left untouched
+ * by `encodeURIComponent`, which is what lets the exemption pattern match the
+ * raw request path that {@link teamsBotMessagingPath} produces.
+ */
+export const TEAMS_BOT_SLUG_SOURCE = '[A-Za-z0-9][A-Za-z0-9._-]{0,63}';
+
+/** {@link TEAMS_BOT_SLUG_SOURCE}, anchored — the provisioner's input guard. */
+export const TEAMS_BOT_SLUG_RE = new RegExp(`^${TEAMS_BOT_SLUG_SOURCE}$`);
+
+/**
+ * The no-slug alias, which channel-teams routes to the DEFAULT bot. Listed in
+ * the manifest as the documented spelling for Azure setup, so a bot registered
+ * by an operator who followed the manifest points here rather than at
+ * `/api/messages`.
+ */
+export const TEAMS_DEFAULT_MESSAGING_PATH = `${TEAMS_MESSAGING_ROOT}/${TEAMS_MESSAGING_SEGMENT}`;
+
+/** The path component of one bot's messaging endpoint. */
+export function teamsBotMessagingPath(botSlug: string): string {
+  return `${TEAMS_MESSAGING_ROOT}/${encodeURIComponent(botSlug)}/${TEAMS_MESSAGING_SEGMENT}`;
+}
+
+/**
+ * The requireAuth exemption pattern. Matched against `req.originalUrl`, hence
+ * the `(?:$|\?)` tail every entry in `auth/publicPaths.ts` carries.
+ *
+ * WHAT IT ADMITS, AND WHY IT IS NOT `^/api/teams`
+ * ----------------------------------------------
+ * Exactly two shapes, both of which are POST-only webhooks whose bodies the
+ * Bot Framework authenticates:
+ *
+ *     /api/teams/messages              → the default bot
+ *     /api/teams/<botSlug>/messages    → that one bot's own credentials
+ *
+ * and nothing else. A prefix exemption for `/api/teams` would be a different
+ * and much worse thing. `publicPaths` is a pure BYPASS, not a terminating
+ * mount (see the header of `platform/publicPathGrants.ts`): a matching URL
+ * skips the session gate and travels on into whatever router answers it. So
+ * the entry must name the URLs that a self-authenticating handler owns TODAY,
+ * not a namespace some future router may mount a session-needing sibling
+ * under. `/api/teams/<slug>/admin` and `/api/teams/settings` do not match this
+ * pattern and 401 exactly as they do now — pinned in
+ * `test/auth/teamsMessagingPublicPath.test.ts`.
+ *
+ * The slug segment is matched with the real slug charset rather than `[^/]+`
+ * for the same reason: only a slug the provisioner would actually have minted
+ * can reach the handler unauthenticated.
+ *
+ * The optional trailing slash is Express's own non-strict routing (`/messages`
+ * and `/messages/` are one route), so it admits no additional handler. It does
+ * NOT admit a subpath: unlike the legacy `/api/messages` entry, which carries
+ * `(?:\/|$|\?)` and therefore exempts anything beneath it, `/messages/anything`
+ * is not matched here.
+ */
+export const TEAMS_MESSAGING_PATH_RE = new RegExp(
+  `^${TEAMS_MESSAGING_ROOT}/(?:${TEAMS_BOT_SLUG_SOURCE}/)?${TEAMS_MESSAGING_SEGMENT}/?(?:$|\\?)`,
+);

--- a/middleware/src/platform/teamsProvisionerService.ts
+++ b/middleware/src/platform/teamsProvisionerService.ts
@@ -69,6 +69,10 @@ import {
   TARGET_DIRECTORY_METHOD_NAMES,
   type TeamsTargetDirectoryMethods,
 } from './teamsTargetDirectory.js';
+import {
+  TEAMS_BOT_SLUG_RE,
+  teamsBotMessagingPath,
+} from './teamsMessagingPath.js';
 
 /** Service-registry key (bare, unversioned). */
 export const TEAMS_PROVISIONER_SERVICE_NAME = 'teamsProvisioner';
@@ -913,8 +917,14 @@ export function requireTeamsProvisioner(
  * channel-teams' per-bot route (`/api/teams/:botSlug/messages`, 0.20.0), so
  * the charset is deliberately conservative: URL-safe, no separators that
  * could re-shape the path.
+ *
+ * Taken from `teamsMessagingPath.ts` rather than declared here, because the
+ * same charset decides which slugs this builder will mint AND which ones the
+ * requireAuth exemption admits. Two copies would let the provisioner hand Azure
+ * an endpoint the session gate then rejects — which is precisely the outage
+ * those shared constants were extracted to make unrepresentable.
  */
-const BOT_SLUG_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+const BOT_SLUG_RE = TEAMS_BOT_SLUG_RE;
 
 /**
  * Build the messaging endpoint handed to Azure for one bot:
@@ -958,5 +968,5 @@ export function buildTeamsBotMessagingEndpoint(
     );
   }
   const basePath = base.pathname.replace(/\/+$/, '');
-  return `${base.origin}${basePath}/api/teams/${encodeURIComponent(botSlug)}/messages`;
+  return `${base.origin}${basePath}${teamsBotMessagingPath(botSlug)}`;
 }

--- a/middleware/test/auth/staticPublicPathsClosedSet.test.ts
+++ b/middleware/test/auth/staticPublicPathsClosedSet.test.ts
@@ -11,6 +11,7 @@ import { createRequireAuth } from '../../src/auth/requireAuth.js';
 import { EmailWhitelist } from '../../src/auth/whitelist.js';
 import { CIMD_METADATA_PATH } from '../../src/services/mcpCimd.js';
 import { PUBLIC_MCP_PATH } from '../../src/mcp/publicMcpPath.js';
+import { teamsBotMessagingPath } from '../../src/platform/teamsMessagingPath.js';
 
 /**
  * Epic #470 C12 — `STATIC_PUBLIC_PATHS` is a CLOSED set of CORE-owned entries.
@@ -66,6 +67,18 @@ const CORE_OWNED_EXEMPTIONS: ReadonlyArray<{
   {
     path: '/api/messages',
     why: 'Bot Framework webhook — the adapter validates the Bot-issued JWT in the handler',
+  },
+  {
+    // Built from the shared builder, for the reason stated above this array:
+    // this path exists in exactly one place (platform/teamsMessagingPath.ts),
+    // which is what keeps the provisioned URL and the exemption in step.
+    path: teamsBotMessagingPath('hr-bot'),
+    why:
+      'the SAME Bot Framework webhook by its slug-addressed spellings ' +
+      '(/api/teams/messages and /api/teams/<botSlug>/messages, channel-teams ' +
+      '0.20.0) — one exemption, one adapter, two URL shapes. Reachability and ' +
+      'the fact that it does NOT open the /api/teams namespace are pinned in ' +
+      'teamsMessagingPublicPath.test.ts',
   },
   {
     path: '/api/v1/operator/mcp-oauth/callback',

--- a/middleware/test/auth/teamsMessagingPublicPath.test.ts
+++ b/middleware/test/auth/teamsMessagingPublicPath.test.ts
@@ -1,0 +1,271 @@
+/**
+ * The Teams messaging webhook must reach its handler without a session — and
+ * nothing else under `/api/teams` may.
+ *
+ * WHAT THIS PINS, AND WHY IT IS NOT AN ENUMERATION OF REGEXES
+ * ----------------------------------------------------------
+ * Every provisioned Teams bot was silent in production. The chain was correct
+ * end to end — app registration, catalog app, Teams channel, chat install,
+ * endpoint URL — except for the last hop: channel-teams 0.20.0 moved the
+ * webhook to `/api/teams/<botSlug>/messages`, `auth/publicPaths.ts` still
+ * exempted only the legacy `/api/messages`, and so the blanket OB-106 `/api`
+ * guard answered Teams `401 {"code":"auth.missing"}` before the bot handler
+ * ran. Measured against production, `/api/messages` answered the Bot
+ * Framework's own "Unauthorized Access. Request is not authorized" while every
+ * `/api/teams/*` spelling answered the session guard's — the difference that
+ * located the bug.
+ *
+ * So these tests assert REACHABILITY through the same chain `src/index.ts`
+ * assembles, not the shape of an allowlist entry. A suite that checked that
+ * `STATIC_PUBLIC_PATHS` contains some regex would have stayed green through the
+ * entire outage: the regex it named was present and correct, and the routes it
+ * did not cover were the broken ones.
+ */
+
+import { strict as assert } from 'node:assert';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { after, before, describe, it } from 'node:test';
+
+import cookieParser from 'cookie-parser';
+import express, { Router } from 'express';
+import type { Request as ExpressRequest, Response as ExpressResponse } from 'express';
+
+import { publicPaths } from '../../src/auth/publicPaths.js';
+import { createRequireAuth } from '../../src/auth/requireAuth.js';
+import { EmailWhitelist } from '../../src/auth/whitelist.js';
+import { buildTeamsBotMessagingEndpoint } from '../../src/platform/teamsProvisionerService.js';
+import {
+  TEAMS_DEFAULT_MESSAGING_PATH,
+  teamsBotMessagingPath,
+} from '../../src/platform/teamsMessagingPath.js';
+
+interface Probe {
+  readonly status: number;
+  readonly body: string;
+}
+
+describe('the Teams messaging webhook is reachable without a session', () => {
+  let server: Server | undefined;
+  let baseUrl = '';
+  let sandboxDeniedListen = false;
+
+  before(async () => {
+    const app = express();
+    app.use(express.json({ limit: '10mb' }));
+    // Load-bearing: without it `req.cookies` is undefined and requireAuth 401s
+    // everything, so the 401 assertions below would pass for the wrong reason.
+    app.use(cookieParser());
+
+    // The production shape, in order. `src/index.ts` mounts the blanket OB-106
+    // guard at `/api` first; channel-teams' router arrives later, through
+    // `channels/routeRegistry.ts#registerRouter`, which mounts straight onto
+    // the app and adds NO auth of its own. The guard is therefore the only
+    // thing standing in front of these routes — which is exactly why an
+    // exemption, and nothing else, decides whether they are reachable.
+    app.use(
+      '/api',
+      createRequireAuth({
+        signingKey: new Uint8Array(64).fill(9),
+        whitelist: new EmailWhitelist('operator@example.com'),
+        publicPaths: publicPaths(),
+      }),
+      Router(),
+    );
+
+    // Stand-in for channel-teams' router: the three messaging routes it really
+    // registers, plus siblings under the same `/api/teams` root. Answering 200
+    // makes "the handler was reached" observable — in production this is where
+    // `adapter.process` validates the Bot-issued JWT and answers its own 401 to
+    // an anonymous caller.
+    const reached = (_req: ExpressRequest, res: ExpressResponse): void => {
+      res.status(200).json({ reached: true });
+    };
+    const pluginRouter = Router();
+    pluginRouter.post('/messages', reached);
+    pluginRouter.post('/teams/messages', reached);
+    pluginRouter.post('/teams/:botSlug/messages', reached);
+    // NOT messaging routes. Nothing mounts these today; they stand for the
+    // sibling somebody adds under `/api/teams` next, and they must keep 401ing.
+    pluginRouter.post('/teams/settings', reached);
+    pluginRouter.post('/teams/:botSlug/admin', reached);
+    pluginRouter.post('/teams/:botSlug/messages/history', reached);
+    app.use('/api', pluginRouter);
+
+    const created = createServer(app);
+    try {
+      await new Promise<void>((resolve, reject) => {
+        created.once('error', reject);
+        created.listen(0, '127.0.0.1', () => {
+          created.removeListener('error', reject);
+          resolve();
+        });
+      });
+    } catch (err) {
+      // Mirrors staticPublicPathsClosedSet.test.ts: some sandboxes refuse
+      // loopback listeners, but skipping in CI would delete this whole suite
+      // while the job stayed green — the failure mode that let the original bug
+      // ship in the first place.
+      if (err instanceof Error && 'code' in err && err.code === 'EPERM') {
+        if (process.env.CI) {
+          throw new Error(
+            'CI must allow a loopback listener for teamsMessagingPublicPath.test.ts. ' +
+              'Without bind(127.0.0.1:0) both halves of this guard — the webhook ' +
+              'being reachable and its siblings staying closed — would be skipped.',
+            { cause: err },
+          );
+        }
+        sandboxDeniedListen = true;
+        return;
+      }
+      throw err;
+    }
+    server = created;
+    baseUrl = `http://127.0.0.1:${String((created.address() as AddressInfo).port)}`;
+  });
+
+  after(async () => {
+    const running = server;
+    if (!running) return;
+    await new Promise<void>((resolve) => {
+      running.close(() => resolve());
+    });
+  });
+
+  const post = async (path: string): Promise<Probe> => {
+    const res = await fetch(`${baseUrl}${path}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ type: 'message' }),
+    });
+    return { status: res.status, body: await res.text() };
+  };
+
+  /**
+   * Every spelling Teams may POST to: the legacy path, the default-bot alias,
+   * and per-bot slugs across the provisioner's charset.
+   */
+  const MESSAGING_PATHS: readonly string[] = [
+    '/api/messages',
+    TEAMS_DEFAULT_MESSAGING_PATH,
+    teamsBotMessagingPath('default'),
+    teamsBotMessagingPath('hr-bot'),
+    teamsBotMessagingPath('Agent_2.beta-1'),
+  ];
+
+  for (const path of MESSAGING_PATHS) {
+    it(`reaches the bot handler for ${path} with no session`, async (t) => {
+      if (sandboxDeniedListen) {
+        t.skip('sandbox refuses loopback listeners');
+        return;
+      }
+      const res = await post(path);
+      assert.equal(
+        res.status,
+        200,
+        `${path} must reach the Bot Framework adapter, which is what authenticates ` +
+          'it (Teams sends a Bot-issued bearer token, never an operator session ' +
+          `cookie). Got ${String(res.status)} ${res.body} — a 401 here is the ` +
+          'session guard answering before routing, i.e. a silent bot.',
+      );
+    });
+  }
+
+  /**
+   * The counter-check, and the reason the exemption names two URL shapes rather
+   * than the `/api/teams` prefix. `publicPaths` is a pure BYPASS: a matching URL
+   * skips the gate and travels on to whatever router answers it. A prefix entry
+   * would hand every present and future sibling the same free pass.
+   */
+  const SESSION_REQUIRED_PATHS: readonly string[] = [
+    '/api/teams/settings',
+    '/api/teams/hr-bot/admin',
+    '/api/teams/hr-bot/messages/history',
+    '/api/teams',
+    '/api/teams/hr-bot',
+    // A slug outside the provisioner's charset never named a real bot.
+    '/api/teams/-nope/messages',
+    // Two segments where the route has one.
+    '/api/teams/hr-bot/extra/messages',
+  ];
+
+  for (const path of SESSION_REQUIRED_PATHS) {
+    it(`still 401s ${path} with no session`, async (t) => {
+      if (sandboxDeniedListen) {
+        t.skip('sandbox refuses loopback listeners');
+        return;
+      }
+      const res = await post(path);
+      assert.equal(
+        res.status,
+        401,
+        `${path} is not a messaging webhook, so nothing about it self-authenticates. ` +
+          'Exempting the /api/teams prefix rather than the two messaging shapes ' +
+          `would open it. Got ${String(res.status)} ${res.body}.`,
+      );
+      const parsed: unknown = JSON.parse(res.body);
+      assert.equal(
+        (parsed as { code?: string }).code,
+        'auth.missing',
+        'the session guard, not a router, must be what answers',
+      );
+    });
+  }
+});
+
+/**
+ * THE RATCHET.
+ *
+ * The outage was a drift between two things core owns alone: the URL core
+ * PROVISIONS into the Azure bot registration, and the URL core EXEMPTS from the
+ * session gate. The provisioner was taught the 0.20.0 path; the allowlist was
+ * not. Both now derive from `platform/teamsMessagingPath.ts`, and this asserts
+ * the property that makes the binding worth having — so a future change to the
+ * provisioned path that the exemption does not cover goes red HERE, at the
+ * commit that makes it, instead of in a field test weeks later.
+ */
+describe('every endpoint the provisioner hands Azure is exempt from the session gate', () => {
+  const SLUGS: readonly string[] = [
+    'default',
+    'hr-bot',
+    'messias',
+    'Agent_2.beta-1',
+    'a',
+    'a'.repeat(64),
+  ];
+
+  for (const slug of SLUGS) {
+    it(`admits the provisioned endpoint for slug '${slug}'`, () => {
+      const endpoint = buildTeamsBotMessagingEndpoint(
+        'https://mw.example.com',
+        slug,
+      );
+      const { pathname } = new URL(endpoint);
+      assert.equal(
+        publicPaths().some((re) => re.test(pathname)),
+        true,
+        `the provisioner hands Azure ${endpoint}, so ${pathname} must skip the ` +
+          'session gate — otherwise the bot it provisions can never answer. If ' +
+          'this fails, the provisioned path and the exemption have drifted apart ' +
+          'again (platform/teamsMessagingPath.ts binds them).',
+      );
+    });
+  }
+
+  it('admits the endpoint served behind a path-prefixed base URL', () => {
+    const endpoint = buildTeamsBotMessagingEndpoint(
+      'https://example.com/omadia/',
+      'hr-bot',
+    );
+    assert.equal(
+      new URL(endpoint).pathname,
+      '/omadia/api/teams/hr-bot/messages',
+    );
+    // The exemption matches `req.originalUrl`, which is the path the reverse
+    // proxy forwards after stripping its own prefix.
+    assert.equal(
+      publicPaths().some((re) => re.test('/api/teams/hr-bot/messages')),
+      true,
+    );
+  });
+});


### PR DESCRIPTION
Every provisioned Teams bot was silent. Not misconfigured, not refused by Microsoft — simply unreachable.

The blanket `requireAuth` mounted at `/api` sits in front of the bot messaging routes, and Teams sends a Bot-issued JWT, not a browser session. Every message was refused before the handler saw it. Measured against production with an unauthenticated `POST`:

```
401  /api/messages                  Unauthorized Access. Request is not authorized   ← Bot Framework
401  /api/teams/messages            {"code":"auth.missing","message":"no session"}   ← session guard
401  /api/teams/hr-bitch/messages   {"code":"auth.missing","message":"no session"}   ← session guard
401  /api/teams/messias/messages    {"code":"auth.missing","message":"no session"}   ← session guard
```

The difference is the proof: the same request reaches the Bot Framework through `/api/messages` and only the guard through every slug route. `/api/messages` has carried an allowlist entry since the single-bot days; the per-bot routes added in 0.20.0 never got one. That is why the legacy bot kept working while every provisioned bot went quiet — and why it failed silently rather than loudly: Teams neither retries a 401 nor reports it.

## The pattern

```
^/api/teams/(?:[A-Za-z0-9][A-Za-z0-9._-]{0,63}/)?messages/?(?:$|\?)
```

Three deliberate narrowings, because `publicPaths` is a **bypass** rather than a terminating mount — a matching URL skips the gate and travels on to whatever answers it:

- **Not a prefix.** An `/api/teams` entry would pre-authorise every sibling anyone mounts there later.
- **The real slug charset**, not `[^/]+`: only a slug the provisioner would actually mint gets through unauthenticated.
- **One optional segment, no subpaths.** Unlike the legacy `/api/messages` entry, `/messages/anything` does not match.

Verified rather than assumed: `/api/teams` is served by nothing in core, in `middleware/packages/`, in web-ui, or in any sibling plugin repo — only channel-teams' three routes.

## The route stays guarded, by the right guard

`adapter.process` has CloudAdapter validate the Bot-issued JWT against **that bot's** app id and password before any turn runs; an unknown slug 404s rather than falling through to the default bot. The field evidence shows it working: `/api/messages` is already exempt and still answers an anonymous POST with the Bot Framework's own refusal. This removes a check that could never pass, not the only check there was.

## Why it drifted, and why it should not again

The gap was not between core and the plugin. It was between two things core owns alone: the URL it **provisions** into Azure and the URL it **exempts**. The provisioner learned the 0.20.0 path; the allowlist did not.

Both now derive from `platform/teamsMessagingPath.ts`, and a test asserts the property directly — every endpoint `buildTeamsBotMessagingEndpoint` produces must be admitted by `publicPaths()`. A future route that changes one without the other goes red at that commit. It is the same idiom the file already uses for two other paths, so this is proportionate rather than new machinery.

## Verification

New suite: **19 tests, 19 pass**. Commenting out the single exemption line produces **11 failures** — and specifically: `/api/messages` still passes and all seven counter-checks still return 401, so the failure is not "everything 401s".

Counter-checks that must stay guarded: `/api/teams/settings`, `/api/teams/hr-bot/admin`, `/api/teams/hr-bot/messages/history`, `/api/teams`, `/api/teams/hr-bot`, `/api/teams/-nope/messages`, `/api/teams/hr-bot/extra/messages`.

middleware: **8111 tests, 8095 pass, 0 fail**; build, typecheck, `typecheck:test` (ratchet 370, no regressions) and lint all clean. web-ui: 1126 pass across 120 files; typecheck, lint and i18n clean.

## Note for review

`publicPathGrants.ts` is the mechanism plugins are told to use, and it was considered. It is barred here — `/api/messages` sits in `CORE_RESERVED_ROOTS` and is never claimable — and it would need a manifest change in a second repo, the plugin re-registering with `auth: 'custom'`, and standing operator consent. Three moving parts, any of which lapsing silences the bots again. Core already treats this webhook as a core-owned exemption; this keeps that decision consistent rather than half-migrating it. Worth a follow-up conversation.

Refs #860.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790758489&installation_model_id=428086&pr_number=966&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F966&signature=0519b106568541b86c61957c75b74efa71543769a40cbf02ebe66365cadfe717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->