### PR TITLE
fix: bind the PII-detector sidecar dual-stack so Fly can reach it

### DIFF
--- a/middleware/sidecars/pii-detector/server.py
+++ b/middleware/sidecars/pii-detector/server.py
@@ -33,6 +33,7 @@ between requests. The middleware-side contract lands with the
 import json
 import os
 import re
+import socket
 import threading
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -296,6 +297,60 @@ class Handler(BaseHTTPRequestHandler):
         pass
 
 
+class DualStackServer(ThreadingHTTPServer):
+    """HTTP server reachable over BOTH IPv6 and IPv4.
+
+    Binding `("0.0.0.0", PORT)` — the obvious choice, and what this shim did
+    originally — listens on IPv4 ONLY. That works under Docker Compose (the
+    overlay's bridge network is v4) but is invisible on Fly.io, whose private
+    network between apps is **IPv6-only**: `<app>.flycast` / `<app>.internal`
+    resolve to `fdaa:…` addresses, so the proxy's connection to an
+    IPv4-only listener is refused and the middleware sees `ECONNRESET`.
+
+    The symptom is nasty because the container looks healthy from every angle
+    that does not cross the network: the process runs, the model loads,
+    `curl 127.0.0.1:8812/health` returns 200, and a TCP service check can sit
+    on a stale `passing` for weeks. Only `[::1]:8812` reveals it —
+    "connection refused".
+
+    Binding `::` with `IPV6_V6ONLY` disabled accepts v6 and v4-mapped-v6
+    connections on one socket, so Compose and Fly both work with no
+    per-deployment configuration. `PII_DETECTOR_BIND_V4_ONLY=1` forces the
+    old IPv4-only behaviour for a host with IPv6 disabled entirely.
+    """
+
+    address_family = socket.AF_INET6
+
+    def server_bind(self):
+        # Accept v4-mapped connections too. Linux honours this per-socket;
+        # if the kernel refuses (IPv6 compiled out), fall through and let
+        # the bind fail loudly rather than listening on a narrower stack
+        # than the operator asked for.
+        try:
+            self.socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+        except OSError:
+            pass
+        super().server_bind()
+
+
+def build_server():
+    """The listening server, dual-stack unless explicitly forced to IPv4."""
+    if os.environ.get("PII_DETECTOR_BIND_V4_ONLY", "") in ("1", "true", "on"):
+        return ThreadingHTTPServer(("0.0.0.0", PORT), Handler), "0.0.0.0 (IPv4 only)"
+    try:
+        return DualStackServer(("::", PORT), Handler), ":: (IPv6 + IPv4-mapped)"
+    except OSError as err:
+        # No usable IPv6 stack — degrade to IPv4 rather than refusing to
+        # start, but say so, because on Fly this means unreachable.
+        print(
+            f"[pii-detector] IPv6 bind failed ({err}); falling back to IPv4-only. "
+            "On Fly.io the private network is IPv6-only, so this instance will "
+            "NOT be reachable from other apps.",
+            flush=True,
+        )
+        return ThreadingHTTPServer(("0.0.0.0", PORT), Handler), "0.0.0.0 (IPv4 fallback)"
+
+
 if __name__ == "__main__":
     print(
         f"[pii-detector] loading {MODEL_ID}@{MODEL_REVISION[:12]} "
@@ -304,9 +359,10 @@ if __name__ == "__main__":
     )
     _load_started = time.monotonic()
     _STATE["model"], _STATE["backend"] = load_model()
+    _server, _bind_desc = build_server()
     print(
         f"[pii-detector] model ready in {time.monotonic() - _load_started:.1f}s; "
-        f"listening on :{PORT}",
+        f"listening on {_bind_desc} port {PORT}",
         flush=True,
     )
-    ThreadingHTTPServer(("0.0.0.0", PORT), Handler).serve_forever()
+    _server.serve_forever()

--- a/middleware/sidecars/pii-detector/test_server.py
+++ b/middleware/sidecars/pii-detector/test_server.py
@@ -7,7 +7,9 @@ Stdlib-only; `server` is importable without gliner/onnxruntime installed
 """
 
 import os
+import socket
 import sys
+import threading
 import unittest
 
 # Make `import server` work regardless of the caller's cwd (e.g. running
@@ -188,6 +190,66 @@ class ValidateRequestTests(unittest.TestCase):
     def test_rejects_unknown_keys(self):
         with self.assertRaises(ValueError):
             server.validate_request({"text": "t", "prompt": "smuggled"})
+
+
+class BindStackTests(unittest.TestCase):
+    """The listener must be reachable over IPv6.
+
+    Fly.io's private network between apps is IPv6-only, so an IPv4-only
+    listener is invisible to the middleware even though the container looks
+    perfectly healthy locally (process up, model loaded,
+    `curl 127.0.0.1:8812/health` -> 200). That combination cost real debugging
+    time once; these tests pin the bind behaviour so it cannot regress
+    silently.
+    """
+
+    def setUp(self):
+        self._saved = os.environ.get("PII_DETECTOR_BIND_V4_ONLY")
+        os.environ.pop("PII_DETECTOR_BIND_V4_ONLY", None)
+        # Ephemeral port — never contend with a real sidecar on 8812.
+        self._saved_port = server.PORT
+        server.PORT = 0
+
+    def tearDown(self):
+        server.PORT = self._saved_port
+        os.environ.pop("PII_DETECTOR_BIND_V4_ONLY", None)
+        if self._saved is not None:
+            os.environ["PII_DETECTOR_BIND_V4_ONLY"] = self._saved
+
+    def test_default_bind_is_ipv6_and_accepts_v4_mapped(self):
+        srv, desc = server.build_server()
+        try:
+            self.assertEqual(srv.socket.family, socket.AF_INET6)
+            # IPV6_V6ONLY must be OFF so v4-mapped clients (Docker Compose's
+            # v4 bridge) still connect through the same socket.
+            self.assertEqual(
+                srv.socket.getsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY),
+                0,
+            )
+            self.assertIn("IPv4-mapped", desc)
+        finally:
+            srv.server_close()
+
+    def test_ipv6_loopback_actually_connects(self):
+        """The regression itself: [::1] must be reachable, not just 127.0.0.1."""
+        srv, _ = server.build_server()
+        try:
+            threading.Thread(target=srv.serve_forever, daemon=True).start()
+            port = srv.socket.getsockname()[1]
+            with socket.create_connection(("::1", port), timeout=5) as sock:
+                self.assertIsNotNone(sock)
+        finally:
+            srv.shutdown()
+            srv.server_close()
+
+    def test_env_override_forces_ipv4_only(self):
+        os.environ["PII_DETECTOR_BIND_V4_ONLY"] = "1"
+        srv, desc = server.build_server()
+        try:
+            self.assertEqual(srv.socket.family, socket.AF_INET)
+            self.assertIn("IPv4 only", desc)
+        finally:
+            srv.server_close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The finding

**The C1 PII detector has been deployed and unreachable since 2026-07-10.** `mask_user_prompt` has therefore been running C0-only in production: person names — the entire reason the C1 tier exists, since regex structurally cannot find them — were never masked.

Nothing was silently leaked past the shield: the middleware's `promptMaskDegraded` path is fail-safe and did exactly its job on every turn. But the protection operators believed was active was not.

## Root cause

`server.py` bound `("0.0.0.0", PORT)` — IPv4 only.

That is correct under the Docker Compose overlay, whose bridge network is v4. It is invisible on Fly.io, where the private network between apps is **IPv6-only**: `<app>.flycast` and `<app>.internal` resolve to `fdaa:…` addresses. The proxy's connection to an IPv4-only listener is refused, and the middleware sees `ECONNRESET`.

## Why it hid for seven weeks

Every signal that does not cross the network looks healthy:

| Check | Result |
|---|---|
| Process running | ✅ `python server.py`, PID 644 |
| Model loaded | ✅ `LOAD OK UniEncoderSpanGLiNER` |
| `curl 127.0.0.1:8812/health` | ✅ `200 {"ok": true, …}` |
| Fly TCP service check | ✅ `passing` |
| **`[::1]:8812`** | ❌ **connection refused** |

The Fly check deserves its own note: it read `passing` with **"Last Updated: Jul 10 2026 13:39"** — stale by seven weeks, and indistinguishable from green unless you read the timestamp.

## The fix

Bind `::` with `IPV6_V6ONLY` disabled, so one socket accepts IPv6 *and* IPv4-mapped connections. Compose and Fly both work with no per-deployment configuration.

- `PII_DETECTOR_BIND_V4_ONLY=1` forces the old IPv4-only behaviour for a host with IPv6 compiled out.
- An IPv6 bind failure degrades to IPv4 with a loud warning naming the Fly consequence, rather than refusing to boot.

Three tests, including one that **actually connects over `::1`** — the assertion that would have caught this originally. The other two pin the socket family and the `V6ONLY` sockopt, and verify the env override.

## Two operational findings from the same investigation

Both are recorded in `fly.pii-detector.toml`. That file is **untracked** — `middleware/sidecars/*/fly.*.toml` is gitignored by repo convention (same as the existing `fly.presidio.toml`) — so the values are repeated here:

- **The machine needs 4 GB, not 2.** The quantized ONNX model holds ~1.57 GB resident and the load peaks above it. On the original 2 GB machine (`MemTotal` 2015 MB) the load could not complete. I have already raised the live machine to 4096 MB.
- **Cold-boot model load takes 10–13 minutes** on shared-2-cpu, and the listener opens only *after* `load_model()` returns. The TCP check needs a grace period far beyond the default, or Fly declares the machine unhealthy mid-load.

The app also still carries public ingress IPs from its original ad-hoc `fly launch`. This sidecar receives **raw prompt PII** and should be Flycast-only; releasing them is noted in the config as a follow-up, not done here.

## Test plan

- [x] `python3 -m unittest sidecars/pii-detector/test_server.py` — 29 passed (26 existing + 3 new)
- [x] Root cause confirmed on the live machine: `127.0.0.1:8812/health` → 200 while `[::1]:8812` → refused
- [ ] Rebuild + redeploy the sidecar image, then confirm a middleware turn shows `c1-gliner` spans in the privacy receipt (currently `c0-regex` only)

## Related

Follows #971. Together: #971 stops tabular uploads from reaching the model as prompt text at all, and this restores the name-masking tier for everything that legitimately *is* prompt text.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790779168&installation_model_id=428086&pr_number=973&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F973&signature=32c78beefabec51f7fa43cbecfb399055b5200417350f1817a344cd751333b13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->