### PR TITLE
fix: route each provisioned bot to its own agent

### DIFF
--- a/middleware/packages/harness-channel-sdk/src/channelRouting.ts
+++ b/middleware/packages/harness-channel-sdk/src/channelRouting.ts
@@ -38,6 +38,21 @@ export interface ChannelResolveResult {
    * iff `decision !== 'reject'`.
    */
   readonly chatAgent?: ChatAgent;
+  /**
+   * `true` iff the key IS the agent's provisioned identity — the bot that
+   * was registered to BE this agent — rather than a binding an operator (or
+   * the auto-bind sweep) chose for it.
+   *
+   * Only matters for an adapter that probes MORE THAN ONE key per turn.
+   * Teams has two: the conversation the message arrived in, and the bot's own
+   * `28:<appId>`. Several provisioned bots can share one group chat, so a hit
+   * on the conversation identifies the chat, never the bot — prefer an
+   * exclusive hit over any other, no matter which key you probed first.
+   *
+   * Optional and additive. Older platforms never set it and adapters that
+   * ignore it behave exactly as they did before.
+   */
+  readonly exclusive?: boolean;
 }
 
 /**

--- a/middleware/packages/harness-orchestrator/src/registry/configStore.ts
+++ b/middleware/packages/harness-orchestrator/src/registry/configStore.ts
@@ -107,6 +107,37 @@ export interface ChannelBindingRow {
   readonly createdAt: Date;
 }
 
+/**
+ * A channel key that IS an agent's own provisioned identity — not an
+ * operator's routing preference.
+ *
+ * WHY THIS IS NOT A `channel_bindings` ROW
+ * ----------------------------------------
+ * `channel_bindings` is the operator's table: one flat (type, key) namespace
+ * they fill in by hand or that the auto-bind sweep fills in for an observed
+ * conversation. An identity is a different kind of fact. Provisioning an
+ * agent's own Microsoft Teams bot registers an Entra app, an Azure bot and an
+ * app package that exist SOLELY to be that agent's face — the mapping is
+ * already persisted (`agent_teams_identities.app_id`) and it is not a
+ * preference anyone may override.
+ *
+ * Copying it into `channel_bindings` would create a second copy of a mapping
+ * that already exists, and the two would drift the first time an identity is
+ * reset, re-provisioned or hand-edited. So routing READS the identity table
+ * instead: one source of truth, no backfill, and deleting the identity
+ * un-routes the bot for free.
+ *
+ * Exclusivity is the other half. Several provisioned bots share one group
+ * chat, so a binding on that CONVERSATION cannot say which bot a turn is for;
+ * only the bot key can. An identity therefore outranks every binding — see
+ * `OrchestratorRegistry.identityForChannel`.
+ */
+export interface ChannelIdentityRow {
+  readonly channelType: string;
+  readonly channelKey: string;
+  readonly agentId: string;
+}
+
 export interface PlatformSettingsRow {
   readonly fallbackAgentId: string | null;
   readonly updatedAt: Date;
@@ -636,6 +667,52 @@ export class ConfigStore {
     );
   }
 
+  // ── channel identities (provisioned bots) ─────────────────────────────
+  /**
+   * Every provisioned Microsoft Teams bot as a routing key.
+   *
+   * `agent_teams_identities` already holds the only mapping that matters —
+   * `app_id` (the bot's Entra application id) against the agent it was
+   * provisioned for. The Bot-Framework identity the middleware sees on an
+   * inbound activity is `activity.recipient.id`, i.e. `28:<appId>`
+   * lowercased; the Teams plugin builds the same string with its
+   * `teamsBotKey()` helper and exact string equality is what routes, so the
+   * projection is done here in SQL rather than anywhere a second spelling
+   * could creep in.
+   *
+   * Rows without an `app_id` are provisioning runs that have not reached the
+   * app-registration step — there is no bot to route to yet, so they are
+   * skipped rather than projected to a `28:null` key.
+   *
+   * MISSING TABLE IS NOT AN ERROR. This package is embeddable without the
+   * platform's migration series (`agent_teams_identities` arrives in
+   * middleware/migrations/0049). "No identity table" means "no provisioned
+   * bots", which is exactly the pre-existing behaviour — so an
+   * undefined_table degrades to an empty list instead of taking the whole
+   * snapshot load, and with it the registry boot, down with it.
+   */
+  async listChannelIdentities(): Promise<readonly ChannelIdentityRow[]> {
+    try {
+      const { rows } = await this.pool.query<{
+        agent_id: string;
+        channel_key: string;
+      }>(
+        `SELECT agent_id, '28:' || lower(app_id) AS channel_key
+           FROM agent_teams_identities
+          WHERE app_id IS NOT NULL AND app_id <> ''
+          ORDER BY channel_key`,
+      );
+      return rows.map((r) => ({
+        channelType: 'teams',
+        channelKey: r.channel_key,
+        agentId: r.agent_id,
+      }));
+    } catch (err) {
+      if (isUndefinedTable(err)) return [];
+      throw err;
+    }
+  }
+
   // ── multi_orchestrator_settings ─────────────────────────────────────────────────
   async getPlatformSettings(): Promise<PlatformSettingsRow> {
     const { rows } = await this.pool.query<PlatformSettingsDbRow>(
@@ -682,6 +759,7 @@ export class ConfigStore {
       agents,
       plugins,
       bindings,
+      identities,
       settings,
       subAgents,
       toolGrants,
@@ -694,6 +772,7 @@ export class ConfigStore {
       this.listAgents(),
       this.listAllAgentPlugins(),
       this.listChannelBindings(),
+      this.listChannelIdentities(),
       this.getPlatformSettings(),
       graph.listAllSubAgents(),
       graph.listAllToolGrants(),
@@ -707,6 +786,7 @@ export class ConfigStore {
       agents,
       agentPlugins: plugins,
       channelBindings: bindings,
+      channelIdentities: identities,
       platformSettings: settings,
       subAgents,
       toolGrants,
@@ -723,6 +803,14 @@ export interface ConfigSnapshot {
   readonly agents: readonly AgentRow[];
   readonly agentPlugins: readonly AgentPluginRow[];
   readonly channelBindings: readonly ChannelBindingRow[];
+  /**
+   * Provisioned channel identities (see {@link ChannelIdentityRow}). Optional
+   * so snapshot literals written before this existed — tests, fixtures, an
+   * embedding host — stay valid and keep their pre-existing routing; a
+   * deployment with no provisioned bots is indistinguishable from one that
+   * never had the field.
+   */
+  readonly channelIdentities?: readonly ChannelIdentityRow[];
   readonly platformSettings: PlatformSettingsRow;
   // Agent Builder graph (P0). Optional so pre-existing snapshot literals
   // (tests, fixtures) stay valid; `loadSnapshot` always populates them.
@@ -735,6 +823,15 @@ export interface ConfigSnapshot {
   readonly mcpServers?: readonly McpServerRow[];
   /** Epic #459 W4 — operator bindings of skill capability contracts. */
   readonly skillToolBindings?: readonly SkillToolBindingRow[];
+}
+
+/** Postgres `undefined_table` (42P01) — the relation does not exist. */
+function isUndefinedTable(err: unknown): boolean {
+  return (
+    !!err &&
+    typeof err === 'object' &&
+    (err as { code?: string }).code === '42P01'
+  );
 }
 
 function isUniqueViolation(err: unknown, constraint?: string): boolean {

--- a/middleware/packages/harness-orchestrator/src/registry/index.ts
+++ b/middleware/packages/harness-orchestrator/src/registry/index.ts
@@ -24,6 +24,7 @@ import {
   type AgentPluginRow,
   type AgentRow,
   type ChannelBindingRow,
+  type ChannelIdentityRow,
   type ConfigSnapshot,
   type ConfigStore,
   type PlatformSettingsRow,
@@ -171,6 +172,13 @@ export class OrchestratorRegistry {
     updatedAt: new Date(0),
   };
   private snapshot: ConfigSnapshot | undefined;
+  /**
+   * Provisioned channel identities from the last snapshot. Flat, not indexed
+   * per agent: the lookup is always key → agent and the list is one row per
+   * provisioned bot (single digits in practice), so a scan costs less than
+   * keeping a second map in sync across four diff actions.
+   */
+  private channelIdentities: readonly ChannelIdentityRow[] = [];
 
   constructor(
     private readonly store: ConfigStore,
@@ -217,6 +225,13 @@ export class OrchestratorRegistry {
     validateSnapshot(safe, this.options.pluginLookup);
     const plan = diffSnapshots(this.snapshot, safe);
     if (plan.actions.length === 0 && !plan.platformChanged) {
+      // Identities are NOT part of the diff: an agent whose bot finished
+      // provisioning has the same row, plugins and bindings it had a minute
+      // ago, so the plan is empty and the fast path returns here. Adopting
+      // them on this branch too is what makes a bot start routing to its own
+      // agent on the next reconcile instead of only after some unrelated
+      // config edit forces a rebuild.
+      this.channelIdentities = safe.channelIdentities ?? [];
       this.snapshot = safe;
       return plan;
     }
@@ -300,6 +315,7 @@ export class OrchestratorRegistry {
         fallbackAgentId: snap.platformSettings.fallbackAgentId,
       });
     }
+    this.channelIdentities = snap.channelIdentities ?? [];
     this.snapshot = snap;
   }
 
@@ -444,6 +460,8 @@ export class OrchestratorRegistry {
     channelType: string,
     channelKey: string,
   ): ActiveAgent | undefined {
+    const identity = this.identityForChannel(channelType, channelKey);
+    if (identity) return identity;
     for (const entry of this.active.values()) {
       for (const binding of entry.bindings) {
         if (
@@ -458,6 +476,37 @@ export class OrchestratorRegistry {
     if (!fallbackId) return undefined;
     for (const entry of this.active.values()) {
       if (entry.agent.id === fallbackId) return entry;
+    }
+    return undefined;
+  }
+
+  /**
+   * Resolve a key that IS an agent's provisioned identity — its own Teams
+   * bot, not a channel someone bound to it.
+   *
+   * Checked BEFORE `channel_bindings` and reported as exclusive, because a
+   * provisioned bot is the one routing input that cannot be ambiguous.
+   * Several bots share one group chat, so a binding on that conversation
+   * names a chat, not a bot; if it were allowed to win, every bot in the chat
+   * would answer as the same agent — which is precisely the failure this
+   * exists to prevent. A stale `channel_bindings` row pointing the bot key
+   * somewhere else loses for the same reason.
+   *
+   * Returns `undefined` when the identity names an agent the registry does
+   * not hold (deleted, disabled, or failed to build). Routing then continues
+   * down the normal path — bindings, then the platform fallback — so an
+   * orphaned identity row degrades instead of dead-ending the bot.
+   */
+  identityForChannel(
+    channelType: string,
+    channelKey: string,
+  ): ActiveAgent | undefined {
+    const match = this.channelIdentities.find(
+      (i) => i.channelType === channelType && i.channelKey === channelKey,
+    );
+    if (!match) return undefined;
+    for (const entry of this.active.values()) {
+      if (entry.agent.id === match.agentId) return entry;
     }
     return undefined;
   }

--- a/middleware/packages/harness-orchestrator/src/routing/channelResolver.ts
+++ b/middleware/packages/harness-orchestrator/src/routing/channelResolver.ts
@@ -12,6 +12,18 @@ import type { ActiveAgent, OrchestratorRegistry } from '../registry/index.js';
  * log stream with full context (FR-020) — the registry itself stays
  * routing-agnostic so unit tests don't have to assert on log lines.
  *
+ * Precedence (highest first):
+ *   1. PROVISIONED IDENTITY — the key is an agent's own bot
+ *      (`agent_teams_identities.app_id` → `28:<appId>`). Reported as
+ *      `decision: 'bound', exclusive: true`. This rank exists because a
+ *      channel adapter probes several keys per turn and the less specific
+ *      ones are genuinely ambiguous: many provisioned bots live in one group
+ *      chat, so a binding on that conversation cannot say which bot a turn
+ *      belongs to. Letting it win made every bot answer as the same agent.
+ *   2. `channel_bindings` — what the operator bound. `decision: 'bound'`.
+ *   3. The platform fallback Agent. `decision: 'fallback'`.
+ *   4. Nothing. `decision: 'reject'`.
+ *
  * Unmatched-key policy (T031):
  *   - If the registry has a `fallback_agent_id` set, the resolver returns
  *     the fallback Agent's `BuiltOrchestrator`. The log line carries
@@ -33,6 +45,18 @@ export interface ResolveResult {
   readonly agent?: ActiveAgent;
   /** Convenience: same as `agent?.built.bundle.agent` when present. */
   readonly chatAgent?: ChatAgent;
+  /**
+   * `true` iff the key IS the agent's provisioned identity (its own Teams
+   * bot), rather than a binding someone chose. Additive and optional: a
+   * channel adapter that ignores it keeps its previous behaviour exactly.
+   *
+   * An adapter that holds several keys for one turn — Teams sends both a
+   * conversation id and the bot's `28:<appId>` — MUST prefer an exclusive
+   * hit over any other, whatever order it probes in. Without that, a binding
+   * on the group chat all the bots share silently answers for every one of
+   * them.
+   */
+  readonly exclusive?: boolean;
 }
 
 export interface ChannelResolverOptions {
@@ -49,6 +73,28 @@ export class ChannelResolver {
    */
   resolve(channelType: string, channelKey: string): ResolveResult {
     const registry = this.options.registry;
+    // A provisioned identity outranks every binding — see
+    // `OrchestratorRegistry.identityForChannel`. Reported separately from
+    // the binding path so the log line names WHY the turn went where it did:
+    // "fell back" and "is that bot's agent" are very different answers to
+    // the same operator question.
+    const identity = registry.identityForChannel(channelType, channelKey);
+    if (identity) {
+      this.log(`channelResolver: route`, {
+        channelType,
+        channelKey,
+        decision: 'bound',
+        match: 'identity',
+        slug: identity.agent.slug,
+        agentId: identity.agent.id,
+      });
+      return {
+        decision: 'bound',
+        agent: identity,
+        chatAgent: identity.built.bundle.agent,
+        exclusive: true,
+      };
+    }
     const direct = registry.resolveByChannel(channelType, channelKey);
     if (direct) {
       // The registry's resolveByChannel returns the fallback too when no
@@ -62,6 +108,7 @@ export class ChannelResolver {
         channelType,
         channelKey,
         decision,
+        match: decision === 'bound' ? 'binding' : 'fallback',
         slug: direct.agent.slug,
         agentId: direct.agent.id,
       });

--- a/middleware/src/routes/operatorAgents.ts
+++ b/middleware/src/routes/operatorAgents.ts
@@ -3426,13 +3426,23 @@ export function createOperatorAgentsRouter(
         return;
       }
       const settings = await live.store.getPlatformSettings();
-      const via =
-        match.agent.id === settings.fallbackAgentId &&
-        !match.bindings.some(
-          (b) =>
-            b.channelType === body.channel_type &&
-            b.channelKey === body.channel_key,
-        )
+      // Order mirrors the resolver: a provisioned identity is checked first,
+      // so reporting it first is what keeps this tester an honest preview.
+      // Without this branch a provisioned bot whose agent also happens to be
+      // the platform fallback would be reported as "fallback" — the exact
+      // wrong explanation for the exact case operators come here to check.
+      const identity = live.registry.identityForChannel(
+        body.channel_type,
+        body.channel_key,
+      );
+      const via = identity
+        ? 'identity'
+        : match.agent.id === settings.fallbackAgentId &&
+            !match.bindings.some(
+              (b) =>
+                b.channelType === body.channel_type &&
+                b.channelKey === body.channel_key,
+            )
           ? 'fallback'
           : 'binding';
       res.json({

--- a/middleware/test/channelIdentityRouting.test.ts
+++ b/middleware/test/channelIdentityRouting.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Provisioned channel identities outrank channel bindings (#860 follow-up).
+ *
+ * THE BUG THIS PINS DOWN
+ * ----------------------
+ * Provisioning an agent's own Teams bot writes `agent_teams_identities`
+ * (app_id ↔ agent_id) and nothing else. Routing reads `channel_bindings`,
+ * which provisioning never touches — so every provisioned bot missed on its
+ * own `28:<appId>` key and the registry handed the turn to the platform
+ * fallback Agent. Three bots, three Entra apps, three agents, one answering
+ * agent. The mapping existed; the resolver was never shown it.
+ *
+ * The fix makes the identity a first-class, EXCLUSIVE routing input:
+ *   - it is matched before any `channel_bindings` row, and
+ *   - it reports `exclusive: true` so a less specific key (the shared group
+ *     conversation every bot sits in) can never override the bot's own agent.
+ *
+ * A deployment with no provisioned identities must behave exactly as before —
+ * that is what the last test in this file is for.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import type { LlmProvider } from '@omadia/llm-provider';
+import { InMemoryNudgeRegistry } from '@omadia/plugin-api';
+import type {
+  EntityRefBus,
+  KnowledgeGraph,
+  MemoryStore,
+} from '@omadia/plugin-api';
+
+import type { OrchestratorDeps } from '../packages/harness-orchestrator/src/buildOrchestrator.js';
+import type { NativeToolRegistry } from '../packages/harness-orchestrator/src/nativeToolRegistry.js';
+import type {
+  AgentRow,
+  ConfigSnapshot,
+  ConfigStore,
+} from '../packages/harness-orchestrator/src/registry/configStore.js';
+import { OrchestratorRegistry } from '../packages/harness-orchestrator/src/registry/index.js';
+import { ChannelResolver } from '../packages/harness-orchestrator/src/routing/channelResolver.js';
+
+/** The three ids from the field report, shortened. */
+const HR_ID = '3f50d98d-5349-49e1-a3fb-a8d61cb0329e';
+const MESSIAS_ID = '8b6a1010-da77-4d4f-b789-88b244aa1598';
+const FALLBACK_ID = '28e47b63-d9db-4c4a-b3e6-0b51c89c4f99';
+
+/** `activity.recipient.id` of each provisioned bot: `28:` + Entra app id. */
+const HR_BOT_KEY = '28:3d78d742-eefb-4fb2-bae5-3687f24c46fc';
+const MESSIAS_BOT_KEY = '28:19ad2729-f7d3-4099-9d2a-7da1230c9533';
+/** The group chat all three bots share — one key, many bots. */
+const GROUP_CHAT = '19:5c8a1f60deadbeef@thread.skype';
+
+function fakeNativeToolRegistry(): NativeToolRegistry {
+  const names = new Set<string>();
+  return {
+    has: (name: string) => names.has(name),
+    register: (name: string) => {
+      names.add(name);
+      return () => names.delete(name);
+    },
+  } as unknown as NativeToolRegistry;
+}
+
+function deps(): OrchestratorDeps {
+  return {
+    provider: {} as LlmProvider,
+    knowledgeGraph: {} as KnowledgeGraph,
+    memoryStore: {} as MemoryStore,
+    entityRefBus: {} as EntityRefBus,
+    nativeToolRegistry: fakeNativeToolRegistry(),
+    nudgeRegistry: new InMemoryNudgeRegistry(),
+    responseGuard: () => undefined,
+    privacyGuard: () => undefined,
+  };
+}
+
+function agent(slug: string, id: string): AgentRow {
+  return {
+    id,
+    slug,
+    name: slug,
+    description: null,
+    privacyProfile: 'default',
+    status: 'enabled',
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  };
+}
+
+const AGENTS: readonly AgentRow[] = [
+  agent('hr', HR_ID),
+  agent('messias', MESSIAS_ID),
+  agent('fallback', FALLBACK_ID),
+];
+
+function snapshot(over: Partial<ConfigSnapshot> = {}): ConfigSnapshot {
+  return {
+    agents: AGENTS,
+    agentPlugins: [],
+    channelBindings: [],
+    platformSettings: { fallbackAgentId: FALLBACK_ID, updatedAt: new Date(0) },
+    ...over,
+  };
+}
+
+const PROVISIONED: ConfigSnapshot['channelIdentities'] = [
+  { channelType: 'teams', channelKey: HR_BOT_KEY, agentId: HR_ID },
+  { channelType: 'teams', channelKey: MESSIAS_BOT_KEY, agentId: MESSIAS_ID },
+];
+
+function fakeStore(snap: ConfigSnapshot): ConfigStore {
+  return { loadSnapshot: () => Promise.resolve(snap) } as unknown as ConfigStore;
+}
+
+async function resolverFor(snap: ConfigSnapshot): Promise<ChannelResolver> {
+  const registry = new OrchestratorRegistry(fakeStore(snap), deps(), {
+    defaultRuntimeConfig: { model: 'm', maxTokens: 100, maxToolIterations: 4 },
+  });
+  await registry.start();
+  return new ChannelResolver({ registry });
+}
+
+test('two provisioned bots in one chat route to two different agents', async () => {
+  const resolver = await resolverFor(
+    snapshot({ channelIdentities: PROVISIONED }),
+  );
+
+  const hr = resolver.resolve('teams', HR_BOT_KEY);
+  const messias = resolver.resolve('teams', MESSIAS_BOT_KEY);
+
+  assert.equal(hr.decision, 'bound');
+  assert.equal(hr.agent?.agent.slug, 'hr');
+  assert.equal(messias.decision, 'bound');
+  assert.equal(messias.agent?.agent.slug, 'messias');
+  assert.notEqual(hr.agent?.agent.id, messias.agent?.agent.id);
+});
+
+test('a provisioned identity is exclusive — nothing less specific may override it', async () => {
+  const resolver = await resolverFor(
+    snapshot({ channelIdentities: PROVISIONED }),
+  );
+
+  const hr = resolver.resolve('teams', HR_BOT_KEY);
+  assert.equal(hr.exclusive, true);
+});
+
+test('a group-chat binding does not steal a provisioned bot key', async () => {
+  // The operator (or the auto-bind sweep) bound the shared group chat to the
+  // HR agent. That binding is legitimate for the chat, but the bot key must
+  // still resolve to the bot's OWN agent — and say so exclusively, so the
+  // channel adapter knows not to prefer the conversation hit.
+  const resolver = await resolverFor(
+    snapshot({
+      channelIdentities: PROVISIONED,
+      channelBindings: [
+        {
+          channelType: 'teams',
+          channelKey: GROUP_CHAT,
+          agentId: HR_ID,
+          createdAt: new Date(0),
+        },
+        // …and someone even pointed the bot key itself elsewhere. The
+        // provisioned identity is the truth; the stale row loses.
+        {
+          channelType: 'teams',
+          channelKey: MESSIAS_BOT_KEY,
+          agentId: HR_ID,
+          createdAt: new Date(0),
+        },
+      ],
+    }),
+  );
+
+  const conversation = resolver.resolve('teams', GROUP_CHAT);
+  assert.equal(conversation.decision, 'bound');
+  assert.equal(conversation.agent?.agent.slug, 'hr');
+  assert.notEqual(conversation.exclusive, true);
+
+  const messias = resolver.resolve('teams', MESSIAS_BOT_KEY);
+  assert.equal(messias.agent?.agent.slug, 'messias');
+  assert.equal(messias.exclusive, true);
+});
+
+test('an unknown bot key still falls back to the default agent', async () => {
+  const resolver = await resolverFor(
+    snapshot({ channelIdentities: PROVISIONED }),
+  );
+
+  const unknown = resolver.resolve('teams', '28:00000000-0000-0000-0000-000000000000');
+  assert.equal(unknown.decision, 'fallback');
+  assert.equal(unknown.agent?.agent.slug, 'fallback');
+  assert.notEqual(unknown.exclusive, true);
+});
+
+test('an identity only claims its own channel type', async () => {
+  const resolver = await resolverFor(
+    snapshot({ channelIdentities: PROVISIONED }),
+  );
+
+  const wrongType = resolver.resolve('telegram', HR_BOT_KEY);
+  assert.equal(wrongType.decision, 'fallback');
+  assert.equal(wrongType.agent?.agent.slug, 'fallback');
+});
+
+test('an identity pointing at a disabled/absent agent degrades to the old path', async () => {
+  // The agent row is gone (deleted) but the identity row survived. Routing
+  // must not dead-end: fall through to bindings, then the platform fallback.
+  const resolver = await resolverFor(
+    snapshot({
+      channelIdentities: [
+        { channelType: 'teams', channelKey: HR_BOT_KEY, agentId: 'ghost' },
+      ],
+    }),
+  );
+
+  const hr = resolver.resolve('teams', HR_BOT_KEY);
+  assert.equal(hr.decision, 'fallback');
+  assert.equal(hr.agent?.agent.slug, 'fallback');
+});
+
+test('a deployment without provisioned identities behaves exactly as before', async () => {
+  const resolver = await resolverFor(
+    snapshot({
+      channelBindings: [
+        {
+          channelType: 'teams',
+          channelKey: GROUP_CHAT,
+          agentId: MESSIAS_ID,
+          createdAt: new Date(0),
+        },
+      ],
+    }),
+  );
+
+  const bound = resolver.resolve('teams', GROUP_CHAT);
+  assert.equal(bound.decision, 'bound');
+  assert.equal(bound.agent?.agent.slug, 'messias');
+  assert.equal(bound.exclusive, undefined);
+
+  const unbound = resolver.resolve('teams', HR_BOT_KEY);
+  assert.equal(unbound.decision, 'fallback');
+  assert.equal(unbound.agent?.agent.slug, 'fallback');
+  assert.equal(unbound.exclusive, undefined);
+});
+
+test('identity routing survives a reload that changes nothing else', async () => {
+  // The provisioning run writes `app_id` long after boot. The registry picks
+  // it up on its next reconcile — even though the agent/plugin/binding diff
+  // is empty and the fast path skips `applyDiffActions` entirely.
+  let snap = snapshot();
+  const store = {
+    loadSnapshot: () => Promise.resolve(snap),
+  } as unknown as ConfigStore;
+  const registry = new OrchestratorRegistry(store, deps(), {
+    defaultRuntimeConfig: { model: 'm', maxTokens: 100, maxToolIterations: 4 },
+  });
+  await registry.start();
+  const resolver = new ChannelResolver({ registry });
+
+  assert.equal(resolver.resolve('teams', HR_BOT_KEY).agent?.agent.slug, 'fallback');
+
+  snap = snapshot({ channelIdentities: PROVISIONED });
+  const plan = await registry.reload();
+  assert.equal(plan.actions.length, 0, 'no agent-level change — fast path');
+
+  const after = resolver.resolve('teams', HR_BOT_KEY);
+  assert.equal(after.agent?.agent.slug, 'hr');
+  assert.equal(after.exclusive, true);
+});
+
+test('the routing decision is logged with its match source', async () => {
+  const lines: Array<{ msg: string; fields?: Record<string, unknown> }> = [];
+  const registry = new OrchestratorRegistry(
+    fakeStore(snapshot({ channelIdentities: PROVISIONED })),
+    deps(),
+    { defaultRuntimeConfig: { model: 'm', maxTokens: 100, maxToolIterations: 4 } },
+  );
+  await registry.start();
+  const resolver = new ChannelResolver({
+    registry,
+    log: (msg, fields) => lines.push({ msg, ...(fields ? { fields } : {}) }),
+  });
+
+  resolver.resolve('teams', HR_BOT_KEY);
+
+  assert.equal(lines.length, 1);
+  assert.equal(lines[0]?.fields?.match, 'identity');
+  assert.equal(lines[0]?.fields?.slug, 'hr');
+  assert.equal(lines[0]?.fields?.agentId, HR_ID);
+});

--- a/middleware/test/configStoreChannelIdentities.pg.test.ts
+++ b/middleware/test/configStoreChannelIdentities.pg.test.ts
@@ -1,0 +1,133 @@
+/**
+ * `ConfigStore.listChannelIdentities` against a real Postgres.
+ *
+ * The projection `28:` + lower(app_id) is the whole contract: it must equal,
+ * byte for byte, the key the Teams plugin builds with `teamsBotKey()` and
+ * receives as `activity.recipient.id`. Exact string equality is what routes,
+ * so the casing rule is asserted against the real column rather than a mock —
+ * an operator-pasted uppercase GUID must not split a bot off its own agent.
+ *
+ * Schema comes from the ACTUAL migration file (0049), applied twice, so the
+ * query and the migration cannot drift apart silently. Runs in its own schema
+ * (search_path pinned per connection) so parallel pg suites never collide, and
+ * skips cleanly when no test Postgres is reachable.
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { after, before, beforeEach, describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { Pool } from 'pg';
+
+import { probePgTest } from './_helpers/pgTestDb.js';
+
+import { ConfigStore } from '../packages/harness-orchestrator/src/registry/configStore.js';
+
+const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
+  label: 'configStoreChannelIdentities',
+  vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'DATABASE_URL'],
+  timeoutMs: 1_500,
+});
+
+const MIGRATIONS_DIR = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'migrations',
+);
+
+/** Only 0049 — the query touches `agent_teams_identities` and nothing else. */
+const MIGRATION_FILE = '0049_agent_teams_identities.sql';
+
+const SCHEMA = `chanident_${String(process.pid)}`;
+
+describe('ConfigStore.listChannelIdentities (pg)', { skip: !pgAvailable }, () => {
+  let pool: Pool;
+  let store: ConfigStore;
+
+  before(async () => {
+    pool = new Pool({ connectionString: PG_URL, max: 2 });
+    pool.on('connect', (client) => {
+      void client.query(`SET search_path TO ${SCHEMA}, public`);
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS ${SCHEMA}`);
+    const sql = await readFile(resolve(MIGRATIONS_DIR, MIGRATION_FILE), 'utf8');
+    // Twice — the migrations README demands every file be re-appliable.
+    await pool.query(sql);
+    await pool.query(sql);
+    store = new ConfigStore(pool);
+  });
+
+  after(async () => {
+    await pool.query(`DROP SCHEMA IF EXISTS ${SCHEMA} CASCADE`);
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    await pool.query('DELETE FROM agent_teams_identities');
+  });
+
+  async function insert(
+    agentId: string,
+    botSlug: string,
+    appId: string | null,
+  ): Promise<void> {
+    await pool.query(
+      `INSERT INTO agent_teams_identities
+         (agent_id, bot_slug, display_name, state, app_id)
+       VALUES ($1, $2, $2, 'installed', $3)`,
+      [agentId, botSlug, appId],
+    );
+  }
+
+  it('projects each provisioned bot to its 28:<appId> routing key', async () => {
+    await insert('agent-hr', 'hr-bitch', '3D78D742-EEFB-4FB2-BAE5-3687F24C46FC');
+    await insert('agent-messias', 'messias', '19ad2729-f7d3-4099-9d2a-7da1230c9533');
+
+    const rows = await store.listChannelIdentities();
+
+    assert.deepEqual(
+      rows.map((r) => ({ ...r })),
+      [
+        {
+          channelType: 'teams',
+          channelKey: '28:19ad2729-f7d3-4099-9d2a-7da1230c9533',
+          agentId: 'agent-messias',
+        },
+        {
+          // Uppercase in the column, lowercase on the wire — the projection
+          // normalizes so mixed casing can never split routing.
+          channelType: 'teams',
+          channelKey: '28:3d78d742-eefb-4fb2-bae5-3687f24c46fc',
+          agentId: 'agent-hr',
+        },
+      ],
+    );
+  });
+
+  it('skips runs that have not registered an app yet', async () => {
+    await insert('agent-pending', 'pending-bot', null);
+    await insert('agent-empty', 'empty-bot', '');
+
+    assert.deepEqual(await store.listChannelIdentities(), []);
+  });
+
+  it('returns nothing when the platform identity table is absent', async () => {
+    // An embedding host that ran the orchestrator's own migrations but not
+    // the platform series. "No table" means "no provisioned bots" — it must
+    // not take the snapshot load, and with it the registry boot, down.
+    const bare = `${SCHEMA}_bare`;
+    const barePool = new Pool({ connectionString: PG_URL, max: 1 });
+    barePool.on('connect', (client) => {
+      void client.query(`SET search_path TO ${bare}`);
+    });
+    try {
+      await barePool.query(`CREATE SCHEMA IF NOT EXISTS ${bare}`);
+      assert.deepEqual(await new ConfigStore(barePool).listChannelIdentities(), []);
+    } finally {
+      await barePool.query(`DROP SCHEMA IF EXISTS ${bare} CASCADE`);
+      await barePool.end();
+    }
+  });
+});

--- a/web-ui/app/_lib/agents.ts
+++ b/web-ui/app/_lib/agents.ts
@@ -940,7 +940,9 @@ export interface ResolveChannelResponse {
     name: string;
     privacy_profile: PrivacyProfile;
   } | null;
-  via: 'binding' | 'fallback' | 'none';
+  /** `identity` — the key IS an agent's provisioned bot, which outranks
+   *  every binding. See the orchestrator's ChannelResolver. */
+  via: 'identity' | 'binding' | 'fallback' | 'none';
   message?: string;
 }
 


### PR DESCRIPTION
Three provisioned bots share a group chat — each with its own Entra app, Azure bot, app package and agent. Every message was answered by the same one:

```
route {"channelKey":"28:3d78d742-…","decision":"fallback","slug":"fallback","agentId":"28e47b63-…"}
route {"channelKey":"28:19ad2729-…","decision":"fallback","slug":"fallback","agentId":"28e47b63-…"}
```

That is the point of the epic, and none of it worked: three masks over one agent, with one memory and one identity. A just-shipped fix that writes the display name into the agent identity was inert for the same reason — it set the name on `messias` while `28e47b63` did the talking.

## Why every bot fell through

**A registration was missing, not a resolver bug.** `resolveByChannel` scans `channel_bindings` and then returns the platform fallback. Provisioning writes `agent_teams_identities` (`app_id` → `agent_id`) and **never touches `channel_bindings`** — the job runner contains no reference to it at all. So `28:3d78d742-…` matched nothing and the fallback branch fired, honestly: `slug: "fallback"` is the seeded fallback agent's literal slug.

## Reading the source instead of copying it

The obvious fix — have provisioning also write a binding row — creates a second copy of a fact that already exists, and it drifts on the first reset or re-provision. So routing now projects `agent_teams_identities` to the same key `teamsBotKey()` builds (`'28:' || lower(app_id)`).

Consequences worth stating: no backfill migration (the live tenant starts routing on the next reconcile), deleting an identity un-routes its bot for free, and a missing table degrades to "no provisioned bots". The `ReloadBus` reconciles on a timer with LISTEN disabled, so no NOTIFY trigger is needed — and `reload()`'s empty-diff fast path adopts identities too, otherwise a bot would only start working after some unrelated config edit.

## The default bot is untouched

Pinned rather than asserted: an unknown bot key still falls back (the `/api/messages` registration has no identity row), and a deployment without provisioned identities behaves exactly as before. Both tests were **green before the fix and stayed green** — that is the back-compat proof.

## Memory

Nothing is lost, and this **ends** a commingling that was already happening. Session transcripts stay in the shared `core` namespace by design, so chat continuity is unaffected. Agent-private notes re-home: until now all three bots wrote into the same `fallback` tree — HR and accounting notes in one namespace. Turns that ran as `fallback` stay there; each agent now writes under its own slug.

## Verification

**8172 tests, 8156 pass, 0 fail**; build, typecheck, `typecheck:test` (ratchet 370, no regressions) and lint clean. web-ui 1137/1137.

RED was real: the nine new registry/resolver tests started **5 failing / 4 passing**, the first failure reading `'fallback'` vs `'bound'` — the field symptom exactly. The pg suite ran against a live Postgres rather than skipping, so the key projection, uppercase-GUID normalisation and missing-table degradation are verified against the real thing.

The routing tester was quietly lying too: `POST /resolve-channel` reported `via: 'fallback'` whenever the matched agent happened to *be* the fallback — precisely a provisioned bot. It now reports `'identity'`.

Requires `@omadia/channel-teams` **0.23.0**, which fixes the other half: the plugin probed `conversation.id` first, and conversations are auto-bound, so a binding on the shared chat would have put all three bots back onto one agent.

## Left deliberately

An operator can still point `28:<appId>` at a different agent in `/operator/channels`. The identity now wins and the log says `match: 'identity'`, so it fails visibly rather than silently — but the UI does not yet stop them. Worth an issue, not worth widening this diff.

Refs #860.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790771633&installation_model_id=428086&pr_number=972&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F972&signature=3e9b54c408c109c53bdb432070822bdebf82cbe3dde8eb5d976b22a9245437dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->