### PR TITLE
fix: let a provisioned Teams bot answer to the name it was given

### DIFF
--- a/middleware/packages/harness-orchestrator/src/buildOrchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/buildOrchestrator.ts
@@ -119,6 +119,20 @@ export interface AgentRuntimeConfig {
    */
   readonly identityInstructions?: string;
   /**
+   * #967 — the name this Agent answers to (`agent_identities.display_name`),
+   * already trimmed and non-empty when present.
+   *
+   * A LAYER, NOT A SLOT. Unlike {@link identityInstructions}, this does not
+   * replace the assistant identity — it is appended to whichever identity text
+   * ends up applying. The name is one fact about the Agent; the identity is
+   * everything else it should do, and an operator who only typed a name into
+   * the Teams provisioning form has not asked to discard the platform's
+   * behaviour text along with its name.
+   *
+   * Absent → the identity text is used verbatim, exactly as before.
+   */
+  readonly identityName?: string;
+  /**
    * W5 memory-ACL — per-Agent rollout switch for chat-context-scoped memory.
    * Read from the `agents.context_memory` column (migration 0050).
    *
@@ -279,6 +293,40 @@ export interface BuiltOrchestrator {
 }
 
 /**
+ * Fold an Agent's own name into the identity text it speaks with (#967).
+ *
+ * THE PROBLEM THIS SOLVES. `assistantIdentity` is the opening section of the
+ * system prompt, and a deployment's platform identity introduces the platform's
+ * assistant by name. A bot provisioned into Teams as `Messias` therefore went
+ * on introducing itself under that platform name: outwardly one bot, inwardly
+ * another, which reads to a user as two different things wearing one avatar.
+ *
+ * APPENDED, NEVER SUBSTITUTED. The identity text is prose an operator wrote;
+ * there is no reliable way to find and replace a name inside it, and trying
+ * would corrupt text that merely mentions the name. Stating the name last is
+ * both safe and unambiguous — the closing instruction is the one that binds.
+ *
+ * ONLY THE NAME. No description, no persona, no tone: those belong to the
+ * operator's identity form, and inventing them here would put words in an
+ * agent's mouth that nobody authored. An Agent that has a name and nothing
+ * else keeps every behaviour it had, and answers to its name.
+ *
+ * A blank or absent name returns the identity byte-for-byte, which is what
+ * keeps the prompt (and its cache key) unchanged for every Agent that never
+ * authored one.
+ */
+export function withAgentName(
+  identity: string | undefined,
+  name: string | undefined,
+): string | undefined {
+  const trimmedName = name?.trim();
+  if (!trimmedName) return identity;
+  const nameLine = `Dein Name ist ${trimmedName}. Stelle dich unter diesem Namen vor und verwende ihn, wenn du von dir sprichst — er gilt auch dann, wenn oben ein anderer Name für dich genannt wird.`;
+  const trimmedIdentity = identity?.trim();
+  return trimmedIdentity ? `${trimmedIdentity}\n\n${nameLine}` : nameLine;
+}
+
+/**
  * Build one Agent's `Orchestrator`, its optional verifier wrapper, and its
  * `chatAgent` bundle. Each call produces a fully independent instance set —
  * no mutable state is shared between two calls.
@@ -426,6 +474,17 @@ export function buildOrchestratorForAgent(
   // opening section of the system prompt.
   const agentAssistantIdentity =
     config.identityInstructions?.trim() || deps.assistantIdentity;
+  // #967 — and then the Agent's own name is layered on top of whichever text
+  // that resolved to. This is the ONLY place the authored display name enters
+  // the system prompt, and it is deliberately the last word: the platform
+  // identity names the platform's assistant, so a bot provisioned as
+  // `Messias` would otherwise keep introducing itself with that name while
+  // Teams shows another. Overriding beats editing — we cannot know where a
+  // name appears inside operator-written prose.
+  const assistantIdentityWithName = withAgentName(
+    agentAssistantIdentity,
+    config.identityName,
+  );
 
   // domainTools is intentionally empty at construct — sub-agents self-register
   // post-activate via `dynamicAgentRuntime.attachOrchestrator(bundle.raw)`.
@@ -510,9 +569,10 @@ export function buildOrchestratorForAgent(
     ...(deps.graphTenantId ? { graphTenantId: deps.graphTenantId } : {}),
     // #914 — the Agent's own behaviour text wins over the platform-wide one.
     // Resolved once, here, so the two call sites below cannot disagree about
-    // which identity this Agent speaks with.
-    ...(agentAssistantIdentity
-      ? { assistantIdentity: agentAssistantIdentity }
+    // which identity this Agent speaks with. #967 folds the Agent's name into
+    // that same resolved value for the same reason.
+    ...(assistantIdentityWithName
+      ? { assistantIdentity: assistantIdentityWithName }
       : {}),
     ...(deps.aiDisclosure ? { aiDisclosure: deps.aiDisclosure } : {}),
     ...(deps.aiDisclosureSeenStore
@@ -568,8 +628,8 @@ export function buildOrchestratorForAgent(
         agent: new CliChatAgent({
           dispatch,
           model: config.model.replace(/-cli$/, '') || 'sonnet',
-          ...(agentAssistantIdentity
-            ? { systemPrompt: agentAssistantIdentity }
+          ...(assistantIdentityWithName
+            ? { systemPrompt: assistantIdentityWithName }
             : {}),
         }),
         raw: orchestrator,

--- a/middleware/packages/harness-orchestrator/src/registry/applyDiff.ts
+++ b/middleware/packages/harness-orchestrator/src/registry/applyDiff.ts
@@ -254,6 +254,13 @@ export function buildForAgent(
       ...(agent.instructions?.trim()
         ? { identityInstructions: agent.instructions.trim() }
         : {}),
+      // #967 — the agent's authored NAME. Layered onto whichever identity
+      // text applies rather than replacing it, so a bot that was given a name
+      // introduces itself under that name without losing the behaviour the
+      // platform (or its own instructions) already describe.
+      ...(agent.identityName?.trim()
+        ? { identityName: agent.identityName.trim() }
+        : {}),
     },
     deps,
   );
@@ -296,6 +303,13 @@ function runtimeChangeReasons(oldAgent: AgentRow, newAgent: AgentRow): string[] 
   // registry would keep serving the Orchestrator built from the old text.
   if ((oldAgent.instructions ?? '') !== (newAgent.instructions ?? '')) {
     reasons.push('identity_instructions');
+  }
+  // #967 — the authored name is part of the system prompt too (it is what the
+  // bot calls itself), so a rename has to reach the running Agent. Without
+  // this reason the operator would rename the bot in Teams and in the UI and
+  // keep hearing the old name in chat until some unrelated edit rebuilt it.
+  if ((oldAgent.identityName ?? '') !== (newAgent.identityName ?? '')) {
+    reasons.push('identity_display_name');
   }
   // `name` / `description` are display-only and never warrant a rebuild —
   // they would invalidate sessions for no semantic gain.

--- a/middleware/packages/harness-orchestrator/src/registry/configStore.ts
+++ b/middleware/packages/harness-orchestrator/src/registry/configStore.ts
@@ -72,6 +72,22 @@ export interface AgentRow {
    * applies, exactly as before this column existed.
    */
   readonly instructions?: string | null;
+  /**
+   * #967 — the agent's authored NAME (`agent_identities.display_name`), joined
+   * in beside {@link instructions} and read the same way: read-only here,
+   * written through `platform/agentIdentityStore.ts`.
+   *
+   * Distinct from {@link name}, which is the registry label an operator gave
+   * the agent row (`hr`, `Sales Agent`). This one is the name the bot WEARS —
+   * the Teams manifest name, and the name it must introduce itself with. It
+   * is deliberately NOT resolved against `name` here: falling back would put
+   * a registry label into the system prompt of every agent that never
+   * authored an identity, changing prompts that are correct today.
+   *
+   * `null`/absent means "no authored name" — the assistant identity is used
+   * verbatim, exactly as before this column was joined.
+   */
+  readonly identityName?: string | null;
   readonly createdAt: Date;
   readonly updatedAt: Date;
 }
@@ -246,6 +262,9 @@ interface AgentDbRow {
    *  not join: a write never changes the identity, and a caller that needs it
    *  re-reads. */
   identity_instructions?: string | null;
+  /** #967 — `agent_identities.display_name`, joined in by the same three read
+   *  queries and absent on the same write paths as `identity_instructions`. */
+  identity_display_name?: string | null;
   created_at: Date;
   updated_at: Date;
 }
@@ -296,6 +315,7 @@ function mapAgent(row: AgentDbRow): AgentRow {
     canvasPosition: row.canvas_position ?? null,
     contextMemory: parseContextMemoryMode(row.context_memory),
     instructions: row.identity_instructions ?? null,
+    identityName: row.identity_display_name ?? null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -347,7 +367,8 @@ function mapPlatformSettings(
  * runs on every dashboard load and every registry rebuild.
  */
 const AGENT_SELECT =
-  'SELECT a.*, COALESCE(i.composed_prompt, i.instructions) AS identity_instructions ' +
+  'SELECT a.*, COALESCE(i.composed_prompt, i.instructions) AS identity_instructions, ' +
+  'i.display_name AS identity_display_name ' +
   'FROM agents a LEFT JOIN agent_identities i ON i.agent_id = a.id';
 
 export class ConfigStore {

--- a/middleware/src/platform/agentIdentityStore.ts
+++ b/middleware/src/platform/agentIdentityStore.ts
@@ -302,6 +302,68 @@ export class AgentIdentityStore {
    * that changes without a content change is the model family — see
    * {@link recompose}.
    */
+  /**
+   * Give an agent the name it already wears OUTWARD, but only if it has no
+   * name of its own yet (byte5ai/omadia#967).
+   *
+   * Teams provisioning asks the operator for a display name, writes it onto
+   * the bot registration and into the app package, and — before this method —
+   * nowhere else. The bot was then called `Messias` in the tenant while its
+   * identity stayed unauthored, so the prompt fell through to the platform
+   * assistant and the bot introduced itself under the platform's name. One
+   * bot, two names, and the mismatch is the first thing a user sees.
+   *
+   * NEVER OVERWRITES AN AUTHORED NAME. That is the whole point of the method
+   * existing instead of a `save()` from the caller: an operator who wrote a
+   * name (and a persona, and a tone) must not lose it because someone re-ran
+   * provisioning. Losing curated work is strictly worse than the mismatch
+   * this repairs.
+   *
+   * THE GUARD IS THE `WHERE`, NOT A READ. A read-then-write from the route
+   * would leave a window in which a concurrent identity save is clobbered.
+   * `ON CONFLICT … DO UPDATE … WHERE` evaluates the predicate against the
+   * CURRENT row inside the same statement, so the refusal is atomic and the
+   * worst a race can do is decide the order, never lose a write.
+   *
+   * BLANK COUNTS AS UNSET, exactly as {@link resolveAgentIdentity} reads it:
+   * a row whose `display_name` is `''` resolves to the registry name today,
+   * so filling it takes nothing away. A row with an actual name is refused.
+   *
+   * NO REVISION BUMP. The Teams manifest already renders this name — it falls
+   * back to the provisioning row's `display_name`, which is the value being
+   * adopted — so the package is byte-identical and a re-publish would buy
+   * nothing. What DOES change is the system prompt, and that travels through
+   * the registry rebuild, not through the manifest version.
+   *
+   * Returns the row as it now stands: the seeded one, or the authored one
+   * left untouched. `undefined` only when the refusal met no row at all,
+   * which cannot happen (the INSERT would have created it).
+   */
+  async adoptDisplayName(
+    agentId: string,
+    displayName: string,
+  ): Promise<AgentIdentityRecord | undefined> {
+    const name = nonEmpty(displayName);
+    // Nothing to adopt. Seeding a blank would create an empty row whose only
+    // effect is to switch the manifest onto the revision-based version.
+    if (name === null) return this.getByAgentId(agentId);
+    const res = await this.pool.query<AgentIdentityMetaRow>(
+      `INSERT INTO agent_identities (agent_id, display_name)
+       VALUES ($1, $2)
+       ON CONFLICT (agent_id) DO UPDATE SET
+         display_name = EXCLUDED.display_name,
+         updated_at   = now()
+       WHERE agent_identities.display_name IS NULL
+          OR btrim(agent_identities.display_name) = ''
+       RETURNING ${META_COLUMNS}`,
+      [agentId, name],
+    );
+    const row = res.rows[0];
+    // No RETURNING row = the WHERE refused the update: this agent already has
+    // an authored name. Report what is actually stored rather than nothing.
+    return row ? mapRow(row) : this.getByAgentId(agentId);
+  }
+
   async save(
     agentId: string,
     input: AgentIdentitySaveInput,

--- a/middleware/src/routes/operatorAgents.ts
+++ b/middleware/src/routes/operatorAgents.ts
@@ -1248,6 +1248,55 @@ function startProvisioningRun(
     });
 }
 
+/**
+ * Carry the provisioned Teams name into the agent's own identity (#967).
+ *
+ * WHY HERE. This is the one moment an operator states what the bot is called.
+ * The name reaches the bot registration and the app package from the
+ * provisioning row; before this call it reached nothing else, so the agent
+ * kept speaking as the platform assistant — outwardly `Messias`, inwardly the
+ * platform's name. Seeding at the START of the chain rather than at its end
+ * means the very first package and the very first turn already agree, and a
+ * chain that fails at step two still leaves the operator's chosen name
+ * visible on the agent page.
+ *
+ * FROM THE STORED ROW, NOT THE REQUEST BODY. `ensureForAgent` is
+ * create-if-absent: a re-POST carrying a different `display_name` does NOT
+ * rename an existing Teams identity. Seeding from the body would therefore
+ * write a name the tenant does not use — re-creating the exact split this
+ * fixes, pointing the other way. The row's `displayName` is what the bot
+ * actually wears.
+ *
+ * NEVER FAILS THE REQUEST. Provisioning is the operator's actual intent; the
+ * name adoption is convergence on top of it. A failure is logged and the
+ * chain proceeds, in the same spirit as the `teams_bots` config sync.
+ */
+async function adoptProvisionedDisplayName(
+  identity: OperatorAgentIdentityDeps | undefined,
+  registry: OrchestratorRegistry,
+  agent: { readonly id: string; readonly slug: string },
+  displayName: string,
+): Promise<void> {
+  // No identity store wired (minimal mount, no DATABASE_URL): nothing to
+  // seed, and provisioning never depended on it.
+  if (!identity) return;
+  try {
+    const before = await identity.store.getByAgentId(agent.id);
+    const after = await identity.store.adoptDisplayName(agent.id, displayName);
+    // The store refuses an authored name, so an unchanged value means either
+    // "already named" or "already named exactly this" — neither is a change
+    // the running Agent needs to hear about. Only a real adoption reloads,
+    // because the name is part of this Agent's system prompt and a stored
+    // name nobody rebuilt for is a name the bot never says.
+    if ((before?.displayName ?? null) === (after?.displayName ?? null)) return;
+    await registry.reload();
+  } catch (err) {
+    console.warn(
+      `[operator-agents] could not adopt the provisioned Teams name for '${agent.slug}' into its identity: ${err instanceof Error ? err.message : String(err)} — provisioning continues; the operator can set the name on the agent's identity page`,
+    );
+  }
+}
+
 /** Derive a URL- and Azure-safe default bot slug from an agent slug.
  *  Bounds and charset follow channel-teams' BOT_SLUG_PATTERN (max 63); the
  *  dash-trim runs AFTER the length cut so a truncation can never leave a
@@ -1275,6 +1324,12 @@ export interface OperatorAgentIdentityStore {
   recompose(
     agentId: string,
     composed: AgentIdentityComposedPrompt,
+  ): Promise<AgentIdentityRecord | undefined>;
+  /** #967 — adopt the provisioned Teams name, ONLY when none is authored.
+   *  The refusal lives in the store's SQL; see `adoptDisplayName`. */
+  adoptDisplayName(
+    agentId: string,
+    displayName: string,
   ): Promise<AgentIdentityRecord | undefined>;
   setAvatar(
     agentId: string,
@@ -1859,9 +1914,21 @@ export function createOperatorAgentsRouter(
       // contract as every other write on this router; the diff decides whether
       // an Orchestrator is actually rebuilt.
       // Normalised on both sides: a first save has no `before` at all, and
-      // `undefined !== null` would rebuild every Agent whose operator merely
-      // typed a display name — dropping live sessions for a label change.
-      if ((before?.composed.text ?? null) !== (composed.text ?? null)) {
+      // `undefined !== null` would rebuild every Agent over a value that did
+      // not actually move.
+      //
+      // #967 — the display name is on this list now. It used to be excluded
+      // as "a label change, not worth dropping sessions", which was true
+      // while the name only reached the Teams manifest. It reaches the system
+      // prompt as well now (`AgentRow.identityName`), so leaving it out would
+      // store a rename the agent never speaks — the same silent no-op this
+      // reload exists to prevent for `instructions`.
+      const nameChanged =
+        (before?.displayName ?? '').trim() !== (body.display_name ?? '').trim();
+      if (
+        (before?.composed.text ?? null) !== (composed.text ?? null) ||
+        nameChanged
+      ) {
         await live.registry.reload();
       }
       // A save whose CONTENT did not change returns the stored row
@@ -2267,6 +2334,14 @@ export function createOperatorAgentsRouter(
         }
         throw err;
       }
+      // #967 — before the run, so the first package and the first turn are
+      // built from an identity that already carries the operator's name.
+      await adoptProvisionedDisplayName(
+        options.getAgentIdentity?.(),
+        live.registry,
+        existing,
+        row.displayName,
+      );
       startProvisioningRun(deps, existing, target.id, { targetKind: target.kind });
       res.status(202).json({
         ok: true,
@@ -2907,6 +2982,17 @@ export function createOperatorAgentsRouter(
         teamId: target.id,
         targetKind: target.kind,
       });
+      // #967 — same adoption as the provisioning POST, and for the agents
+      // that need it most: an identity provisioned BEFORE this existed has no
+      // name of its own, and installing it into a(nother) team is the next
+      // operator action that passes through here. Idempotent and guarded, so
+      // running it on an already-named identity costs one refused UPDATE.
+      await adoptProvisionedDisplayName(
+        options.getAgentIdentity?.(),
+        live.registry,
+        agent,
+        updated.displayName,
+      );
       startProvisioningRun(deps, agent, target.id, { targetKind: target.kind });
       res.status(202).json({
         ok: true,

--- a/middleware/test/agentIdentityStore.pg.test.ts
+++ b/middleware/test/agentIdentityStore.pg.test.ts
@@ -324,4 +324,90 @@ describe('AgentIdentityStore against a real Postgres (#914)', { skip: !pgAvailab
     await pool.query('DELETE FROM agents WHERE id = $1', [agentId]);
     assert.equal(await store.getByAgentId(agentId), undefined);
   });
+
+  // ── #967 — adopting the provisioned Teams name ──────────────────────
+  //
+  // The refusal is an `ON CONFLICT … DO UPDATE … WHERE` predicate, so it can
+  // only be proven against a real Postgres: a read-then-write in the caller
+  // would pass the same assertions while still losing a concurrent save.
+
+  it('adopts a name for an agent that has no identity row at all', async () => {
+    const adopted = await store.adoptDisplayName(agentId, 'Messias');
+
+    assert.equal(adopted?.displayName, 'Messias');
+    assert.equal((await store.getByAgentId(agentId))?.displayName, 'Messias');
+    // A fresh row starts at revision 1: the Teams manifest already renders
+    // this exact name (it falls back to the provisioning row), so there is no
+    // package change to publish and nothing to bump for.
+    assert.equal(adopted?.revision, 1);
+  });
+
+  it('REFUSES to overwrite an authored name, and leaves the whole row alone', async () => {
+    // The condition the whole feature hangs on. Someone built this by hand.
+    const curated = await store.save(agentId, {
+      ...EMPTY,
+      displayName: 'Karen',
+      shortDescription: 'Kümmert sich um HR-Anliegen',
+      instructions: 'Antworte knapp und freundlich.',
+      composed: { text: 'Antworte knapp und freundlich.', family: 'sonnet' },
+    });
+
+    const after = await store.adoptDisplayName(agentId, 'Messias');
+
+    assert.equal(after?.displayName, 'Karen');
+    assert.equal(after?.shortDescription, 'Kümmert sich um HR-Anliegen');
+    assert.equal(after?.instructions, 'Antworte knapp und freundlich.');
+    assert.equal(after?.composed.text, 'Antworte knapp und freundlich.');
+    // Not even a revision bump or an `updated_at` touch: nothing happened.
+    assert.equal(after?.revision, curated.revision);
+    assert.deepEqual(after?.updatedAt, curated.updatedAt);
+  });
+
+  it('treats a blank authored name as unset and fills it', async () => {
+    // `resolveAgentIdentity` already reads blank as "inherit from the
+    // registry", so adopting takes nothing away — and the rest of the row
+    // must survive untouched.
+    await store.save(agentId, {
+      ...EMPTY,
+      displayName: '   ',
+      instructions: 'Antworte knapp.',
+    });
+
+    const after = await store.adoptDisplayName(agentId, 'Messias');
+
+    assert.equal(after?.displayName, 'Messias');
+    assert.equal(after?.instructions, 'Antworte knapp.');
+  });
+
+  it('is idempotent: adopting twice writes once', async () => {
+    const first = await store.adoptDisplayName(agentId, 'Messias');
+    const second = await store.adoptDisplayName(agentId, 'Messias');
+
+    assert.equal(second?.displayName, 'Messias');
+    assert.equal(second?.revision, first?.revision);
+    // The second call hit the refusal branch (a name is already authored),
+    // so it must not have moved the timestamp either.
+    assert.deepEqual(second?.updatedAt, first?.updatedAt);
+  });
+
+  it('adopting a blank name creates nothing', async () => {
+    // An empty row whose only effect is switching the manifest onto the
+    // revision-based version number is worse than no row.
+    assert.equal(await store.adoptDisplayName(agentId, '   '), undefined);
+    assert.equal(await store.getByAgentId(agentId), undefined);
+  });
+
+  it('an adopted name is what the registry joins into the system prompt', async () => {
+    // The column the orchestrator's AGENT_SELECT reads (#967). Pinned here so
+    // the store and that join cannot drift apart silently — a name in a
+    // column nobody reads is the bug this feature exists to fix.
+    await store.adoptDisplayName(agentId, 'Messias');
+    const { rows } = await pool.query<{ identity_display_name: string | null }>(
+      `SELECT i.display_name AS identity_display_name
+         FROM agents a LEFT JOIN agent_identities i ON i.agent_id = a.id
+        WHERE a.id = $1`,
+      [agentId],
+    );
+    assert.equal(rows[0]?.identity_display_name, 'Messias');
+  });
 });

--- a/middleware/test/buildForAgentIdentity.test.ts
+++ b/middleware/test/buildForAgentIdentity.test.ts
@@ -140,3 +140,103 @@ test('an unchanged identity does not rebuild anything', () => {
 
   assert.deepEqual(plan.actions, []);
 });
+
+// ---------------------------------------------------------------------------
+// #967 — the agent's own NAME reaching the prompt
+// ---------------------------------------------------------------------------
+
+/**
+ * The other half of #967. Writing the provisioned name into
+ * `agent_identities.display_name` fixes nothing on its own: before this, the
+ * column reached the Teams manifest and stopped there, so a bot the operator
+ * named `Messias` went on introducing itself with the PLATFORM assistant's
+ * name. These cases pin the path from the column to the system prompt, and —
+ * just as important — pin that nothing else about the prompt moved.
+ */
+
+test('an authored name is layered onto the platform identity, not swapped for it', () => {
+  const identity = String(
+    identityOf(buildForAgent(agentRow({ identityName: 'Messias' }), deps(), RUNTIME)),
+  );
+
+  // Both halves matter. Losing the platform text would silently strip every
+  // behaviour a deployment configured, just because somebody typed a name
+  // into the provisioning form.
+  assert.match(identity, /You are the platform assistant\./);
+  assert.match(identity, /Dein Name ist Messias\./);
+});
+
+test('an authored name is layered onto an authored identity too', () => {
+  const identity = String(
+    identityOf(
+      buildForAgent(
+        agentRow({
+          instructions: 'You are the sales agent. Be brief.',
+          identityName: 'Messias',
+        }),
+        deps(),
+        RUNTIME,
+      ),
+    ),
+  );
+
+  assert.match(identity, /You are the sales agent\. Be brief\./);
+  // Last word wins: the name must outrank any name the prose above mentions,
+  // and appending is the only safe way to override a name inside free prose.
+  assert.ok(
+    identity.indexOf('Dein Name ist Messias') >
+      identity.indexOf('You are the sales agent'),
+    'the name line must come after the identity text it overrides',
+  );
+});
+
+test('the name is the ONLY thing added — no invented persona', () => {
+  const identity = String(
+    identityOf(buildForAgent(agentRow({ identityName: 'Messias' }), deps(), RUNTIME)),
+  );
+  const added = identity.replace(PLATFORM_IDENTITY, '').trim();
+
+  // One sentence, about the name. Nothing that describes what the agent IS:
+  // a self-description belongs to the operator's identity form, and inventing
+  // one here would put words in an agent's mouth that nobody authored.
+  assert.match(added, /^Dein Name ist Messias\./);
+  assert.doesNotMatch(added, /Assistent|assistant|hilfsbereit|helpful/i);
+});
+
+test('an agent without an authored name keeps the platform identity byte-for-byte', () => {
+  // The no-change guarantee: every agent that predates #967 must compile to
+  // the exact same prompt, down to the prompt-cache key.
+  assert.equal(
+    identityOf(buildForAgent(agentRow(), deps(), RUNTIME)),
+    PLATFORM_IDENTITY,
+  );
+  assert.equal(
+    identityOf(buildForAgent(agentRow({ identityName: '   ' }), deps(), RUNTIME)),
+    PLATFORM_IDENTITY,
+    'whitespace is not a name',
+  );
+});
+
+test('renaming an agent rebuilds it', () => {
+  // Without this the operator renames the bot, sees it saved, and keeps
+  // hearing the old name in chat until some unrelated edit rebuilds the
+  // Agent — the same silent no-op `identity_instructions` guards against.
+  const plan = diffSnapshots(
+    snapshot(agentRow({ identityName: 'Willi' })),
+    snapshot(agentRow({ identityName: 'Messias' })),
+  );
+
+  assert.equal(plan.actions.length, 1);
+  const action = plan.actions[0];
+  assert.equal(action?.kind, 'rebuild');
+  assert.match((action as { reason: string }).reason, /identity_display_name/);
+});
+
+test('an unchanged name does not rebuild anything', () => {
+  const plan = diffSnapshots(
+    snapshot(agentRow({ identityName: 'Messias' })),
+    snapshot(agentRow({ identityName: 'Messias' })),
+  );
+
+  assert.deepEqual(plan.actions, []);
+});

--- a/middleware/test/operatorAgentsIdentityRoutes.test.ts
+++ b/middleware/test/operatorAgentsIdentityRoutes.test.ts
@@ -164,6 +164,23 @@ class FakeIdentityStore implements OperatorAgentIdentityStore {
     return Promise.resolve(next);
   }
 
+  /** #967 — mirrors the store's SQL guard: an authored name is never
+   *  overwritten. Not exercised by these routes, but the port requires it. */
+  adoptDisplayName(
+    agentId: string,
+    displayName: string,
+  ): Promise<AgentIdentityRecord | undefined> {
+    const existing = this.rows.get(agentId);
+    if (existing && (existing.displayName ?? '').trim().length > 0) {
+      return Promise.resolve(existing);
+    }
+    const name = displayName.trim();
+    if (name.length === 0) return Promise.resolve(existing);
+    const next = { ...(existing as AgentIdentityRecord), displayName: name };
+    this.rows.set(agentId, next);
+    return Promise.resolve(next);
+  }
+
   recompose(
     agentId: string,
     composed: AgentIdentityComposedPrompt,
@@ -630,15 +647,35 @@ describe('operator agent identity routes (#914)', () => {
     assert.equal(reloads, 1);
   });
 
-  it('does not reload when only the nameplate changed', async () => {
+  it('reloads the registry when the name changed (#967)', async () => {
     reloads = 0;
     await fetch(`${baseUrl}/sales/identity`, {
       method: 'PUT',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ display_name: 'Vertrieb' }),
     });
-    // A name is not a prompt — rebuilding every Agent for it would drop live
-    // sessions for a label change.
+    // This case used to assert the OPPOSITE, on the premise that "a name is
+    // not a prompt" — true while the display name only reached the Teams
+    // manifest. #967 gives it a path into the system prompt (it is the name
+    // the bot introduces itself with), so a rename that never reaches the
+    // registry is a rename the operator sees saved and never hears spoken.
+    // A rename is rare and deliberate; rolling sessions for it is the point.
+    assert.equal(reloads, 1);
+  });
+
+  it('does not reload when nothing about the identity changed', async () => {
+    await fetch(`${baseUrl}/sales/identity`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ display_name: 'Vertrieb' }),
+    });
+    reloads = 0;
+    // The same values again: no prompt change, no name change, no rebuild.
+    await fetch(`${baseUrl}/sales/identity`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ display_name: 'Vertrieb' }),
+    });
     assert.equal(reloads, 0);
   });
 

--- a/middleware/test/teamsProvisioningAdoptsIdentityName.test.ts
+++ b/middleware/test/teamsProvisioningAdoptsIdentityName.test.ts
@@ -1,0 +1,431 @@
+/**
+ * #967 — the provisioned Teams name becomes the agent's own name.
+ *
+ * THE FIELD-TEST BUG. A bot provisioned as `Messias` in the tenant introduced
+ * itself in chat as the platform assistant, because the operator's display
+ * name landed on the bot registration and in the app package and NOWHERE
+ * else: `agent_identities` stayed empty, so the agent fell through to the
+ * platform-wide identity — one bot wearing two names.
+ *
+ * THE HARD CONDITION. An identity somebody actually authored must never be
+ * overwritten by a provisioning run. Losing a curated persona, description and
+ * tone is strictly worse than the mismatch this repairs, so the "already
+ * named" case is the most important thing this file pins.
+ *
+ * The refusal itself lives in the store's SQL (`adoptDisplayName`), where it
+ * is atomic; `agentIdentityStore.pg.test.ts` proves it against the real
+ * constraint. What is proven HERE is the routing decision: that provisioning
+ * reaches for the adoption at all, that it passes the name the bot actually
+ * wears (not the one the request asked for), that a refused adoption does not
+ * roll live sessions, and that neither a missing identity store nor a failing
+ * one can take provisioning down with it.
+ */
+
+import { strict as assert } from 'node:assert';
+import { after, afterEach, before, describe, it } from 'node:test';
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+
+import express from 'express';
+
+import type { ConfigStore, OrchestratorRegistry } from '@omadia/orchestrator';
+
+import {
+  createOperatorAgentsRouter,
+  type OperatorAgentIdentityStore,
+  type OperatorTeamsIdentityRecord,
+} from '../src/routes/operatorAgents.js';
+import type {
+  AgentIdentityAvatarInput,
+  AgentIdentityComposedPrompt,
+  AgentIdentityRecord,
+  AgentIdentitySaveInput,
+} from '../src/platform/agentIdentityStore.js';
+import { listenLoopback } from './_helpers/listenLoopback.js';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+const AGENT_ID = 'agent-messias';
+const TEAM_ID = 'abcabcab-0000-4000-8000-000000000003';
+
+class FakeConfigStore {
+  getAgentBySlug(slug: string): Promise<
+    { id: string; slug: string; name: string; description: string | null } | undefined
+  > {
+    return Promise.resolve(
+      slug === 'messias'
+        ? { id: AGENT_ID, slug: 'messias', name: 'messias', description: null }
+        : undefined,
+    );
+  }
+}
+
+/**
+ * In-memory `agent_identities` with the REAL adoption semantics — the guard
+ * mirrors the store's `ON CONFLICT … DO UPDATE … WHERE display_name IS NULL
+ * OR btrim(display_name) = ''`. A fake that adopted unconditionally would make
+ * the case that matters most pass for the wrong reason.
+ */
+class FakeIdentityStore implements OperatorAgentIdentityStore {
+  public rows = new Map<string, AgentIdentityRecord>();
+  public adoptCalls: Array<{ agentId: string; displayName: string }> = [];
+  /** When set, every call rejects — the "identity table is unreachable" case. */
+  public failure: Error | undefined;
+
+  getByAgentId(agentId: string): Promise<AgentIdentityRecord | undefined> {
+    if (this.failure) return Promise.reject(this.failure);
+    return Promise.resolve(this.rows.get(agentId));
+  }
+
+  adoptDisplayName(
+    agentId: string,
+    displayName: string,
+  ): Promise<AgentIdentityRecord | undefined> {
+    this.adoptCalls.push({ agentId, displayName });
+    if (this.failure) return Promise.reject(this.failure);
+    const name = displayName.trim();
+    if (name.length === 0) return Promise.resolve(this.rows.get(agentId));
+    const existing = this.rows.get(agentId);
+    // The guard, verbatim: a row that already carries a name is refused, and
+    // the caller gets the stored row back unchanged.
+    if (existing && (existing.displayName ?? '').trim().length > 0) {
+      return Promise.resolve(existing);
+    }
+    const next: AgentIdentityRecord = {
+      ...(existing ?? blankIdentity(agentId)),
+      displayName: name,
+      updatedAt: new Date('2026-08-31T12:00:00.000Z'),
+    };
+    this.rows.set(agentId, next);
+    return Promise.resolve(next);
+  }
+
+  save(
+    agentId: string,
+    input: AgentIdentitySaveInput,
+  ): Promise<AgentIdentityRecord> {
+    const next: AgentIdentityRecord = {
+      ...blankIdentity(agentId),
+      ...input,
+      revision: (this.rows.get(agentId)?.revision ?? 0) + 1,
+    };
+    this.rows.set(agentId, next);
+    return Promise.resolve(next);
+  }
+
+  recompose(
+    agentId: string,
+    composed: AgentIdentityComposedPrompt,
+  ): Promise<AgentIdentityRecord | undefined> {
+    const existing = this.rows.get(agentId);
+    if (!existing) return Promise.resolve(undefined);
+    const next = { ...existing, composed };
+    this.rows.set(agentId, next);
+    return Promise.resolve(next);
+  }
+
+  setAvatar(
+    agentId: string,
+    avatar: AgentIdentityAvatarInput,
+  ): Promise<AgentIdentityRecord> {
+    const next: AgentIdentityRecord = {
+      ...(this.rows.get(agentId) ?? blankIdentity(agentId)),
+      avatar: { etag: avatar.etag },
+    };
+    this.rows.set(agentId, next);
+    return Promise.resolve(next);
+  }
+
+  clearAvatar(agentId: string): Promise<AgentIdentityRecord | undefined> {
+    return Promise.resolve(this.rows.get(agentId));
+  }
+
+  getAvatar(): Promise<{ bytes: Uint8Array; etag: string } | undefined> {
+    return Promise.resolve(undefined);
+  }
+}
+
+function blankIdentity(agentId: string): AgentIdentityRecord {
+  return {
+    agentId,
+    displayName: null,
+    shortDescription: null,
+    longDescription: null,
+    instructions: null,
+    accentColor: null,
+    persona: null,
+    quality: null,
+    composed: { text: null, family: null },
+    revision: 1,
+    avatar: null,
+    createdAt: new Date('2026-08-31T10:00:00.000Z'),
+    updatedAt: new Date('2026-08-31T10:00:00.000Z'),
+  };
+}
+
+/** A fully authored identity — the one a provisioning run must not touch. */
+function curatedIdentity(): AgentIdentityRecord {
+  return {
+    ...blankIdentity(AGENT_ID),
+    displayName: 'Karen',
+    shortDescription: 'Kümmert sich um HR-Anliegen',
+    longDescription: 'Karen beantwortet Fragen rund um Urlaub und Verträge.',
+    instructions: 'Antworte knapp und freundlich.',
+    accentColor: '#123456',
+    revision: 7,
+  };
+}
+
+class FakeTeamsIdentityStore {
+  public rows = new Map<string, OperatorTeamsIdentityRecord>();
+
+  getByAgentId(agentId: string): Promise<OperatorTeamsIdentityRecord | undefined> {
+    return Promise.resolve(this.rows.get(agentId));
+  }
+
+  /** Mirrors the real store: create-if-absent, and an existing row keeps its
+   *  `display_name` no matter what the request asked for. */
+  ensureForAgent(input: {
+    agentId: string;
+    botSlug: string;
+    displayName: string;
+    teamId?: string;
+  }): Promise<OperatorTeamsIdentityRecord> {
+    const existing = this.rows.get(input.agentId);
+    if (existing) {
+      const next = { ...existing, teamId: input.teamId ?? existing.teamId };
+      this.rows.set(input.agentId, next);
+      return Promise.resolve(next);
+    }
+    const row: OperatorTeamsIdentityRecord = {
+      agentId: input.agentId,
+      botSlug: input.botSlug,
+      displayName: input.displayName,
+      state: 'pending',
+      teamId: input.teamId ?? null,
+      appId: null,
+      tenantId: null,
+      teamsAppId: null,
+      teamsAppExternalId: null,
+      lastError: null,
+      createdAt: new Date('2026-08-31T09:00:00.000Z'),
+      updatedAt: new Date('2026-08-31T09:00:00.000Z'),
+    };
+    this.rows.set(input.agentId, row);
+    return Promise.resolve(row);
+  }
+
+  recordEnqueueFailure(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class FakeTeamsRunner {
+  public enqueued: Array<{ agentId: string; teamId: string }> = [];
+
+  enqueue(request: { agentId: string; teamId: string }): Promise<unknown> {
+    this.enqueued.push({ agentId: request.agentId, teamId: request.teamId });
+    // Never settles: reaching an assertion proves the route did not await it.
+    return new Promise<unknown>(() => {});
+  }
+
+  isRunning(): boolean {
+    return false;
+  }
+
+  runningTeamId(): string | null {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('teams provisioning adopts the display name into the agent identity (#967)', () => {
+  let server: Server;
+  let baseUrl: string;
+  let identityStore = new FakeIdentityStore();
+  let teamsStore = new FakeTeamsIdentityStore();
+  let teamsRunner = new FakeTeamsRunner();
+  let identityWired = true;
+  let reloads = 0;
+
+  const registry = {
+    reload: () => {
+      reloads += 1;
+      return Promise.resolve({ actions: [], platformChanged: false });
+    },
+  } as unknown as OrchestratorRegistry;
+
+  before(async () => {
+    const app = express();
+    app.use(express.json());
+    app.use(
+      '/api/v1/operator/agents',
+      createOperatorAgentsRouter({
+        getConfigStore: () => new FakeConfigStore() as unknown as ConfigStore,
+        getRegistry: () => registry,
+        getChatSessionStore: () => undefined,
+        getAgentIdentity: () =>
+          identityWired ? { store: identityStore } : undefined,
+        getTeamsIdentity: () => ({
+          store: teamsStore as never,
+          runner: teamsRunner,
+          isProvisionerInstalled: () => true,
+        }),
+      }),
+    );
+    server = await listenLoopback(app);
+    const addr = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${String(addr.port)}/api/v1/operator/agents`;
+  });
+
+  after(async () => {
+    await new Promise<void>((r) => server.close(() => r()));
+  });
+
+  afterEach(() => {
+    identityStore = new FakeIdentityStore();
+    teamsStore = new FakeTeamsIdentityStore();
+    teamsRunner = new FakeTeamsRunner();
+    identityWired = true;
+    reloads = 0;
+  });
+
+  function provision(body: Record<string, unknown>): Promise<Response> {
+    return fetch(`${baseUrl}/messias/teams-identity`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ team_id: TEAM_ID, ...body }),
+    });
+  }
+
+  it('gives an agent WITHOUT an identity the name it was provisioned under', async () => {
+    const res = await provision({ display_name: 'Messias' });
+
+    assert.equal(res.status, 202);
+    const identity = identityStore.rows.get(AGENT_ID);
+    assert.equal(
+      identity?.displayName,
+      'Messias',
+      'the name on the Teams bot must be the name the agent answers to',
+    );
+    // And the running Agent has to hear about it — the name is part of its
+    // system prompt, so a stored name nobody rebuilt for is a name the bot
+    // never says.
+    assert.equal(reloads, 1);
+  });
+
+  it('leaves an AUTHORED identity completely untouched', async () => {
+    // The case that matters most: someone built this persona by hand.
+    identityStore.rows.set(AGENT_ID, curatedIdentity());
+
+    const res = await provision({ display_name: 'Messias' });
+
+    assert.equal(res.status, 202);
+    assert.deepEqual(
+      identityStore.rows.get(AGENT_ID),
+      curatedIdentity(),
+      'a provisioning run must never overwrite an authored identity',
+    );
+    // Nothing changed, so nothing may roll live sessions either.
+    assert.equal(reloads, 0);
+  });
+
+  it('re-running provisioning changes nothing the second time', async () => {
+    await provision({ display_name: 'Messias' });
+    const afterFirst = identityStore.rows.get(AGENT_ID);
+    assert.equal(reloads, 1);
+
+    await provision({ display_name: 'Messias' });
+
+    assert.deepEqual(identityStore.rows.get(AGENT_ID), afterFirst);
+    assert.equal(reloads, 1, 'an idempotent re-run must not roll sessions');
+  });
+
+  it('a later re-POST under a NEW name does not rename the agent', async () => {
+    await provision({ display_name: 'Messias' });
+
+    // `ensureForAgent` is create-if-absent: the Teams row keeps the name it
+    // was created with, so the tenant still shows `Messias`. Adopting the
+    // request's name here would re-create the very split this fixes, pointing
+    // the other way — inwardly `Judas`, outwardly `Messias`.
+    await provision({ display_name: 'Judas' });
+
+    assert.equal(identityStore.rows.get(AGENT_ID)?.displayName, 'Messias');
+    assert.deepEqual(
+      identityStore.adoptCalls.map((c) => c.displayName),
+      ['Messias', 'Messias'],
+      'the adoption follows the stored bot name, never the request body',
+    );
+  });
+
+  it('adopts the agent name when the request names no bot at all', async () => {
+    // No `display_name` in the body: the route falls back to the registry
+    // name, which is then what the tenant sees — and what the bot should say.
+    await provision({});
+
+    assert.equal(identityStore.rows.get(AGENT_ID)?.displayName, 'messias');
+  });
+
+  it('a blank display_name in an existing row is treated as unset', async () => {
+    // `resolveAgentIdentity` already reads blank as "inherit", so filling it
+    // takes nothing away from the operator.
+    identityStore.rows.set(AGENT_ID, {
+      ...blankIdentity(AGENT_ID),
+      displayName: '   ',
+      instructions: 'Antworte knapp.',
+    });
+
+    await provision({ display_name: 'Messias' });
+
+    const identity = identityStore.rows.get(AGENT_ID);
+    assert.equal(identity?.displayName, 'Messias');
+    assert.equal(
+      identity?.instructions,
+      'Antworte knapp.',
+      'adopting a name must not disturb anything else on the row',
+    );
+  });
+
+  it('provisioning still succeeds when the identity store is not wired', async () => {
+    identityWired = false;
+
+    const res = await provision({ display_name: 'Messias' });
+
+    assert.equal(res.status, 202);
+    assert.equal(teamsRunner.enqueued.length, 1);
+  });
+
+  it('a failing adoption does not take provisioning down with it', async () => {
+    // Provisioning is the operator's actual intent; the name adoption is
+    // convergence on top of it. A dead identity table must not cost them the
+    // bot.
+    identityStore.failure = new Error('relation "agent_identities" is gone');
+
+    const res = await provision({ display_name: 'Messias' });
+
+    assert.equal(res.status, 202);
+    assert.equal(teamsRunner.enqueued.length, 1);
+  });
+
+  it('adopts the name BEFORE the provisioning run is enqueued', async () => {
+    // Ordering is load-bearing: the run builds the Teams app package from the
+    // identity, so an adoption that landed afterwards would ship the first
+    // package from a row that did not have the name yet.
+    let identityAtEnqueue: string | null | undefined;
+    const runner = teamsRunner;
+    const originalEnqueue = runner.enqueue.bind(runner);
+    runner.enqueue = (request: { agentId: string; teamId: string }) => {
+      identityAtEnqueue = identityStore.rows.get(AGENT_ID)?.displayName;
+      return originalEnqueue(request);
+    };
+
+    await provision({ display_name: 'Messias' });
+
+    assert.equal(identityAtEnqueue, 'Messias');
+  });
+});

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -2080,7 +2080,7 @@
       "avatarHint": "PNG, JPEG oder WebP bis 2 MB. Daraus entsteht das 192×192-Farbsymbol des Teams-Pakets; ein 32×32-Umrisssymbol nur dann, wenn das Bild transparente Flächen hat — sonst bleibt das Standardsymbol.",
       "fields": {
         "displayName": "Anzeigename",
-        "displayNameHint": "So heißt der Agent in Teams. Leer lassen heißt: Name aus der Registry.",
+        "displayNameHint": "So heißt der Agent in Teams — und so stellt er sich im Chat vor. Leer lassen heißt: Name aus der Registry.",
         "accentColor": "Akzentfarbe",
         "accentColorHint": "Als #RRGGBB. Färbt das Teams-App-Paket ein.",
         "shortDescription": "Kurzbeschreibung",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -2080,7 +2080,7 @@
       "avatarHint": "PNG, JPEG or WebP up to 2 MB. It becomes the 192×192 colour icon of the Teams package; a 32×32 outline icon follows only if the picture has transparent areas, otherwise the default outline stays.",
       "fields": {
         "displayName": "Display name",
-        "displayNameHint": "What the agent is called in Teams. Leave it empty to use the registry name.",
+        "displayNameHint": "What the agent is called in Teams — and the name it introduces itself with in chat. Leave it empty to use the registry name.",
         "accentColor": "Accent colour",
         "accentColorHint": "As #RRGGBB. Colours the Teams app package.",
         "shortDescription": "Short description",


### PR DESCRIPTION
A provisioned bot showed up in Teams as **Messias** and introduced itself as **Willi**. The mapping was never wrong — bot slug, agent and installation all lined up. The name simply never reached the agent.

## Two halves, not one

The obvious diagnosis is that `agent_identities` is empty, so the platform persona answers. True, but incomplete: **`display_name` had no path into the system prompt at all.** The registry join read only `COALESCE(composed_prompt, instructions)`. An agent with `display_name = 'Messias'` already in the database would still have introduced itself as Willi.

So the name now travels: `configStore` joins `identity_display_name` → `AgentRow.identityName` → `AgentRuntimeConfig` → `withAgentName()` in `buildOrchestrator`, which appends one sentence to the resolved identity.

**Appended, not substituted.** `identityInstructions` (#914) *replaces* the platform identity wholesale — putting the name there, which the column list invites, would have deleted the entire platform persona because somebody filled in a name field. The name sits one layer above.

Both consumers of `agentAssistantIdentity` (orchestrator and `CliChatAgent.systemPrompt`) read the same composed value, so the comment there — "resolved once, so the two call sites cannot disagree" — stays true.

## Never overwriting an authored name

The guard is **SQL**, not read-then-write:

```sql
INSERT INTO agent_identities (agent_id, display_name) VALUES ($1, $2)
ON CONFLICT (agent_id) DO UPDATE SET display_name = EXCLUDED.display_name, updated_at = now()
WHERE agent_identities.display_name IS NULL
   OR btrim(agent_identities.display_name) = ''
```

Reading first and writing after would leave a window where a concurrent save from the identity UI is clobbered — exactly the loss this feature must not cause. The `WHERE` evaluates against the current row inside the same statement.

"Not set" is judged **per field**, not per row: no row, a null name, or a blank name all adopt; a real name refuses, even an identical one. Blank counts as unset because `resolveAgentIdentity` already treats it that way. An agent with an avatar and a persona but no name still gets the name — an empty name field is an open slot, not a decision. Everything else on the row is untouched, with its own test.

The decisive test runs against real Postgres and asserts that *nothing* changed on refusal — not just the name, but `short_description`, `instructions`, `composed_prompt`, `revision` and `updated_at`. Removing only the `WHERE` clause turns it red.

## Renaming later

**Provisioning never renames.** Once a name exists it is off limits; renaming happens in `/operator/agents/<slug>`, where the intent is unambiguous, and that path works fully — the prompt reads `display_name` regardless of who wrote it.

A detail found while building: adoption takes the name from the *stored* provisioning row, not the request body. `ensureForAgent` is create-if-absent, so a re-POST under a new display name does not rename the Teams identity. Reading the body would have made the agent Judas inside while Teams still said Messias — the same split, mirrored. Its own test covers that.

Adoption sits in **both** provisioning routes, so bots that are already provisioned pick up their name without anyone re-running the chain.

## An inverted assumption

`operatorAgents.ts` documented that a name change must *not* rebuild — "dropping live sessions for a label change" — with a test named `does not reload when only the nameplate changed`. That was correct while the name only fed the Teams manifest. It is now false: without a rebuild the agent keeps answering to the old name. Comment and test are inverted rather than circumvented; the test now reads `reloads the registry when the name changed`. A rename is rare and deliberate, and rolling sessions for it is the point.

The reload only fires on genuine adoption — a refused write rolls nobody.

## Two honest caveats

"Willi" still stands in the prompt; it is overridden by instruction, not deleted. Searching operator-authored prose for a name and rewriting it would damage text that merely mentions it. The closing sentence binds reliably, but it is an instruction, not a guarantee. Keeping the name out of the platform identity entirely is the clean long-term answer and a decision of its own.

Persona skills (wave 8) replace `assistantIdentity` per turn, so the name line is absent for those turns. That was already a full override and is unchanged here.

## Verification

middleware: **8132 tests, 8116 pass, 0 fail**; build, typecheck, `typecheck:test` (ratchet held) and lint all clean. web-ui: 1126 pass across 120 files; typecheck, lint and `i18n:check` clean.

Postgres suites ran for real against a throwaway container — **0 skipped** in the targeted suites. Neutralising the fix (route calls, plumbing, SQL guard) turns **12** of the new cases red across all three layers.

No migration needed: `display_name` has existed since 0052.

Refs #860.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790765448&installation_model_id=428086&pr_number=970&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F970&signature=3f95eb4d2614213105d5158059fcfff72d84735aa97586006b843c7917b8d69c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->