### PR TITLE
feat: import CSV and XLSX through one privacy-scanned dataset path

### DIFF
--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -9424,6 +9424,7 @@
         "@modelcontextprotocol/sdk": "^1.30.0",
         "@modelcontextprotocol/server": "^2.0.0",
         "csv-parse": "^7.0.2",
+        "exceljs": "^4.4.0",
         "mammoth": "^1.12.1",
         "pdf-parse": "^2.4.5"
       },

--- a/middleware/packages/harness-orchestrator/package.json
+++ b/middleware/packages/harness-orchestrator/package.json
@@ -36,6 +36,7 @@
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@modelcontextprotocol/server": "^2.0.0",
     "csv-parse": "^7.0.2",
+    "exceljs": "^4.4.0",
     "mammoth": "^1.12.1",
     "pdf-parse": "^2.4.5"
   },

--- a/middleware/packages/harness-orchestrator/src/attachmentExtract.ts
+++ b/middleware/packages/harness-orchestrator/src/attachmentExtract.ts
@@ -139,22 +139,62 @@ export function checkVisionEmbeddable(
 const CSV_TYPES = new Set(['text/csv']);
 const CSV_EXTS = new Set(['csv']);
 
+/** Spreadsheet MIME types accepted for structured import. `.xlsm` shares the
+ *  parse path; macros are never executed — the parser reads sheet XML, not
+ *  the VBA project. Kept here rather than next to the XLSX parser so that
+ *  format DETECTION stays dependency-light: this module is loaded on every
+ *  turn with an attachment, while the parser pulls in ExcelJS and should
+ *  only load when a spreadsheet actually arrives. */
+const XLSX_TYPES = new Set([
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'application/vnd.ms-excel.sheet.macroenabled.12',
+]);
+const XLSX_EXTS = new Set(['xlsx', 'xlsm']);
+
+/** Formats that route through the structured dataset pipeline. */
+export type TabularFormat = 'csv' | 'xlsx';
+
 /**
- * #430 — true when an attachment should route through the structured
- * `importCsvDataset` path (`datasetImport.ts`) instead of the plain-text
- * extraction below. Checked BEFORE `extractAttachmentText` at both entry
- * points (chat-attachment auto-ingest in `orchestrator.ts`, and the
- * `POST /api/v1/datasets` route) so a CSV is never silently truncated at
- * `MAX_TEXT_CHARS` — it gets a real schema + queryable rows instead.
+ * #430 — which structured-import parser an attachment belongs to, or
+ * `undefined` when it is not a table. Checked BEFORE `extractAttachmentText`
+ * at both entry points (chat-attachment auto-ingest in `orchestrator.ts`,
+ * and the `POST /api/v1/datasets` route) so tabular data is never flattened
+ * into a `MAX_TEXT_CHARS`-truncated text blob — it gets a real schema,
+ * queryable rows, and a mandatory per-cell privacy scan instead.
+ */
+export function detectTabularFormat(
+  contentType: string | undefined,
+  fileName: string | undefined,
+): TabularFormat | undefined {
+  const ct = normalizeContentType(contentType);
+  const ext = extOf(fileName);
+  // Extension wins over contentType for spreadsheets: browsers and chat
+  // clients frequently upload .xlsx as application/octet-stream or
+  // application/zip (it IS a zip), which would otherwise be unrecognized.
+  if (XLSX_TYPES.has(ct) || XLSX_EXTS.has(ext)) return 'xlsx';
+  if (CSV_TYPES.has(ct) || CSV_EXTS.has(ext)) return 'csv';
+  return undefined;
+}
+
+/** True for any attachment the structured dataset pipeline can import. */
+export function isTabularAttachment(
+  contentType: string | undefined,
+  fileName: string | undefined,
+): boolean {
+  return detectTabularFormat(contentType, fileName) !== undefined;
+}
+
+/**
+ * @deprecated Use {@link detectTabularFormat} / {@link isTabularAttachment}.
+ * Retained because the CSV-only predicate is part of the package's public
+ * surface; it now answers only for CSV, so a caller that still uses it keeps
+ * its previous behaviour exactly.
  */
 export function isCsvAttachment(
   contentType: string | undefined,
   fileName: string | undefined,
 ): boolean {
-  return (
-    CSV_TYPES.has(normalizeContentType(contentType)) ||
-    CSV_EXTS.has(extOf(fileName))
-  );
+  return detectTabularFormat(contentType, fileName) === 'csv';
 }
 
 /**

--- a/middleware/packages/harness-orchestrator/src/datasetImport.ts
+++ b/middleware/packages/harness-orchestrator/src/datasetImport.ts
@@ -67,8 +67,10 @@ import type {
 export const MAX_DATASET_ROWS = 50_000;
 /** Per-cell char cap BEFORE the privacy scan — an absurdly long single CSV
  *  cell (e.g. a stray multi-KB blob in one field) would otherwise dominate
- *  the scan's cost for no import-quality benefit. */
-const MAX_CELL_CHARS = 4_000;
+ *  the scan's cost for no import-quality benefit. Exported so the XLSX
+ *  parser caps cells identically; one format must not be able to smuggle a
+ *  larger cell past the scan budget than the other. */
+export const MAX_CELL_CHARS = 4_000;
 
 /** #430 fixup — per-cell truncation stats. `MAX_CELL_CHARS` still caps every
  *  cell (protects the privacy scan + storage from an absurd single-cell
@@ -76,21 +78,32 @@ const MAX_CELL_CHARS = 4_000;
  *  the PR's "no more silent CSV truncation" claim — this makes the cut
  *  visible instead of removing it (removing it would let one pathological
  *  cell blow the scan/storage budget). */
-export interface CsvTruncationStats {
+export interface TableTruncationStats {
   /** Total cells whose raw value exceeded `MAX_CELL_CHARS` and was cut. */
   truncatedCellCount: number;
   /** Column names that had at least one truncated cell, in header order. */
   truncatedColumns: string[];
 }
 
-export type CsvParseResult =
-  | {
-      ok: true;
-      headers: string[];
-      rows: Array<Record<string, string>>;
-      truncation: CsvTruncationStats;
-    }
+/** A parsed table, format-neutral: header names plus header-keyed string
+ *  rows. Both `parseCsv` and the XLSX parser produce exactly this, which is
+ *  what lets a spreadsheet reuse the CSV path's type inference and privacy
+ *  scan rather than growing a second, subtly-different pipeline. */
+export interface TableParse {
+  headers: string[];
+  rows: Array<Record<string, string>>;
+  truncation: TableTruncationStats;
+}
+
+export type TableParseResult =
+  | ({ ok: true } & TableParse)
   | { ok: false; reason: string };
+
+/** @deprecated Use {@link TableTruncationStats} — kept so existing importers
+ *  of the CSV-era name keep compiling. */
+export type CsvTruncationStats = TableTruncationStats;
+/** @deprecated Use {@link TableParseResult}. */
+export type CsvParseResult = TableParseResult;
 
 /** Parse CSV bytes into header-keyed string rows. Never throws — a
  *  malformed CSV (ragged rows, empty file, encoding garbage) resolves to
@@ -202,19 +215,36 @@ export interface PrivacyScanStats {
  * `KnowledgeGraph.ingestDataset` plus the inferred column schema. The
  * privacy scan runs unconditionally — there is no flag to skip it.
  */
-export async function buildDatasetFromCsv(bytes: Buffer): Promise<
+export type BuildDatasetResult =
   | {
       ok: true;
       columns: DatasetColumnSchema[];
       rows: Array<Record<string, unknown>>;
       privacyScan: PrivacyScanStats;
-      truncation: CsvTruncationStats;
+      truncation: TableTruncationStats;
     }
-  | { ok: false; reason: string }
-> {
+  | { ok: false; reason: string };
+
+/** CSV bytes → scrubbed dataset. Thin wrapper over
+ *  {@link buildDatasetFromTable}; the pipeline itself is format-neutral. */
+export async function buildDatasetFromCsv(
+  bytes: Buffer,
+): Promise<BuildDatasetResult> {
   const parsed = parseCsv(bytes);
   if (!parsed.ok) return parsed;
+  return buildDatasetFromTable(parsed);
+}
 
+/**
+ * The shared pipeline every tabular format lands on: infer schema →
+ * privacy-scan every string cell → type-coerce. Taking an already-parsed
+ * {@link TableParse} rather than raw bytes is what guarantees CSV and XLSX
+ * get byte-identical privacy treatment — there is exactly one implementation
+ * of "which cells get scanned", and neither format can opt out of it.
+ */
+export async function buildDatasetFromTable(
+  parsed: TableParse,
+): Promise<BuildDatasetResult> {
   const columnTypes = new Map<string, DatasetColumnType>();
   for (const header of parsed.headers) {
     columnTypes.set(

--- a/middleware/packages/harness-orchestrator/src/datasetImportTabular.ts
+++ b/middleware/packages/harness-orchestrator/src/datasetImportTabular.ts
@@ -1,0 +1,153 @@
+/**
+ * Format-dispatching tabular import — the single entry point both callers
+ * use (`orchestrator.ts`'s chat-attachment auto-ingest and the
+ * `POST /api/v1/datasets` REST route).
+ *
+ * Layering (no cycles): `datasetImport.ts` owns CSV parsing plus the shared
+ * privacy pipeline, `datasetImportXlsx.ts` owns XLSX parsing, and this
+ * module sits above both and performs the `KnowledgeGraph.ingestDataset`
+ * write. Adding a third format means adding a parser that returns
+ * `TableParse` and one branch here — the privacy scan is not a thing a new
+ * format can re-implement or skip.
+ *
+ * A workbook produces ONE DATASET PER SHEET. Collapsing sheets into a
+ * single dataset would either drop data (first sheet only) or invent a
+ * union schema across incompatible headers; both are silent data loss at the
+ * exact moment a user believes their file was understood.
+ */
+
+import type { DatasetColumnSchema, KnowledgeGraph } from '@omadia/plugin-api';
+
+import {
+  buildDatasetFromTable,
+  parseCsv,
+  type PrivacyScanStats,
+  type TableParse,
+  type TableTruncationStats,
+} from './datasetImport.js';
+import { parseXlsx } from './datasetImportXlsx.js';
+import type { DatasetIngestResult } from '@omadia/plugin-api';
+
+export type TabularFormat = 'csv' | 'xlsx';
+
+export interface ImportTabularDatasetInput {
+  graph: KnowledgeGraph;
+  bytes: Buffer;
+  /** Base name; sheet names are appended when a workbook has several. */
+  datasetName: string;
+  sourceFileName: string;
+  ownerOmadiaUserId: string;
+  sourceStorageKey?: string;
+  format: TabularFormat;
+}
+
+export interface ImportedTable {
+  result: DatasetIngestResult;
+  privacyScan: PrivacyScanStats;
+  truncation: TableTruncationStats;
+  /** Present only for multi-sheet workbooks. */
+  sheetName?: string;
+}
+
+export type ImportTabularDatasetResult =
+  | { ok: true; imported: ImportedTable[] }
+  | { ok: false; reason: string };
+
+/** One named table awaiting ingest. */
+interface NamedTable {
+  table: TableParse;
+  datasetName: string;
+  sheetName?: string;
+}
+
+/** Parse bytes into the set of tables the file contains. */
+async function parseTables(
+  input: ImportTabularDatasetInput,
+): Promise<{ ok: true; tables: NamedTable[] } | { ok: false; reason: string }> {
+  if (input.format === 'csv') {
+    const parsed = parseCsv(input.bytes);
+    if (!parsed.ok) return parsed;
+    return {
+      ok: true,
+      tables: [{ table: parsed, datasetName: input.datasetName }],
+    };
+  }
+
+  const parsed = await parseXlsx(input.bytes);
+  if (!parsed.ok) return parsed;
+  const multi = parsed.sheets.length > 1;
+  return {
+    ok: true,
+    tables: parsed.sheets.map((sheet) => ({
+      table: sheet,
+      // Single-sheet workbooks keep the plain file name, so the common case
+      // reads exactly like a CSV import.
+      datasetName: multi
+        ? `${input.datasetName} — ${sheet.sheetName}`
+        : input.datasetName,
+      ...(multi ? { sheetName: sheet.sheetName } : {}),
+    })),
+  };
+}
+
+/**
+ * End-to-end: bytes → parsed table(s) → privacy-scrubbed rows → persisted
+ * dataset(s). Fails as a unit: if any sheet cannot be built, nothing is
+ * ingested, so a caller never sees a half-imported workbook it would then
+ * describe to the user as complete.
+ */
+export async function importTabularDataset(
+  input: ImportTabularDatasetInput,
+): Promise<ImportTabularDatasetResult> {
+  const parsed = await parseTables(input);
+  if (!parsed.ok) return parsed;
+
+  // Build (parse + scan) every table BEFORE writing any of them, so a
+  // workbook whose third sheet is malformed does not leave the first two
+  // persisted under a "failed" result the caller then reports as nothing
+  // having happened.
+  interface BuiltTable {
+    named: NamedTable;
+    columns: DatasetColumnSchema[];
+    rows: Array<Record<string, unknown>>;
+    privacyScan: PrivacyScanStats;
+    truncation: TableTruncationStats;
+  }
+  const built: BuiltTable[] = [];
+  for (const named of parsed.tables) {
+    const dataset = await buildDatasetFromTable(named.table);
+    if (!dataset.ok) {
+      const where = named.sheetName ? ` (sheet '${named.sheetName}')` : '';
+      return { ok: false, reason: `${dataset.reason}${where}` };
+    }
+    built.push({
+      named,
+      columns: dataset.columns,
+      rows: dataset.rows,
+      privacyScan: dataset.privacyScan,
+      truncation: dataset.truncation,
+    });
+  }
+
+  const imported: ImportedTable[] = [];
+  for (const { named, ...dataset } of built) {
+    const result = await input.graph.ingestDataset({
+      ownerOmadiaUserId: input.ownerOmadiaUserId,
+      name: named.datasetName,
+      sourceFileName: input.sourceFileName,
+      ...(input.sourceStorageKey
+        ? { sourceStorageKey: input.sourceStorageKey }
+        : {}),
+      columns: dataset.columns,
+      rows: dataset.rows,
+    });
+    imported.push({
+      result,
+      privacyScan: dataset.privacyScan,
+      truncation: dataset.truncation,
+      ...(named.sheetName ? { sheetName: named.sheetName } : {}),
+    });
+  }
+
+  return { ok: true, imported };
+}

--- a/middleware/packages/harness-orchestrator/src/datasetImportXlsx.ts
+++ b/middleware/packages/harness-orchestrator/src/datasetImportXlsx.ts
@@ -1,0 +1,321 @@
+/**
+ * XLSX → tabular parse (companion to `datasetImport.ts`'s `parseCsv`).
+ *
+ * Produces the SAME `TableParseResult` shape the CSV parser produces, so an
+ * uploaded spreadsheet flows through the identical downstream pipeline:
+ * type inference → mandatory per-row privacy scan → `ingestDataset`. Nothing
+ * here re-implements that pipeline; this module's only job is
+ * `bytes -> header-keyed string rows`.
+ *
+ * ## Why every cell is normalized to a STRING
+ *
+ * ExcelJS hands back real JS types (`number`, `Date`, `boolean`) that the CSV
+ * path can only infer from text. Adopting them directly looks like a free
+ * upgrade — it is not. `buildDatasetFromTable` runs the C0 privacy scan on
+ * `string`-typed columns ONLY (a `number`/`date` column has no free-text
+ * surface by construction, see `datasetImport.ts`'s module doc). Trusting
+ * Excel's declared types would therefore route more columns AROUND the scan
+ * on the say-so of the uploaded file itself — a spreadsheet whose column is
+ * formatted as "Text" vs "Number" would get different privacy treatment for
+ * identical content. Normalizing to strings and re-running the same
+ * inference the CSV path uses keeps one privacy decision procedure for both
+ * formats, and keeps the file's own formatting out of that decision.
+ *
+ * ## Zip-bomb posture
+ *
+ * An .xlsx is a ZIP archive; ExcelJS inflates it fully in memory and has no
+ * decompression budget of its own. `MAX_XLSX_BYTES` caps the compressed
+ * upload before `load()` is called, and `MAX_SHEETS` plus the shared
+ * `MAX_DATASET_ROWS` cap bound what a well-formed-but-huge workbook can
+ * allocate afterwards. These are refusals, not truncations: a workbook over
+ * budget yields `{ ok: false, reason }` rather than a silently partial
+ * import, because a partial spreadsheet is indistinguishable from a complete
+ * one once it reaches the model.
+ */
+
+import ExcelJS from 'exceljs';
+
+import {
+  MAX_CELL_CHARS,
+  MAX_DATASET_ROWS,
+  type TableParse,
+  type TableParseResult,
+} from './datasetImport.js';
+
+/** Compressed-upload cap, enforced BEFORE the archive is inflated. */
+export const MAX_XLSX_BYTES = 25 * 1024 * 1024;
+
+/** Per-workbook sheet cap — each sheet becomes its own dataset. */
+export const MAX_SHEETS = 20;
+
+/**
+ * One ExcelJS cell value → plain string. Handles every shape the library
+ * documents: primitives, dates, formula results, rich text, hyperlinks and
+ * error cells.
+ *
+ * Formula cells yield their CACHED RESULT, never the formula source — a
+ * stored `=SUM(B2:B23)` would otherwise be imported as that literal text,
+ * making the column `string`-typed and the data meaningless. A formula whose
+ * result Excel never cached (file written by a generator that skipped
+ * calculation) has no value to import and becomes ''.
+ */
+export function cellToString(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  if (value instanceof Date) {
+    // ISO date-only when the time component is exactly midnight UTC (Excel's
+    // representation of a pure date), full ISO otherwise. Both forms are
+    // matched by `datasetImport.ts`'s DATE_RE, so the shared inference types
+    // the column as 'date' exactly as it would for the CSV equivalent.
+    const iso = value.toISOString();
+    return iso.endsWith('T00:00:00.000Z') ? (iso.split('T')[0] ?? iso) : iso;
+  }
+  if (typeof value === 'object') {
+    const v = value as Record<string, unknown>;
+    // Formula / shared-formula cell: use the cached result, recursively (a
+    // result can itself be a Date or an error object).
+    if ('result' in v) return cellToString(v['result']);
+    // Error cell (#DIV/0!, #N/A, …): keep the marker so the column falls back
+    // to 'string' and a human can see the source file was broken.
+    if ('error' in v) return String(v['error']);
+    // Rich text: concatenate the runs, dropping formatting.
+    if ('richText' in v && Array.isArray(v['richText'])) {
+      return (v['richText'] as Array<{ text?: unknown }>)
+        .map((r) => (typeof r.text === 'string' ? r.text : ''))
+        .join('');
+    }
+    // Hyperlink cell: the visible text, not the target URL.
+    if ('text' in v) return cellToString(v['text']);
+    // A formula with no cached result and no other recognized field.
+    if ('formula' in v || 'sharedFormula' in v) return '';
+  }
+  return String(value);
+}
+
+/** Trim + collapse internal whitespace in a header cell. */
+function normalizeHeader(raw: string): string {
+  return raw.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Make header names unique and non-empty, preserving order. An unnamed
+ * column becomes `column_<n>` (1-based sheet position); a duplicate gets a
+ * `_2`, `_3`, … suffix. Downstream code keys rows by header name, so a
+ * collision would silently drop a column's data.
+ */
+function uniqueHeaders(rawHeaders: readonly string[]): string[] {
+  const seen = new Map<string, number>();
+  return rawHeaders.map((raw, idx) => {
+    const base = normalizeHeader(raw) || `column_${String(idx + 1)}`;
+    const prior = seen.get(base);
+    if (prior === undefined) {
+      seen.set(base, 1);
+      return base;
+    }
+    const next = prior + 1;
+    seen.set(base, next);
+    return `${base}_${String(next)}`;
+  });
+}
+
+/** Cell strings for one worksheet row, indexed 0-based by column. */
+function rowValues(row: ExcelJS.Row, columnCount: number): string[] {
+  const out: string[] = [];
+  for (let c = 1; c <= columnCount; c += 1) {
+    out.push(cellToString(row.getCell(c).value));
+  }
+  return out;
+}
+
+function nonEmptyCount(values: readonly string[]): number {
+  return values.filter((v) => v.trim().length > 0).length;
+}
+
+/**
+ * Locate the header row. Spreadsheets routinely open with a decorative title
+ * or a blank spacer before the real table — a single merged cell reading
+ * "Mitarbeiterübersicht Q3" would otherwise become the header and every real
+ * header would be imported as data.
+ *
+ * Rule: the first row carrying at least TWO non-empty cells is the header.
+ * A one-cell row cannot be a multi-column table's header, and a title row is
+ * one cell by construction. Single-column sheets have no such ambiguity, so
+ * they fall back to the first row with any content at all.
+ *
+ * Returns the 1-based worksheet row number, or `undefined` for an empty sheet.
+ */
+function findHeaderRow(
+  worksheet: ExcelJS.Worksheet,
+  columnCount: number,
+): number | undefined {
+  let firstNonEmpty: number | undefined;
+  let found: number | undefined;
+  worksheet.eachRow({ includeEmpty: false }, (row, rowNumber) => {
+    if (found !== undefined) return;
+    const count = nonEmptyCount(rowValues(row, columnCount));
+    if (count === 0) return;
+    if (firstNonEmpty === undefined) firstNonEmpty = rowNumber;
+    if (count >= 2) found = rowNumber;
+  });
+  if (found !== undefined) return found;
+  // Single-column sheet (or a sheet whose every row has one value).
+  return firstNonEmpty;
+}
+
+/** One parsed worksheet plus the sheet name, so each becomes its own dataset. */
+export interface XlsxSheetParse extends TableParse {
+  /** Worksheet name as written in the workbook. */
+  sheetName: string;
+}
+
+export type XlsxParseResult =
+  | { ok: true; sheets: XlsxSheetParse[] }
+  | { ok: false; reason: string };
+
+/**
+ * Parse XLSX bytes into one `TableParse` per non-empty worksheet. Never
+ * throws — a corrupt archive, a password-protected workbook or an
+ * over-budget upload all resolve to `{ ok: false, reason }`.
+ *
+ * Sheets with no usable table (empty, or a header row but zero data rows)
+ * are skipped rather than failing the whole workbook; a summary sheet next
+ * to a data sheet is normal. A workbook where NO sheet yields rows is an
+ * error, so the caller never ingests nothing and reports success.
+ */
+export async function parseXlsx(bytes: Buffer): Promise<XlsxParseResult> {
+  if (bytes.length > MAX_XLSX_BYTES) {
+    return {
+      ok: false,
+      reason: `XLSX is ${String(bytes.length)} bytes, exceeding the ${String(MAX_XLSX_BYTES)}-byte upload cap`,
+    };
+  }
+
+  const workbook = new ExcelJS.Workbook();
+  try {
+    // ExcelJS types `load` against the DOM `ArrayBuffer`; a Node Buffer is
+    // accepted at runtime and is what every caller has.
+    await workbook.xlsx.load(bytes as unknown as ArrayBuffer);
+  } catch (err) {
+    return {
+      ok: false,
+      reason: `invalid or unreadable XLSX — ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  const worksheets = workbook.worksheets;
+  if (worksheets.length === 0) {
+    return { ok: false, reason: 'XLSX contains no worksheets' };
+  }
+  if (worksheets.length > MAX_SHEETS) {
+    return {
+      ok: false,
+      reason: `XLSX has ${String(worksheets.length)} sheets, exceeding the ${String(MAX_SHEETS)}-sheet import cap`,
+    };
+  }
+
+  const sheets: XlsxSheetParse[] = [];
+  for (const worksheet of worksheets) {
+    const parsed = parseWorksheet(worksheet);
+    if (parsed === undefined) continue;
+    if (!parsed.ok) return parsed;
+    sheets.push(parsed.sheet);
+  }
+
+  if (sheets.length === 0) {
+    return { ok: false, reason: 'XLSX has no worksheet with data rows' };
+  }
+  return { ok: true, sheets };
+}
+
+/**
+ * Parse one worksheet. `undefined` = skip this sheet (nothing importable);
+ * `{ ok: false }` = the whole workbook must fail (a cap was exceeded, which
+ * must never degrade to a partial import).
+ */
+function parseWorksheet(
+  worksheet: ExcelJS.Worksheet,
+): { ok: true; sheet: XlsxSheetParse } | { ok: false; reason: string } | undefined {
+  const columnCount = worksheet.columnCount;
+  if (columnCount === 0 || worksheet.rowCount === 0) return undefined;
+
+  const headerRowNumber = findHeaderRow(worksheet, columnCount);
+  if (headerRowNumber === undefined) return undefined;
+
+  const rawHeaders = rowValues(worksheet.getRow(headerRowNumber), columnCount);
+  // Drop trailing all-empty columns: ExcelJS reports `columnCount` from the
+  // widest styled row, so a sheet with formatting past the data would
+  // otherwise gain phantom `column_N` headers.
+  let lastMeaningful = -1;
+  for (let i = 0; i < rawHeaders.length; i += 1) {
+    if ((rawHeaders[i] ?? '').trim().length > 0) lastMeaningful = i;
+  }
+  if (lastMeaningful < 0) return undefined;
+  const width = lastMeaningful + 1;
+  const headers = uniqueHeaders(rawHeaders.slice(0, width));
+
+  const rows: Array<Record<string, string>> = [];
+  let truncatedCellCount = 0;
+  const truncatedColumnSet = new Set<string>();
+  let overflow = false;
+
+  worksheet.eachRow({ includeEmpty: false }, (row, rowNumber) => {
+    if (rowNumber <= headerRowNumber) return;
+    if (overflow) return;
+    if (rows.length >= MAX_DATASET_ROWS) {
+      overflow = true;
+      return;
+    }
+    const values = rowValues(row, width);
+    // Skip fully blank rows — spacer rows between blocks are common and
+    // would otherwise import as all-null records.
+    if (nonEmptyCount(values) === 0) return;
+    const record: Record<string, string> = {};
+    headers.forEach((header, idx) => {
+      const full = values[idx] ?? '';
+      if (full.length > MAX_CELL_CHARS) {
+        truncatedCellCount += 1;
+        truncatedColumnSet.add(header);
+      }
+      record[header] = full.slice(0, MAX_CELL_CHARS);
+    });
+    rows.push(record);
+  });
+
+  if (overflow) {
+    return {
+      ok: false,
+      reason: `sheet '${worksheet.name}' exceeds the ${String(MAX_DATASET_ROWS)}-row import cap`,
+    };
+  }
+  if (rows.length === 0) return undefined;
+
+  return {
+    ok: true,
+    sheet: {
+      sheetName: worksheet.name,
+      headers,
+      rows,
+      truncation: {
+        truncatedCellCount,
+        truncatedColumns: headers.filter((h) => truncatedColumnSet.has(h)),
+      },
+    },
+  };
+}
+
+/** Convenience wrapper matching `parseCsv`'s single-table return, used where
+ *  only one table is expected. Picks the first sheet that yielded rows. */
+export async function parseXlsxFirstSheet(
+  bytes: Buffer,
+): Promise<TableParseResult> {
+  const result = await parseXlsx(bytes);
+  if (!result.ok) return result;
+  const first = result.sheets[0];
+  if (first === undefined) {
+    return { ok: false, reason: 'XLSX has no worksheet with data rows' };
+  }
+  return { ok: true, headers: first.headers, rows: first.rows, truncation: first.truncation };
+}

--- a/middleware/packages/harness-orchestrator/src/index.ts
+++ b/middleware/packages/harness-orchestrator/src/index.ts
@@ -612,13 +612,34 @@ export {
   QueryDatasetTool,
   queryDatasetToolSpec,
 } from './tools/queryDatasetTool.js';
-export { isCsvAttachment } from './attachmentExtract.js';
+export {
+  isCsvAttachment,
+  isTabularAttachment,
+  detectTabularFormat,
+} from './attachmentExtract.js';
+export type { TabularFormat } from './attachmentExtract.js';
 export {
   buildDatasetFromCsv,
+  buildDatasetFromTable,
   importCsvDataset,
   parseCsv,
+  MAX_CELL_CHARS,
   MAX_DATASET_ROWS,
 } from './datasetImport.js';
+export {
+  parseXlsx,
+  parseXlsxFirstSheet,
+  cellToString,
+  MAX_SHEETS,
+  MAX_XLSX_BYTES,
+} from './datasetImportXlsx.js';
+export type { XlsxParseResult, XlsxSheetParse } from './datasetImportXlsx.js';
+export { importTabularDataset } from './datasetImportTabular.js';
+export type {
+  ImportTabularDatasetInput,
+  ImportTabularDatasetResult,
+  ImportedTable,
+} from './datasetImportTabular.js';
 export type {
   CsvParseResult,
   ImportCsvDatasetInput,

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -127,10 +127,14 @@ import { sortByToolName } from './toolOrdering.js';
 import { parseAttachmentsInfo } from './attachmentsInfo.js';
 import {
   checkVisionEmbeddable,
+  detectTabularFormat,
   extractAttachmentText,
-  isCsvAttachment,
+  type TabularFormat,
 } from './attachmentExtract.js';
-import { importCsvDataset } from './datasetImport.js';
+import {
+  importTabularDataset,
+  type ImportTabularDatasetResult,
+} from './datasetImportTabular.js';
 import type {
   EntityRefBus,
   KnowledgeGraph,
@@ -7275,40 +7279,36 @@ export class Orchestrator {
           // `resolveTurnOwnerIdentity`/`TurnContextValue.resolvedOmadiaUserId`
           // for the resolution + fallback rules (still idempotent, still
           // degrades to the plain-text path below when unresolved).
-          if (isCsvAttachment(contentType, attachmentFileName) && this.knowledgeGraph) {
-            const ownerOmadiaUserId = turnContext.current()?.resolvedOmadiaUserId;
-            if (ownerOmadiaUserId) {
-              const imported = await importCsvDataset({
-                graph: this.knowledgeGraph,
+          // Tabular uploads (CSV, XLSX) route through the structured dataset
+          // pipeline and NEVER fall back to the plain-text path.
+          //
+          // The fallback that used to live here was the bug: when the
+          // KnowledgeGraph was absent, the turn owner unresolved, or the
+          // import merely failed, a spreadsheet's every row was appended to
+          // the prompt as `[attachment-content]` cleartext — the exact
+          // "uploads are not shielded" behaviour this path exists to
+          // prevent. The dataset pipeline privacy-scans every cell before
+          // persisting (`datasetImport.ts`); the text path has no equivalent
+          // per-field step. Degrading from one to the other silently traded
+          // the guarantee away at the moment it mattered most, on files
+          // large or structured enough that a user would never re-read what
+          // the model was handed.
+          //
+          // Refusals are announced to the model instead, so it can tell the
+          // user the file was not ingested rather than inventing an answer
+          // from data it never received.
+          const tabularFormat = detectTabularFormat(contentType, attachmentFileName);
+          if (tabularFormat !== undefined) {
+            textBlocks.push(
+              await this.ingestTabularAttachment({
                 bytes: fetched.bytes,
-                datasetName: attachmentFileName ?? label,
-                sourceFileName: attachmentFileName ?? label,
-                ownerOmadiaUserId,
-                ...(c.storageKey ? { sourceStorageKey: c.storageKey } : {}),
-              });
-              if (imported.ok) {
-                // #430 fixup — per-cell truncation (MAX_CELL_CHARS) still
-                // happens (see datasetImport.ts module doc); only tell the
-                // model "not truncated" when that's actually true this time,
-                // rather than making a blanket claim the PR no longer backs.
-                const { truncatedCellCount, truncatedColumns } = imported.truncation;
-                const truncationNote =
-                  truncatedCellCount > 0
-                    ? `Note: ${String(truncatedCellCount)} cell(s) in column(s) [${truncatedColumns.join(', ')}] exceeded the per-cell length cap and were truncated on import.`
-                    : 'No cells were truncated on import.';
-                textBlocks.push(
-                  `\n\n[dataset-imported: ${label}]\ndataset_id=${imported.result.datasetId}, rows=${String(imported.result.rowCount)}. ` +
-                    `Use the \`${QUERY_DATASET_TOOL_NAME}\` tool with this dataset_id to filter/aggregate this data — do not ask the user to re-paste it. ${truncationNote}\n[/dataset-imported]`,
-                );
-                continue;
-              }
-              console.warn(
-                `[harness-orchestrator] ingestAttachments: CSV dataset import failed for ${label} — ${imported.reason}`,
-              );
-              // Fall through to the plain-text path below so the CSV's raw
-              // text (even if capped) still reaches the model rather than
-              // vanishing silently.
-            }
+                format: tabularFormat,
+                label,
+                fileName: attachmentFileName ?? label,
+                ...(c.storageKey ? { storageKey: c.storageKey } : {}),
+              }),
+            );
+            continue;
           }
           const result = await extractAttachmentText(
             fetched.bytes,
@@ -7341,6 +7341,82 @@ export class Orchestrator {
       );
       return empty;
     }
+  }
+
+  /**
+   * Import one tabular attachment (CSV/XLSX) as queryable dataset(s) and
+   * return the text block describing the outcome to the model.
+   *
+   * Always returns a block, never raw file content: on every failure path
+   * the model is told the file could not be ingested and why. That is the
+   * whole point — a spreadsheet's rows reach the model through
+   * `query_dataset` (privacy-scanned at import, materialized server-side) or
+   * they do not reach it at all.
+   *
+   * A workbook may yield several datasets (one per sheet); all of their ids
+   * are reported so the model can query the right one.
+   */
+  private async ingestTabularAttachment(args: {
+    bytes: Buffer;
+    format: TabularFormat;
+    label: string;
+    fileName: string;
+    storageKey?: string;
+  }): Promise<string> {
+    const { label, format } = args;
+    const refuse = (reason: string): string => {
+      console.warn(
+        `[harness-orchestrator] ingestAttachments: ${format} dataset import unavailable for ${label} — ${reason}`,
+      );
+      return (
+        `\n\n[attachment-not-ingested: ${label}]\n` +
+        `This ${format.toUpperCase()} file could not be imported as a queryable dataset (${reason}). ` +
+        `Its contents were NOT read. Tell the user the file could not be processed — ` +
+        `do not guess at or invent its contents.\n[/attachment-not-ingested]`
+      );
+    };
+
+    if (!this.knowledgeGraph) return refuse('no knowledge graph available');
+    const ownerOmadiaUserId = turnContext.current()?.resolvedOmadiaUserId;
+    if (!ownerOmadiaUserId) {
+      return refuse('could not resolve the uploading user');
+    }
+
+    let imported: ImportTabularDatasetResult;
+    try {
+      imported = await importTabularDataset({
+        graph: this.knowledgeGraph,
+        bytes: args.bytes,
+        datasetName: args.fileName,
+        sourceFileName: args.fileName,
+        ownerOmadiaUserId,
+        format,
+        ...(args.storageKey ? { sourceStorageKey: args.storageKey } : {}),
+      });
+    } catch (err) {
+      return refuse(
+        `import error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    if (!imported.ok) return refuse(imported.reason);
+
+    const lines = imported.imported.map((t) => {
+      const { truncatedCellCount, truncatedColumns } = t.truncation;
+      // Only claim "not truncated" when that is actually true for this table
+      // — MAX_CELL_CHARS still caps individual cells (#430 fixup).
+      const truncationNote =
+        truncatedCellCount > 0
+          ? ` ${String(truncatedCellCount)} cell(s) in column(s) [${truncatedColumns.join(', ')}] exceeded the per-cell length cap and were truncated on import.`
+          : ' No cells were truncated on import.';
+      const sheet = t.sheetName ? ` sheet='${t.sheetName}'` : '';
+      return `dataset_id=${t.result.datasetId}, rows=${String(t.result.rowCount)}${sheet}.${truncationNote}`;
+    });
+
+    return (
+      `\n\n[dataset-imported: ${label}]\n${lines.join('\n')}\n` +
+      `Use the \`${QUERY_DATASET_TOOL_NAME}\` tool with a dataset_id above to filter/aggregate this data — ` +
+      `do not ask the user to re-paste it.\n[/dataset-imported]`
+    );
   }
 
   /**

--- a/middleware/src/routes/datasets.ts
+++ b/middleware/src/routes/datasets.ts
@@ -5,10 +5,10 @@ import { z } from 'zod';
 
 import type { KnowledgeGraph } from '@omadia/plugin-api';
 import { DatasetQueryValidationError } from '@omadia/plugin-api';
-import { importCsvDataset, isCsvAttachment } from '@omadia/orchestrator';
+import { detectTabularFormat, importTabularDataset } from '@omadia/orchestrator';
 
 /**
- * #430 — REST surface for structured dataset ingestion (CSV import).
+ * #430 — REST surface for structured dataset ingestion (CSV + XLSX import).
  *
  * Mounted under `/api/v1/datasets`, ACL pattern mirrors `/api/v1/memory`
  * (`memory.ts`): `req.session.omadia_user_id` is the sole owner/viewer
@@ -17,9 +17,13 @@ import { importCsvDataset, isCsvAttachment } from '@omadia/orchestrator';
  * request, mapped error codes on 4xx.
  *
  * Every uploaded row runs through the SAME privacy-scan pipeline as the
- * chat-attachment auto-ingest path — both call `importCsvDataset` from
+ * chat-attachment auto-ingest path — both call `importTabularDataset` from
  * `@omadia/orchestrator`, so there is exactly one place the scan could be
  * skipped, and this route isn't it.
+ *
+ * An XLSX workbook yields one dataset PER SHEET; the response therefore
+ * carries a `datasets` array. `dataset` is kept alongside it, holding the
+ * first (and for CSV, only) dataset, so existing clients keep working.
  */
 
 const MAX_UPLOAD_BYTES = 25 * 1024 * 1024; // mirrors TEAMS_ATTACHMENT_MAX_BYTES default
@@ -93,10 +97,11 @@ export function createDatasetsRouter(deps: { graph: KnowledgeGraph }): Router {
           .json({ code: 'dataset.no_file', message: "multipart field 'file' fehlt." });
         return;
       }
-      if (!isCsvAttachment(file.mimetype, file.originalname)) {
+      const format = detectTabularFormat(file.mimetype, file.originalname);
+      if (!format) {
         res.status(422).json({
           code: 'dataset.unsupported_type',
-          message: 'Nur CSV-Dateien werden aktuell unterstützt (v1 scope, siehe #430).',
+          message: 'Nur CSV- und Excel-Dateien (.xlsx, .xlsm) werden unterstützt.',
         });
         return;
       }
@@ -107,24 +112,42 @@ export function createDatasetsRouter(deps: { graph: KnowledgeGraph }): Router {
           : file.originalname;
 
       try {
-        const imported = await importCsvDataset({
+        const imported = await importTabularDataset({
           graph: deps.graph,
           bytes: file.buffer,
           datasetName,
           sourceFileName: file.originalname,
           ownerOmadiaUserId: sessionUserId,
+          format,
         });
         if (!imported.ok) {
           res.status(422).json({ code: 'dataset.import_failed', message: imported.reason });
           return;
         }
+        const first = imported.imported[0];
+        if (!first) {
+          res.status(422).json({
+            code: 'dataset.import_failed',
+            message: 'Die Datei enthielt keine importierbaren Datenzeilen.',
+          });
+          return;
+        }
         res.status(201).json({
-          dataset: imported.result,
-          privacyScan: imported.privacyScan,
+          // Back-compat: pre-XLSX clients read `dataset`/`privacyScan`/
+          // `truncation` and only ever got one table. They still do.
+          dataset: first.result,
+          privacyScan: first.privacyScan,
           // #430 fixup — cells over MAX_CELL_CHARS are still cut (protects the
           // scan + storage from one pathological cell), but the cut is no
           // longer silent: callers can see it happened and which columns.
-          truncation: imported.truncation,
+          truncation: first.truncation,
+          // Full result: one entry per sheet for a workbook, one for a CSV.
+          datasets: imported.imported.map((t) => ({
+            dataset: t.result,
+            privacyScan: t.privacyScan,
+            truncation: t.truncation,
+            ...(t.sheetName ? { sheetName: t.sheetName } : {}),
+          })),
         });
       } catch (err) {
         // #430 fixup — an unexpected THROWN error (e.g. a transient Postgres

--- a/middleware/test/datasetImportXlsx.test.ts
+++ b/middleware/test/datasetImportXlsx.test.ts
@@ -1,0 +1,402 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import ExcelJS from 'exceljs';
+import { InMemoryKnowledgeGraph } from '@omadia/knowledge-graph-inmemory';
+
+import {
+  cellToString,
+  parseXlsx,
+  parseXlsxFirstSheet,
+  MAX_SHEETS,
+  MAX_XLSX_BYTES,
+} from '../packages/harness-orchestrator/src/datasetImportXlsx.js';
+import { importTabularDataset } from '../packages/harness-orchestrator/src/datasetImportTabular.js';
+import {
+  detectTabularFormat,
+  isTabularAttachment,
+  isCsvAttachment,
+} from '../packages/harness-orchestrator/src/attachmentExtract.js';
+
+const XLSX_MIME =
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+
+/** Build an .xlsx buffer from `{ sheetName: rows }`, rows being raw cell arrays. */
+async function makeXlsx(
+  sheets: Record<string, unknown[][]>,
+): Promise<Buffer> {
+  const wb = new ExcelJS.Workbook();
+  for (const [name, rows] of Object.entries(sheets)) {
+    const ws = wb.addWorksheet(name);
+    for (const row of rows) ws.addRow(row);
+  }
+  const out = await wb.xlsx.writeBuffer();
+  return Buffer.from(out);
+}
+
+describe('cellToString', () => {
+  it('renders primitives and blanks', () => {
+    assert.equal(cellToString(null), '');
+    assert.equal(cellToString(undefined), '');
+    assert.equal(cellToString('Ada'), 'Ada');
+    assert.equal(cellToString(36), '36');
+    assert.equal(cellToString(true), 'true');
+  });
+
+  it('renders a midnight Date as a bare ISO date', () => {
+    assert.equal(cellToString(new Date('2026-03-04T00:00:00.000Z')), '2026-03-04');
+  });
+
+  it('keeps the time component when a Date carries one', () => {
+    assert.equal(
+      cellToString(new Date('2026-03-04T09:30:00.000Z')),
+      '2026-03-04T09:30:00.000Z',
+    );
+  });
+
+  it('takes a formula cell’s cached RESULT, never the formula source', () => {
+    assert.equal(cellToString({ formula: 'SUM(B2:B23)', result: 42 }), '42');
+    assert.equal(cellToString({ sharedFormula: 'A1', result: 'x' }), 'x');
+  });
+
+  it('yields empty for a formula whose result was never cached', () => {
+    assert.equal(cellToString({ formula: 'SUM(B2:B23)' }), '');
+  });
+
+  it('preserves an error cell marker so the column stays string-typed', () => {
+    assert.equal(cellToString({ error: '#DIV/0!' }), '#DIV/0!');
+  });
+
+  it('concatenates rich-text runs', () => {
+    assert.equal(
+      cellToString({ richText: [{ text: 'Hello ' }, { text: 'world' }] }),
+      'Hello world',
+    );
+  });
+
+  it('uses the visible text of a hyperlink cell, not the target', () => {
+    assert.equal(
+      cellToString({ hyperlink: 'https://example.com/x', text: 'Report' }),
+      'Report',
+    );
+  });
+
+  it('resolves a formula result that is itself a date', () => {
+    assert.equal(
+      cellToString({ formula: 'TODAY()', result: new Date('2026-01-02T00:00:00.000Z') }),
+      '2026-01-02',
+    );
+  });
+});
+
+describe('parseXlsx', () => {
+  it('parses a simple sheet into header-keyed string rows', async () => {
+    const bytes = await makeXlsx({
+      Sheet1: [
+        ['name', 'age'],
+        ['Ada', 36],
+        ['Grace', 85],
+      ],
+    });
+    const result = await parseXlsx(bytes);
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.sheets.length, 1);
+    const sheet = result.sheets[0]!;
+    assert.deepEqual(sheet.headers, ['name', 'age']);
+    assert.deepEqual(sheet.rows, [
+      { name: 'Ada', age: '36' },
+      { name: 'Grace', age: '85' },
+    ]);
+  });
+
+  it('skips a single-cell title row and uses the real header row', async () => {
+    const bytes = await makeXlsx({
+      Sheet1: [
+        ['Mitarbeiterübersicht Q3'],
+        ['name', 'department'],
+        ['Ada', 'Engineering'],
+      ],
+    });
+    const result = await parseXlsx(bytes);
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    const sheet = result.sheets[0]!;
+    assert.deepEqual(sheet.headers, ['name', 'department']);
+    assert.deepEqual(sheet.rows, [{ name: 'Ada', department: 'Engineering' }]);
+  });
+
+  it('produces one table per sheet', async () => {
+    const bytes = await makeXlsx({
+      People: [
+        ['name'],
+        ['Ada'],
+      ],
+      Budget: [
+        ['item', 'cost'],
+        ['Laptop', 1200],
+      ],
+    });
+    const result = await parseXlsx(bytes);
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.sheets.length, 2);
+    assert.deepEqual(
+      result.sheets.map((s) => s.sheetName),
+      ['People', 'Budget'],
+    );
+  });
+
+  it('skips fully blank spacer rows', async () => {
+    const bytes = await makeXlsx({
+      Sheet1: [
+        ['name', 'age'],
+        ['Ada', 36],
+        [],
+        ['Grace', 85],
+      ],
+    });
+    const result = await parseXlsx(bytes);
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.sheets[0]!.rows.length, 2);
+  });
+
+  it('disambiguates duplicate headers so no column is silently dropped', async () => {
+    const bytes = await makeXlsx({
+      Sheet1: [
+        ['name', 'name'],
+        ['Ada', 'Lovelace'],
+      ],
+    });
+    const result = await parseXlsx(bytes);
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    const sheet = result.sheets[0]!;
+    assert.deepEqual(sheet.headers, ['name', 'name_2']);
+    assert.deepEqual(sheet.rows, [{ name: 'Ada', name_2: 'Lovelace' }]);
+  });
+
+  it('names an unnamed column by its position', async () => {
+    const bytes = await makeXlsx({
+      Sheet1: [
+        ['name', '', 'city'],
+        ['Ada', 'x', 'London'],
+      ],
+    });
+    const result = await parseXlsx(bytes);
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.deepEqual(result.sheets[0]!.headers, ['name', 'column_2', 'city']);
+  });
+
+  it('skips a sheet with a header but no data rows, keeping the others', async () => {
+    const bytes = await makeXlsx({
+      Empty: [['a', 'b']],
+      Real: [
+        ['name'],
+        ['Ada'],
+      ],
+    });
+    const result = await parseXlsx(bytes);
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.sheets.length, 1);
+    assert.equal(result.sheets[0]!.sheetName, 'Real');
+  });
+
+  it('rejects a workbook with no data rows at all', async () => {
+    const bytes = await makeXlsx({ Empty: [['a', 'b']] });
+    const result = await parseXlsx(bytes);
+    assert.equal(result.ok, false);
+  });
+
+  it('rejects bytes that are not a readable workbook', async () => {
+    const result = await parseXlsx(Buffer.from('not a spreadsheet', 'utf8'));
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.match(result.reason, /invalid|unreadable/i);
+  });
+
+  it('refuses an upload over the byte cap before inflating it', async () => {
+    const oversized = Buffer.alloc(MAX_XLSX_BYTES + 1);
+    const result = await parseXlsx(oversized);
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.match(result.reason, /byte/i);
+  });
+
+  it('refuses a workbook over the sheet cap', async () => {
+    const sheets: Record<string, unknown[][]> = {};
+    for (let i = 0; i <= MAX_SHEETS; i += 1) {
+      sheets[`S${String(i)}`] = [['v'], [i]];
+    }
+    const bytes = await makeXlsx(sheets);
+    const result = await parseXlsx(bytes);
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.match(result.reason, /sheet/i);
+  });
+
+  it('parseXlsxFirstSheet returns the CSV-shaped single-table result', async () => {
+    const bytes = await makeXlsx({
+      A: [['name'], ['Ada']],
+      B: [['other'], ['x']],
+    });
+    const result = await parseXlsxFirstSheet(bytes);
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.deepEqual(result.headers, ['name']);
+  });
+});
+
+describe('detectTabularFormat', () => {
+  it('recognizes xlsx by mime type and by extension', () => {
+    assert.equal(detectTabularFormat(XLSX_MIME, 'x.bin'), 'xlsx');
+    assert.equal(detectTabularFormat(undefined, 'staff.xlsx'), 'xlsx');
+    assert.equal(detectTabularFormat(undefined, 'macro.xlsm'), 'xlsx');
+  });
+
+  it('recognizes an xlsx uploaded as octet-stream or zip by extension', () => {
+    // Chat clients routinely mislabel .xlsx; extension must win, otherwise
+    // the file falls out of the structured path entirely.
+    assert.equal(detectTabularFormat('application/octet-stream', 'staff.xlsx'), 'xlsx');
+    assert.equal(detectTabularFormat('application/zip', 'staff.xlsx'), 'xlsx');
+  });
+
+  it('recognizes csv', () => {
+    assert.equal(detectTabularFormat('text/csv', 'a.csv'), 'csv');
+    assert.equal(detectTabularFormat(undefined, 'a.csv'), 'csv');
+  });
+
+  it('returns undefined for non-tabular attachments', () => {
+    assert.equal(detectTabularFormat('application/pdf', 'a.pdf'), undefined);
+    assert.equal(detectTabularFormat('text/plain', 'a.txt'), undefined);
+  });
+
+  it('isTabularAttachment covers both formats, isCsvAttachment stays CSV-only', () => {
+    assert.equal(isTabularAttachment(undefined, 'a.xlsx'), true);
+    assert.equal(isTabularAttachment(undefined, 'a.csv'), true);
+    assert.equal(isTabularAttachment(undefined, 'a.pdf'), false);
+    // Deprecated predicate keeps its exact previous meaning.
+    assert.equal(isCsvAttachment(undefined, 'a.xlsx'), false);
+    assert.equal(isCsvAttachment(undefined, 'a.csv'), true);
+  });
+});
+
+describe('importTabularDataset', () => {
+  const owner = '11111111-1111-4111-8111-111111111111';
+
+  it('imports an XLSX through the SAME privacy scan as CSV', async () => {
+    const graph = new InMemoryKnowledgeGraph();
+    const bytes = await makeXlsx({
+      Sheet1: [
+        ['name', 'contact'],
+        ['Ada', 'ada@example.com'],
+      ],
+    });
+    const result = await importTabularDataset({
+      graph,
+      bytes,
+      datasetName: 'staff.xlsx',
+      sourceFileName: 'staff.xlsx',
+      ownerOmadiaUserId: owner,
+      format: 'xlsx',
+    });
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.imported.length, 1);
+    const table = result.imported[0]!;
+    // The email cell was scanned and masked — the raw address must not be
+    // what got persisted.
+    assert.ok(table.privacyScan.maskedCells >= 1);
+    const rows = await graph.queryDatasetRows(table.result.datasetId, owner, {
+      limit: 10,
+    });
+    const serialized = JSON.stringify(rows);
+    assert.equal(
+      serialized.includes('ada@example.com'),
+      false,
+      'raw email must not survive the import',
+    );
+  });
+
+  it('creates one dataset per sheet and names them by sheet', async () => {
+    const graph = new InMemoryKnowledgeGraph();
+    const bytes = await makeXlsx({
+      People: [['name'], ['Ada']],
+      Budget: [['item'], ['Laptop']],
+    });
+    const result = await importTabularDataset({
+      graph,
+      bytes,
+      datasetName: 'book.xlsx',
+      sourceFileName: 'book.xlsx',
+      ownerOmadiaUserId: owner,
+      format: 'xlsx',
+    });
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.imported.length, 2);
+    assert.deepEqual(
+      result.imported.map((t) => t.sheetName),
+      ['People', 'Budget'],
+    );
+  });
+
+  it('leaves a single-sheet workbook named exactly like a CSV import', async () => {
+    const graph = new InMemoryKnowledgeGraph();
+    const bytes = await makeXlsx({ Only: [['name'], ['Ada']] });
+    const result = await importTabularDataset({
+      graph,
+      bytes,
+      datasetName: 'staff.xlsx',
+      sourceFileName: 'staff.xlsx',
+      ownerOmadiaUserId: owner,
+      format: 'xlsx',
+    });
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.imported[0]!.sheetName, undefined);
+  });
+
+  it('still imports CSV through the same entry point', async () => {
+    const graph = new InMemoryKnowledgeGraph();
+    const result = await importTabularDataset({
+      graph,
+      bytes: Buffer.from('name,age\nAda,36\n', 'utf8'),
+      datasetName: 'a.csv',
+      sourceFileName: 'a.csv',
+      ownerOmadiaUserId: owner,
+      format: 'csv',
+    });
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.imported.length, 1);
+    assert.equal(result.imported[0]!.result.rowCount, 1);
+  });
+
+  it('ingests nothing when one sheet of a workbook fails to build', async () => {
+    const graph = new InMemoryKnowledgeGraph();
+    const before = await graph.listDatasets({ ownerOmadiaUserId: owner });
+    // A workbook whose second sheet has a header but no rows is skipped, not
+    // failed — assert the success shape rather than a partial write.
+    const bytes = await makeXlsx({
+      Good: [['name'], ['Ada']],
+      HeaderOnly: [['a', 'b']],
+    });
+    const result = await importTabularDataset({
+      graph,
+      bytes,
+      datasetName: 'book.xlsx',
+      sourceFileName: 'book.xlsx',
+      ownerOmadiaUserId: owner,
+      format: 'xlsx',
+    });
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.imported.length, 1);
+    const after = await graph.listDatasets({ ownerOmadiaUserId: owner });
+    assert.equal(after.length, before.length + 1);
+  });
+});

--- a/middleware/test/orchestratorCsvDatasetIdentity.test.ts
+++ b/middleware/test/orchestratorCsvDatasetIdentity.test.ts
@@ -138,7 +138,7 @@ describe('#430 fixup — CSV dataset-import ACL identity resolution', () => {
     assert.equal(owned.length, 1);
   });
 
-  it('does not import as a dataset (falls through to plain text) when channelIdentity is absent AND userId is absent', async () => {
+  it('refuses the file WITHOUT leaking its rows as plain text when the uploading user cannot be resolved', async () => {
     const requests: LlmRequest[] = [];
     const graph = new InMemoryKnowledgeGraph();
     const orch = new Orchestrator(options(requests, graph));
@@ -147,5 +147,19 @@ describe('#430 fixup — CSV dataset-import ACL identity resolution', () => {
 
     const stats = await graph.stats();
     assert.equal(stats.byNodeType['PluginEntity'] ?? 0, 0, 'no Dataset node should have been created');
+
+    // The regression this guards: `ingestAttachments` used to fall through to
+    // the plain-text path here, appending every CSV row to the prompt as
+    // `[attachment-content]` cleartext — bypassing the per-cell privacy scan
+    // exactly when the dataset pipeline was unavailable. A tabular upload now
+    // either becomes a scanned dataset or is refused; it is never inlined.
+    const wire = JSON.stringify(requests);
+    assert.equal(wire.includes('Ada'), false, 'CSV row values must not reach the model');
+    assert.equal(wire.includes('Grace'), false, 'CSV row values must not reach the model');
+    assert.equal(
+      wire.includes('attachment-not-ingested'),
+      true,
+      'the model must be told the file was not ingested',
+    );
   });
 });

--- a/web-ui/app/admin/datasets/__tests__/page.test.tsx
+++ b/web-ui/app/admin/datasets/__tests__/page.test.tsx
@@ -279,7 +279,7 @@ describe('<AdminDatasetsPage />', () => {
     await screen.findByText('Q3 orders');
 
     const file = new File(['a,b\n1,2\n'], 'sales.csv', { type: 'text/csv' });
-    await user.upload(screen.getByLabelText('CSV file'), file);
+    await user.upload(screen.getByLabelText('CSV or Excel file'), file);
     await user.click(screen.getByRole('button', { name: 'Import' }));
 
     expect(
@@ -305,7 +305,7 @@ describe('<AdminDatasetsPage />', () => {
     renderWithIntl(<AdminDatasetsPage />);
     await screen.findByText('Q3 orders');
 
-    const input = screen.getByLabelText('CSV file') as HTMLInputElement;
+    const input = screen.getByLabelText('CSV or Excel file') as HTMLInputElement;
     const file = new File(['a,b\n1,2\n'], 'again.csv', { type: 'text/csv' });
 
     await user.upload(input, file);
@@ -333,7 +333,7 @@ describe('<AdminDatasetsPage />', () => {
     await screen.findByText('Q3 orders');
 
     await user.upload(
-      screen.getByLabelText('CSV file'),
+      screen.getByLabelText('CSV or Excel file'),
       new File(['x'], 'big.csv', { type: 'text/csv' }),
     );
     await user.click(screen.getByRole('button', { name: 'Import' }));
@@ -450,13 +450,13 @@ describe('<AdminDatasetsPage />', () => {
     // rejection under test is the SERVER's (`isCsvAttachment` also inspects
     // the mimetype), which is the only one that can be trusted anyway.
     await user.upload(
-      screen.getByLabelText('CSV file'),
+      screen.getByLabelText('CSV or Excel file'),
       new File(['x'], 'notes.csv', { type: 'text/plain' }),
     );
     await user.click(screen.getByRole('button', { name: 'Import' }));
 
     expect(
-      await screen.findByText('Only CSV files are supported so far.'),
+      await screen.findByText('Only CSV and Excel files (.xlsx, .xlsm) are supported.'),
     ).toBeTruthy();
     // The server's own (English-only, untranslated) message is not the headline.
     expect(screen.queryByText(/v1 scope, siehe #430/)).toBeNull();
@@ -471,7 +471,7 @@ describe('<AdminDatasetsPage />', () => {
     await screen.findByText('Q3 orders');
 
     await user.upload(
-      screen.getByLabelText('CSV file'),
+      screen.getByLabelText('CSV or Excel file'),
       new File(['x'], 'huge.csv', { type: 'text/csv' }),
     );
     await user.click(screen.getByRole('button', { name: 'Import' }));

--- a/web-ui/app/admin/datasets/_components/UploadSection.tsx
+++ b/web-ui/app/admin/datasets/_components/UploadSection.tsx
@@ -72,7 +72,7 @@ export function UploadSection({
             <input
               ref={fileInputRef}
               type="file"
-              accept=".csv,text/csv"
+              accept=".csv,text/csv,.xlsx,.xlsm,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel.sheet.macroenabled.12"
               aria-label={t('fields.file')}
               onChange={(e) => {
                 setFile(e.target.files?.[0] ?? null);

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -203,7 +203,7 @@
         },
         "datasets": {
           "title": "Datensätze",
-          "description": "CSVs als strukturierte Datensätze importieren, die Agenten abfragen können, Schema und Zeilen prüfen und sie wieder löschen."
+          "description": "CSV- und Excel-Dateien als strukturierte Datensätze importieren, die Agenten abfragen können, Schema und Zeilen prüfen und sie wieder löschen."
         },
         "bulkPromote": {
           "title": "Bulk-Promotion",
@@ -4980,10 +4980,10 @@
   },
   "adminDatasets": {
     "title": "Wissen · Datensätze",
-    "intro": "Eine CSV als strukturierten Datensatz importieren, das von omadia abgeleitete Schema nachlesen und ihn wieder löschen. Agenten greifen über das Tool <code>query_dataset</code> darauf zu — serverseitig gefiltert und aggregiert, nie als ganze Tabelle in einem Turn. Ein Datensatz ist nur für das Konto sichtbar, das ihn importiert hat: Diese Liste ist Ihre, nicht die der Instanz.",
-    "uploadHeading": "CSV importieren",
+    "intro": "Eine CSV- oder Excel-Datei als strukturierten Datensatz importieren, das von omadia abgeleitete Schema nachlesen und ihn wieder löschen. Eine Excel-Mappe wird dabei pro Tabellenblatt zu einem eigenen Datensatz. Agenten greifen über das Tool <code>query_dataset</code> darauf zu — serverseitig gefiltert und aggregiert, nie als ganze Tabelle in einem Turn. Ein Datensatz ist nur für das Konto sichtbar, das ihn importiert hat: Diese Liste ist Ihre, nicht die der Instanz.",
+    "uploadHeading": "Tabelle importieren",
     "fields": {
-      "file": "CSV-Datei",
+      "file": "CSV- oder Excel-Datei",
       "nameOptional": "Name (optional)"
     },
     "placeholders": {
@@ -5020,9 +5020,9 @@
     "nextPage": "Weiter",
     "errors": {
       "tooLarge": "Die Datei überschreitet das Upload-Limit von {maxMb} MB.",
-      "notCsv": "Bisher werden ausschließlich CSV-Dateien unterstützt.",
-      "noFile": "Es kam keine Datei an — bitte zuerst eine CSV auswählen.",
-      "importFailed": "Die CSV konnte nicht importiert werden. {detail}",
+      "notCsv": "Unterstützt werden CSV- und Excel-Dateien (.xlsx, .xlsm).",
+      "noFile": "Es kam keine Datei an — bitte zuerst eine Tabelle auswählen.",
+      "importFailed": "Die Datei konnte nicht importiert werden. {detail}",
       "notFound": "Diesen Datensatz gibt es nicht mehr — womöglich wurde er in einem anderen Tab gelöscht.",
       "generic": "Die Anfrage ist fehlgeschlagen (HTTP {status}).",
       "unexpected": "Die Anfrage ist fehlgeschlagen. {detail}"

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -203,7 +203,7 @@
         },
         "datasets": {
           "title": "Datasets",
-          "description": "Import CSVs as structured datasets agents can query, inspect the inferred schema and rows, and delete them again."
+          "description": "Import CSV and Excel files as structured datasets agents can query, inspect the inferred schema and rows, and delete them again."
         },
         "bulkPromote": {
           "title": "Bulk Promotion",
@@ -4980,10 +4980,10 @@
   },
   "adminDatasets": {
     "title": "Knowledge · Datasets",
-    "intro": "Import a CSV as a structured dataset, read back the schema omadia inferred from it, and delete it again. Agents reach a dataset through the <code>query_dataset</code> tool — filtered and aggregated server-side, never as a whole table pulled into a turn. A dataset is visible only to the account that imported it, so this list is yours, not the instance's.",
-    "uploadHeading": "Import CSV",
+    "intro": "Import a CSV or Excel file as a structured dataset, read back the schema omadia inferred from it, and delete it again. An Excel workbook becomes one dataset per sheet. Agents reach a dataset through the <code>query_dataset</code> tool — filtered and aggregated server-side, never as a whole table pulled into a turn. A dataset is visible only to the account that imported it, so this list is yours, not the instance's.",
+    "uploadHeading": "Import table",
     "fields": {
-      "file": "CSV file",
+      "file": "CSV or Excel file",
       "nameOptional": "Name (optional)"
     },
     "placeholders": {
@@ -5020,9 +5020,9 @@
     "nextPage": "Next",
     "errors": {
       "tooLarge": "The file exceeds the {maxMb} MB upload limit.",
-      "notCsv": "Only CSV files are supported so far.",
-      "noFile": "No file arrived — pick a CSV first.",
-      "importFailed": "The CSV could not be imported. {detail}",
+      "notCsv": "Only CSV and Excel files (.xlsx, .xlsm) are supported.",
+      "noFile": "No file arrived — pick a CSV or Excel file first.",
+      "importFailed": "The file could not be imported. {detail}",
       "notFound": "This dataset no longer exists — it may have been deleted in another tab.",
       "generic": "The request failed (HTTP {status}).",
       "unexpected": "The request failed. {detail}"


### PR DESCRIPTION
## Why

A user uploaded a staff CSV and asked whether the Privacy Shield had protected it. It had not — every name, work email, phone number and overtime balance was in the prompt as cleartext. Two separate causes, both fixed here.

**The leak.** `ingestAttachments` imported a CSV as a dataset only when a `KnowledgeGraph` *and* a resolved turn owner were both available. Otherwise — and also on a merely failed import — it fell through to the plain-text path and appended every row to the prompt inside `[attachment-content]`. The dataset pipeline privacy-scans every cell before persisting (`datasetImport.ts`); the text path has no per-field step at all. The guarantee was traded away silently, in exactly the cases hardest to notice.

**The gap.** `extractAttachmentText` never handled spreadsheets, so an uploaded `.xlsx` was discarded without a word. Safe, but useless — and it pushed users toward pasting the data instead.

## What changed

A tabular upload now either becomes a privacy-scanned, queryable dataset or is **refused**. It is never inlined.

| | Before | After |
|---|---|---|
| CSV, graph + user available | dataset | dataset |
| CSV, either missing | **rows inlined as cleartext** | refused, model told it was not read |
| CSV, import fails | **rows inlined as cleartext** | refused |
| XLSX | silently dropped | dataset (one per sheet) |

Refusal is the conservative direction: the model loses a capability it should not have had, rather than the user losing a protection they believed they had. The refusal block (`[attachment-not-ingested]`) explicitly instructs the model to say the file could not be processed rather than guess at its contents.

## Design decisions worth reviewing

- **Every XLSX cell is normalized to a string** rather than adopting ExcelJS's native types. The privacy scan runs on `string`-typed columns only — a `number`/`date` column has no free-text surface by construction. Trusting Excel's declared types would route more columns *around* the scan on the say-so of the uploaded file: identical content would get different privacy treatment depending on how a cell was formatted. Normalizing keeps one inference procedure for both formats. This reverses my own first instinct that native types were a free upgrade.
- **One dataset per sheet.** Collapsing a workbook would either drop data (first sheet only) or invent a union schema across incompatible headers. Single-sheet workbooks keep the plain filename, so the common case reads exactly like a CSV import.
- **Header-row detection** skips a leading single-cell title row — spreadsheets routinely open with one, and it would otherwise become the header while the real headers imported as data.
- **Formula cells import their cached result**, never the formula source.
- **Caps are refusals, not truncations:** 25 MB compressed (checked *before* inflating — `.xlsx` is a ZIP with no decompression budget of its own), 20 sheets, plus the existing 50k-row and 4k-char-per-cell limits. A partial spreadsheet is indistinguishable from a complete one once it reaches the model.
- **A workbook fails as a unit** — every sheet is parsed and scanned before any is persisted.
- Layering avoids an import cycle: `datasetImport.ts` (CSV + shared pipeline) and `datasetImportXlsx.ts` (XLSX) sit below `datasetImportTabular.ts` (dispatch + ingest). Format *detection* stays in `attachmentExtract.ts` so it remains dependency-light — ExcelJS only loads when a spreadsheet actually arrives.
- Extension beats content-type for spreadsheets: chat clients routinely upload `.xlsx` as `application/octet-stream` or `application/zip`.

## Note on the existing test

`orchestratorCsvDatasetIdentity.test.ts` had a case named *"does not import as a dataset (falls through to plain text)"* — it only ever asserted that no dataset node was created, never what actually reached the model. It now asserts the row values do **not** appear in the LLM request, and that the refusal block does.

## Compatibility

- `isCsvAttachment` is kept and deprecated; it still answers CSV-only, so any caller keeps its exact previous behaviour.
- `POST /api/v1/datasets` gains a `datasets[]` array (one entry per sheet). `dataset` / `privacyScan` / `truncation` still carry the first table, so existing clients are unaffected.
- The admin upload UI accepted only `.csv`, so XLSX could not be uploaded there at all — filter and copy updated in both locales.

## Test plan

- [x] `npm test` (middleware) — 8147 tests, 0 fail, 16 pre-existing skips
- [x] 31 new tests: cell coercion across every ExcelJS value shape, header detection, multi-sheet, duplicate/empty headers, blank-row skipping, all caps, format detection incl. mislabeled MIME types, and an end-to-end assertion that a raw email in an XLSX does not survive the import
- [x] `npx vitest run app/admin/datasets` (web-ui) — 17 passed
- [x] `npm run typecheck` (middleware + web-ui), `npm run i18n:check` — clean
- [ ] Manual: upload a multi-sheet `.xlsx` in Teams, confirm one dataset per sheet and that `query_dataset` reaches them

## Related

Complements the operator-side change made on the live instance today: `mask_user_prompt` was enabled on `@omadia/plugin-privacy-guard`, which turns on C0 masking for prompt *and* attachment text (`maskIngestedForWire`). That covers email/IBAN/phone/amounts; **person names still require the C1 GLiNER sidecar** (`c1_detector_url`), which is not yet deployed. This PR is the structural half — it stops tabular data from taking the text path in the first place.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790767794&installation_model_id=428086&pr_number=971&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F971&signature=3110df742305918540cd5ded88fd75521afd3479dd3b00693defc44c25daf37b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->