### PR TITLE
fix: ride out the catalog replication window instead of failing the first run

### DIFF
--- a/middleware/src/services/teamsProvisioningJob.ts
+++ b/middleware/src/services/teamsProvisioningJob.ts
@@ -300,6 +300,15 @@ export const REGISTRATION_CREATED_DETAIL = 'registration_created';
  *  watching a stalled panel actually needs. */
 export const DELEGATED_UPLOAD_DETAIL = 'delegated_upload';
 
+/** `detail` of the `retrying` event emitted while the install step waits for a
+ *  catalog entry this same run has just published to become referenceable.
+ *
+ *  Its own vocabulary rather than the generic retry detail: "attempt 2 of 5,
+ *  next in 8s" and "the catalog entry is seconds old, waiting for it to
+ *  replicate" send an operator to different places, and only the second one
+ *  ends by itself. */
+export const AWAITING_CATALOG_REPLICATION_DETAIL = 'awaiting_catalog_replication';
+
 /** `detail` of the `progress` event for a silent token rotation. Worth a line
  *  because it is the one moment the run pauses for a reason that is NOT a
  *  fault and that the operator would otherwise never see. */
@@ -634,6 +643,86 @@ function isDeterministicRequestFailure(err: unknown): boolean {
   return status >= 400 && status < 500 && !TIME_DEPENDENT_CLIENT_STATUSES.has(status);
 }
 
+/**
+ * The connector step labels whose request references the catalog entry — the
+ * only two steps of the chain that can be told about an object Graph itself
+ * created moments earlier.
+ *
+ * Matched as the connector emits them (`ProvisioningRequestError.step`); the
+ * `endsWith` in {@link isCatalogReplicationFailure} keeps a future
+ * `users/…/teamwork` direction from needing a fourth entry here.
+ */
+const CATALOG_DEPENDENT_INSTALL_STEPS: readonly string[] = [
+  'chats.installedApps.add',
+  'teams.installedApps.add',
+];
+
+/**
+ * A 400 that names its reason is a VERDICT and stays terminal even inside the
+ * replication window — re-asking cannot change a permission set or a consent.
+ *
+ * Deliberately short and deliberately about CONFIGURATION: these are the
+ * conditions a second, third and fourth attempt would reproduce exactly.
+ * `ResourceSpecificPermissionsMismatch` is already lifted to its own typed
+ * error upstream; it is listed anyway so an older connector that reports it as
+ * a bare `ProvisioningRequestError` also fails on attempt 1.
+ */
+const TERMINAL_INSTALL_400_MARKERS: readonly string[] = [
+  'ResourceSpecificPermissionsMismatch',
+  'Forbidden',
+  'Unauthorized',
+  'AccessDenied',
+  'consent',
+  'permission',
+];
+
+/**
+ * Is this the read-your-writes race that makes an operator press the button
+ * twice (byte5ai/omadia#916, same shape, different API)?
+ *
+ * WHY A BARE 400 IS NOT ENOUGH ON ITS OWN, and how the two are separated.
+ * `POST /appCatalogs/teamsApps` answers 201 from the app-catalog service,
+ * while `POST /chats/{id}/installedApps` is served by the Teams app service —
+ * a different backing store, with no read-your-writes guarantee across the
+ * two. For a few seconds the catalog entry provably exists and provably
+ * cannot be referenced, and Graph reports that as a 400 with no error code
+ * worth the name. A misconfigured install answers 400 as well, so the STATUS
+ * cannot separate them. Three gates do:
+ *
+ *   1. THE STEP — only the two install verbs, the only ones that dereference
+ *      a just-created catalog id.
+ *   2. THE BODY — a 400 that names a configuration reason
+ *      ({@link TERMINAL_INSTALL_400_MARKERS}) is a verdict and is excluded
+ *      here, so a real misconfiguration still fails on attempt 1.
+ *   3. THE RUN'S OWN HISTORY — see `catalogPublishedInRun`. A replication race
+ *      is only POSSIBLE when this same run published the entry. A resumed run
+ *      that skipped step 4 (the entry is minutes or days old) gets the old
+ *      terminal behaviour, because for it a 400 really is a verdict.
+ *
+ * Gate 3 is what makes this safe rather than a blanket "retry 400s": a
+ * configuration error is 400 whether or not we just uploaded, but a
+ * replication 400 cannot occur without a fresh upload. The residual
+ * false-positive — a genuine config error on a run that did publish — costs a
+ * bounded handful of seconds and then fails with a detail that says the
+ * replication window was exhausted, which is strictly more information than
+ * today's bare 400.
+ */
+function isCatalogReplicationFailure(err: unknown): boolean {
+  if (!(err instanceof Error) || err.name !== 'ProvisioningRequestError') return false;
+  if ((err as Error & { status?: unknown }).status !== 400) return false;
+  const step = (err as Error & { step?: unknown }).step;
+  if (
+    typeof step !== 'string' ||
+    !CATALOG_DEPENDENT_INSTALL_STEPS.some((known) => step.endsWith(known))
+  ) {
+    return false;
+  }
+  const message = err.message.toLowerCase();
+  return !TERMINAL_INSTALL_400_MARKERS.some((marker) =>
+    message.includes(marker.toLowerCase()),
+  );
+}
+
 function isProvisionerUnavailable(err: unknown): boolean {
   return (
     err instanceof Error &&
@@ -815,6 +904,18 @@ export interface TeamsProvisioningJobOptions {
   readonly baseRetryDelayMs?: number;
   /** Backoff cap (default 5 min). */
   readonly maxRetryDelayMs?: number;
+  /**
+   * Extra install attempts spent waiting for a catalog entry this run just
+   * published to become referenceable (default 4).
+   *
+   * Small on purpose. Graph closes this window in seconds; a budget large
+   * enough to hide a real misconfiguration would be the wrong trade, because
+   * the cost of guessing wrong is paid on every genuinely broken run.
+   */
+  readonly catalogReplicationAttempts?: number;
+  /** Delay between those attempts (default 4s), capped by
+   *  {@link maxRetryDelayMs} like every other delay in this runner. */
+  readonly catalogReplicationDelayMs?: number;
   /** Test seam — defaults to real timers. */
   readonly timers?: TimerSeam;
   /** #910 — the finishing move that makes the bot live. Absent means the
@@ -856,6 +957,13 @@ export interface TeamsProvisioningJobOptions {
 const DEFAULT_MAX_ATTEMPTS = 5;
 const DEFAULT_BASE_RETRY_DELAY_MS = 5_000;
 const DEFAULT_MAX_RETRY_DELAY_MS = 300_000;
+/** 4 extra install attempts, 4s apart — ~16s of tolerance for the catalog
+ *  replication window. Sized against the field report (a second run started
+ *  by hand, i.e. tens of seconds later, always succeeded) and against the
+ *  opposite risk: a genuinely misconfigured install must still reach the
+ *  operator quickly, so this is bounded in seconds, not minutes. */
+const DEFAULT_CATALOG_REPLICATION_ATTEMPTS = 4;
+const DEFAULT_CATALOG_REPLICATION_DELAY_MS = 4_000;
 /** Node's setTimeout ceiling (2^31 − 1 ms) — a longer delay would overflow
  *  to ~1 ms and burn the whole retry budget instantly. */
 const MAX_TIMER_DELAY_MS = 2 ** 31 - 1;
@@ -876,6 +984,8 @@ export class TeamsProvisioningJobRunner {
   private readonly maxAttempts: number;
   private readonly baseRetryDelayMs: number;
   private readonly maxRetryDelayMs: number;
+  private readonly catalogReplicationAttempts: number;
+  private readonly catalogReplicationDelayMs: number;
   private readonly timers: TimerSeam;
   private readonly syncBotConfig: TeamsBotsConfigSyncPort | undefined;
   private readonly installs: TeamsInstallJobStore | undefined;
@@ -913,6 +1023,23 @@ export class TeamsProvisioningJobRunner {
    *  {@link inFlight}, so an agent id is a sufficient key. */
   private readonly currentStep = new Map<string, TeamsProvisioningStep>();
   /**
+   * Agents whose CURRENT run published or re-published the catalog entry
+   * itself — gate 3 of {@link isCatalogReplicationFailure}.
+   *
+   * This is the causal evidence that a read-your-writes race is even possible.
+   * A resumed run that found `teams_app_id` already set and skipped step 4 is
+   * NOT in this set, so for it an install 400 keeps the old terminal
+   * behaviour: the entry is old, and an old entry that cannot be referenced is
+   * a verdict, not a race. Keyed by agent id like {@link currentStep} — one
+   * run per agent is guaranteed by {@link inFlight} — and cleared per run in
+   * {@link markSettled}, never left to accumulate.
+   */
+  private readonly catalogPublishedInRun = new Set<string>();
+  /** Replication retries already spent by the current run's install step.
+   *  Its OWN budget, deliberately not the chain's `maxAttempts`: this wait is
+   *  seconds of eventual consistency, not a failing chain. */
+  private readonly catalogReplicationRetries = new Map<string, number>();
+  /**
    * Agents held by an operation that is NOT a provisioning run — today only
    * the teardown (`services/teamsIdentityReset.ts`), reserved through
    * {@link acquireExclusive}.
@@ -942,6 +1069,14 @@ export class TeamsProvisioningJobRunner {
     this.maxRetryDelayMs = Math.min(
       opts.maxRetryDelayMs ?? DEFAULT_MAX_RETRY_DELAY_MS,
       MAX_TIMER_DELAY_MS,
+    );
+    this.catalogReplicationAttempts = Math.max(
+      0,
+      opts.catalogReplicationAttempts ?? DEFAULT_CATALOG_REPLICATION_ATTEMPTS,
+    );
+    this.catalogReplicationDelayMs = Math.min(
+      opts.catalogReplicationDelayMs ?? DEFAULT_CATALOG_REPLICATION_DELAY_MS,
+      this.maxRetryDelayMs,
     );
     this.timers = opts.timers ?? REAL_TIMERS;
     this.syncBotConfig = opts.syncBotConfig;
@@ -1195,6 +1330,11 @@ export class TeamsProvisioningJobRunner {
   private markSettled(agentId: string): void {
     const entry = this.inFlight.get(agentId);
     if (entry) entry.settled = true;
+    // Per-run bookkeeping dies with the run: the next run re-establishes its
+    // own evidence, and a stale entry here would let a resumed run inherit a
+    // replication window it never opened.
+    this.catalogPublishedInRun.delete(agentId);
+    this.catalogReplicationRetries.delete(agentId);
   }
 
   /** Stop accepting work and release every pending retry delay. An
@@ -1252,8 +1392,20 @@ export class TeamsProvisioningJobRunner {
       try {
         return await this.advance(request);
       } catch (err) {
+        const waitsBefore = this.catalogReplicationRetries.get(request.agentId) ?? 0;
         const outcome = await this.handleFailure(request, err, attempt);
         if (outcome) return outcome;
+        // A REPLICATION WAIT IS NOT A CHAIN ATTEMPT. The chain did not get a
+        // different answer to the same question; it got the same answer about
+        // an object that did not exist yet. Giving the attempt back keeps the
+        // five chain attempts available for real failures — otherwise a run
+        // that spent four waits would have one attempt left to survive a
+        // throttle. Terminating: the replication budget is finite and this
+        // counter only ever grows, so the compensation happens a bounded
+        // number of times and the loop then advances normally.
+        if ((this.catalogReplicationRetries.get(request.agentId) ?? 0) > waitsBefore) {
+          attempt -= 1;
+        }
         // else: retry delay already awaited — loop again.
       }
     }
@@ -1373,11 +1525,51 @@ export class TeamsProvisioningJobRunner {
 
     const throttle = throttleHintOf(err);
 
+    // BEFORE the deterministic branch, because this IS a deterministic-looking
+    // 4xx — it is the one whose input is not actually identical next time: the
+    // catalog entry it dereferences is still replicating. See
+    // isCatalogReplicationFailure for how it is told apart from a verdict.
+    if (throttle === undefined && this.catalogPublishedInRun.has(agentId)) {
+      const spent = this.catalogReplicationRetries.get(agentId) ?? 0;
+      if (isCatalogReplicationFailure(err) && spent < this.catalogReplicationAttempts) {
+        this.catalogReplicationRetries.set(agentId, spent + 1);
+        const delayMs = this.catalogReplicationDelayMs;
+        this.log(
+          `[teams-provisioning] ${agentId} install rejected with 400 while the catalog entry ` +
+            `is still replicating (wait ${spent + 1}/${this.catalogReplicationAttempts}); ` +
+            `retrying in ${delayMs}ms`,
+        );
+        // Its own detail, not the generic retry one: this wait ends by itself,
+        // and the operator should be told to sit still rather than to look for
+        // a broken configuration. `attempt` here counts WAITS, not chain
+        // attempts — {@link attemptLoop} gives the chain attempt back, so a
+        // run that spends its whole replication budget and then hits a REAL
+        // failure still has all five chain attempts to report it.
+        await this.emit(agentId, this.currentStep.get(agentId) ?? 'run', 'retrying', {
+          attempt: spent + 1,
+          detail: AWAITING_CATALOG_REPLICATION_DETAIL,
+        });
+        await this.sleep(delayMs);
+        return undefined;
+      }
+    }
+
     if (throttle === undefined && isDeterministicRequestFailure(err)) {
       // A 4xx on identical input is a verdict, not a hiccup — see
       // isDeterministicRequestFailure. Stop now, keep the reached state's
       // evidence, and report the real reason on attempt 1.
-      const detail = `${errorMessage(err)} (deterministic — not retried)`;
+      //
+      // Reaching here with a spent replication budget means the wait did not
+      // help, which is itself the finding: say so, so the operator learns
+      // something a bare 400 never told them.
+      const exhausted =
+        (this.catalogReplicationRetries.get(agentId) ?? 0) >=
+          this.catalogReplicationAttempts && isCatalogReplicationFailure(err);
+      const detail = exhausted
+        ? `${errorMessage(err)} (still refused after waiting ` +
+          `${this.catalogReplicationAttempts} times for the catalog entry to replicate — ` +
+          `treat as a configuration error, not a timing one)`
+        : `${errorMessage(err)} (deterministic — not retried)`;
       await this.recordError(agentId, { state: 'failed', lastError: detail });
       return { status: 'failed', agentId, reason: 'error', detail };
     }
@@ -1559,6 +1751,8 @@ export class TeamsProvisioningJobRunner {
         teamsAppExternalId: assets.externalId,
         lastError: null,
       });
+      // A republish is an upload like any other — same window, same gate.
+      this.catalogPublishedInRun.add(agentId);
       // Deliberately NO early return. The chain's own step 5 installs the
       // refreshed app into the requested team, records the binding (#919)
       // and re-asserts the plugin config — a republish that returned here
@@ -1728,6 +1922,11 @@ export class TeamsProvisioningJobRunner {
         teamsAppId,
         lastError: null,
       });
+      // Gate 3 of isCatalogReplicationFailure: this run just put the entry
+      // there (uploaded it, or resolved one so fresh the lookup was the first
+      // thing that could see it), so an install 400 in the next few seconds is
+      // allowed to be a replication race rather than a verdict.
+      this.catalogPublishedInRun.add(agentId);
       await this.emit(agentId, 'catalog_uploaded', 'succeeded');
     } else {
       await this.emit(agentId, 'package_built', 'succeeded', {

--- a/middleware/test/teamsProvisioningJob.test.ts
+++ b/middleware/test/teamsProvisioningJob.test.ts
@@ -252,6 +252,8 @@ function makeRunner(opts: {
   maxAttempts?: number;
   baseRetryDelayMs?: number;
   maxRetryDelayMs?: number;
+  catalogReplicationAttempts?: number;
+  catalogReplicationDelayMs?: number;
   getProvisioner?: () => TeamsProvisionerPort;
   syncBotConfig?: TeamsBotsConfigSyncPort;
   installs?: TeamsInstallJobStore;
@@ -271,6 +273,12 @@ function makeRunner(opts: {
     baseRetryDelayMs: opts.baseRetryDelayMs ?? 1000,
     ...(opts.maxRetryDelayMs !== undefined
       ? { maxRetryDelayMs: opts.maxRetryDelayMs }
+      : {}),
+    ...(opts.catalogReplicationAttempts !== undefined
+      ? { catalogReplicationAttempts: opts.catalogReplicationAttempts }
+      : {}),
+    ...(opts.catalogReplicationDelayMs !== undefined
+      ? { catalogReplicationDelayMs: opts.catalogReplicationDelayMs }
       : {}),
     ...(opts.syncBotConfig ? { syncBotConfig: opts.syncBotConfig } : {}),
     ...(opts.installs ? { installs: opts.installs } : {}),
@@ -1426,5 +1434,171 @@ describe('botHandleUnavailableDetail (#921)', () => {
     const classified = classifyTeamsProvisioningError(detail);
     assert.equal(classified.code, 'bot_handle_unavailable');
     assert.equal(classified.raw, detail);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Catalog replication window — "one press of the button is enough"
+// ---------------------------------------------------------------------------
+
+/** The bare 400 the field report describes: Graph refuses the install right
+ *  after the upload and says nothing useful about why. */
+function bareInstallBadRequest(): Error {
+  return namedError(
+    'ProvisioningRequestError',
+    'graph chats.installedApps.add 400 POST https://graph.microsoft.com/v1.0/chats/19:x/installedApps body={"error":{"code":"BadRequest","message":""}}',
+    { resource: 'graph', step: 'chats.installedApps.add', status: 400 },
+  );
+}
+
+describe('TeamsProvisioningJobRunner — catalog replication window', () => {
+  it('rides out a bare 400 on the install and finishes in ONE run', async () => {
+    // The whole point: the operator presses the button once. Before this, the
+    // first run died on the 400 and only a second, hand-started run went
+    // through — which is exactly the double-trigger the field report describes.
+    let installs = 0;
+    const { runner, store, provisioner } = makeRunner({
+      catalogReplicationDelayMs: 10,
+      behaviour: {
+        installToTeam: () => {
+          installs += 1;
+          return installs <= 2 ? Promise.reject(bareInstallBadRequest()) : undefined;
+        },
+      },
+    });
+
+    const result = await runner.enqueue(REQUEST);
+
+    assert.equal(result.status, 'installed');
+    assert.equal(installs, 3, 'two refusals ridden out, third install accepted');
+    assert.equal(store.row?.state, 'installed');
+    assert.equal(store.row?.lastError, null);
+    // The upload happened exactly once — the waits re-drive only the install.
+    assert.equal(
+      provisioner.calls.filter((c) => c.startsWith('uploadToCatalog')).length,
+      1,
+    );
+  });
+
+  it('a 400 that NAMES a configuration reason still fails on attempt 1', async () => {
+    // The other half of the trade. Waiting cannot grant a permission, so a
+    // named 400 must not buy itself a single extra second.
+    let installs = 0;
+    const { runner, store } = makeRunner({
+      catalogReplicationDelayMs: 10,
+      behaviour: {
+        installToTeam: () => {
+          installs += 1;
+          return Promise.reject(
+            namedError(
+              'ProvisioningRequestError',
+              'graph teams.installedApps.add 400 POST https://graph.microsoft.com/... body={"error":{"code":"ResourceSpecificPermissionsMismatch"}}',
+              { resource: 'graph', step: 'teams.installedApps.add', status: 400 },
+            ),
+          );
+        },
+      },
+    });
+
+    const result = await runner.enqueue(REQUEST);
+
+    assert.equal(installs, 1, 'a verdict is not retried, not even once');
+    assert.equal(result.status, 'failed');
+    // Named 400s are lifted to their own typed detail one branch EARLIER than
+    // the deterministic guard, so the assertion is on the actionable sentence
+    // rather than on the word "deterministic". What matters here is that the
+    // replication window never opened: one install call, and a message that
+    // sends the operator to the permission grant.
+    const lastError = String(store.row?.lastError);
+    assert.ok(lastError.includes('rsc_permissions_mismatch'), lastError);
+    assert.ok(!lastError.includes('replicate'), lastError);
+  });
+
+  it('a run that SKIPPED the upload treats the same bare 400 as terminal', async () => {
+    // Gate 3. The catalog entry is old here (the row already carries a
+    // teams_app_id, so step 4 skips itself), and an old entry that cannot be
+    // referenced is a verdict — there is no replication race to wait out.
+    let installs = 0;
+    const { runner, provisioner } = makeRunner({
+      catalogReplicationDelayMs: 10,
+      storeOverrides: {
+        state: 'catalog_uploaded',
+        appId: 'app-123',
+        tenantId: 'tenant-9',
+        teamsAppId: 'catalog-77',
+        teamsAppExternalId: 'external-abc',
+      },
+      behaviour: {
+        installToTeam: () => {
+          installs += 1;
+          return Promise.reject(bareInstallBadRequest());
+        },
+      },
+    });
+
+    const result = await runner.enqueue(REQUEST);
+
+    assert.equal(installs, 1, 'no upload this run ⇒ no replication window');
+    assert.equal(result.status, 'failed');
+    assert.ok(!provisioner.calls.some((c) => c.startsWith('uploadToCatalog')));
+  });
+
+  it('gives up after the window and says the wait did not help', async () => {
+    let installs = 0;
+    const { runner, store } = makeRunner({
+      catalogReplicationAttempts: 3,
+      catalogReplicationDelayMs: 10,
+      behaviour: {
+        installToTeam: () => {
+          installs += 1;
+          return Promise.reject(bareInstallBadRequest());
+        },
+      },
+    });
+
+    const result = await runner.enqueue(REQUEST);
+
+    assert.equal(installs, 4, 'first attempt plus the three waits');
+    assert.equal(result.status, 'failed');
+    const lastError = String(store.row?.lastError);
+    assert.ok(
+      lastError.includes('still refused after waiting'),
+      `expected an exhausted-window detail, got: ${lastError}`,
+    );
+    // The operator must not be sent looking for a timing problem twice.
+    assert.ok(lastError.includes('configuration error'), lastError);
+  });
+
+  it('waiting does not eat the chain attempts a real failure needs', async () => {
+    // A replication wait is not a chain attempt. With the two budgets
+    // separate, a run may spend the whole window AND still get its full five
+    // (here: three) attempts at whatever fails next.
+    let installs = 0;
+    const { runner } = makeRunner({
+      maxAttempts: 3,
+      baseRetryDelayMs: 10,
+      catalogReplicationAttempts: 2,
+      catalogReplicationDelayMs: 10,
+      behaviour: {
+        installToTeam: () => {
+          installs += 1;
+          if (installs <= 2) return Promise.reject(bareInstallBadRequest());
+          return Promise.reject(
+            namedError(
+              'ProvisioningRequestError',
+              'graph chats.installedApps.add 503 POST https://graph.microsoft.com/...',
+              { resource: 'graph', step: 'chats.installedApps.add', status: 503 },
+            ),
+          );
+        },
+      },
+    });
+
+    const result = await runner.enqueue(REQUEST);
+
+    assert.equal(result.status, 'failed');
+    // 2 replication waits + 3 chain attempts. Were the waits charged to the
+    // chain, this would be 3 in total.
+    assert.equal(installs, 5, 'the two budgets are independent');
   });
 });


### PR DESCRIPTION
Provisioning regularly had to be started **twice**: the first run failed, the second went through. Observed as a bare `400 BadRequest` — no error code, no message — on the install step, moments after the catalog upload.

That shape is familiar. It is the same class as #916, where a freshly created Entra object was not yet visible to the call that came next, and the fix was to wait rather than to give up. Here it is the catalog entry: seconds old, and the install dereferences it before it has propagated.

## Telling a timing failure from a real one

Not by status code — both are 400. Three gates, all of which must hold before anything waits:

**The step.** Only the two install verbs, the ones that dereference a catalog id that this run just minted. Nothing else retries.

**The body.** A 400 that *names* its reason — RSC mismatch, consent, permission, forbidden — stays terminal on the first attempt. Only a 400 that says nothing is a candidate.

**The causal history of this run.** Waiting happens only if *this* run published the catalog entry. A resume that skipped step 4 keeps the old behaviour.

Gate three carries the weight. A configuration error is a 400 whether or not we just uploaded something — but a replication 400 cannot occur without a fresh upload. Without that gate the first two would eventually wave through a genuine misconfiguration.

The residual cost of being wrong is four waits of four seconds, ending in a message that says the request was *still* refused after waiting and should be treated as a configuration problem rather than a timing one.

The two budgets are deliberately separate: a wait cycle does not consume a chain attempt. Otherwise a run that waited four times would have a single attempt left for a real throttle.

## Verification

middleware: **8116 tests, 8100 pass, 0 fail**; build, typecheck, `typecheck:test` (ratchet 370, no regressions) and lint all clean.

One honest limit: the replication window was never observed directly. The bare 400 comes from a field report, not from a log I read. The direction is supported by the #916 precedent and fenced by gate three, but it is reasoned rather than measured — the proof will be the next provisioning run showing the wait in its progress log.

Refs #860.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/969"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790764129&installation_model_id=428086&pr_number=969&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F969&signature=afa041f984eb498292259e3671bf283ae690f2680fb648f40febdffe310f55bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->