### PR TITLE
fix: ship the fp32 PII model — the quantized one computes noise on our CPU

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,18 @@ jobs:
       - name: Test — updater sidecar (node --test)
         run: npm run test:updater
 
+      # PII-detector sidecar (#361). Python, therefore outside every glob
+      # above — until now it was tested nowhere, which is how a shipped
+      # IPv4-only bind and a CPU-dependent broken model export both reached
+      # production unnoticed. The suite is stdlib-only and imports `server`
+      # WITHOUT gliner/onnxruntime (the model import is deferred into
+      # `load_model`), so it needs no install step and no model download:
+      # chunking, span merging, request validation, the dual-stack bind, and
+      # the startup selftest's rejection logic all run in milliseconds.
+      - name: Test — PII-detector sidecar (python unittest)
+        working-directory: middleware
+        run: python3 -m unittest sidecars/pii-detector/test_server.py -v
+
       # Anti-silent-skip guard (#565). The pg suites self-skip when the DB
       # is unreachable, so a broken/renamed service would once again pass
       # green with zero Postgres coverage. Fail loudly here instead if the

--- a/middleware/sidecars/pii-detector/Dockerfile
+++ b/middleware/sidecars/pii-detector/Dockerfile
@@ -15,8 +15,24 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Default: the ONNX export of urchade/gliner_multi_pii-v1 (quantized variant,
-# CPU-friendly). Torch fallback: build with
+# Default: the FP32 ONNX export of urchade/gliner_multi_pii-v1.
+#
+# NOT the quantized variant, despite it being 3x smaller. `model_quantized.onnx`
+# is a u8s8 export, and INT8 matmul saturates on CPUs without VNNI
+# (`avx512_vnni` / `avx_vnni`). The AMD EPYC backing our Fly machines has
+# `avx2` + `fma` but no VNNI, and there the quantized model returns
+# near-uniform ~0.15 scores that decay with token position — noise, not
+# predictions. It raises nothing: the model loads, /health answers 200, and
+# every span lands under threshold, so /detect returns `{"spans": []}` for
+# every input and the middleware masks nothing. The same file scores 1.000 on
+# an arm64 dev machine, which is exactly what made it hard to see.
+#
+# fp32 costs ~1.15 GB of image and RAM instead of ~349 MB, and is correct on
+# every CPU. Correctness wins here: this model decides what reaches a public
+# LLM. `server.py` additionally refuses to serve if its startup selftest does
+# not detect a known entity, so a bad export can never again degrade quietly.
+#
+# Torch fallback: build with
 #   --build-arg MODEL_ID=urchade/gliner_multi_pii-v1 \
 #   --build-arg MODEL_REVISION=1fcf13e85f4eef5394e1fcd406cf2ca9ea82351d \
 #   --build-arg DETECTOR_BACKEND=torch
@@ -24,6 +40,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 ARG MODEL_ID=onnx-community/gliner_multi_pii-v1
 ARG MODEL_REVISION=2e0397a7e8a250d76c37122232b3cbde42c8d629
 ARG DETECTOR_BACKEND=onnx
+ARG ONNX_MODEL_FILE=onnx/model.onnx
 RUN python -c "\
 import os; \
 from huggingface_hub import snapshot_download; \
@@ -35,13 +52,14 @@ snapshot_download(\
         'gliner_config.json', 'config.json', \
         'tokenizer.json', 'tokenizer_config.json', \
         'special_tokens_map.json', 'added_tokens.json', 'spm.model', \
-        'onnx/model_quantized.onnx', \
+        'onnx/model.onnx', \
         'pytorch_model.bin', \
     ])"
 
 ENV MODEL_ID=${MODEL_ID} \
     MODEL_REVISION=${MODEL_REVISION} \
     DETECTOR_BACKEND=${DETECTOR_BACKEND} \
+    ONNX_MODEL_FILE=${ONNX_MODEL_FILE} \
     MODEL_DIR=/app/model \
     HF_HUB_OFFLINE=1
 

--- a/middleware/sidecars/pii-detector/server.py
+++ b/middleware/sidecars/pii-detector/server.py
@@ -333,6 +333,55 @@ class DualStackServer(ThreadingHTTPServer):
         super().server_bind()
 
 
+# --- Startup self-test -------------------------------------------------
+#
+# A sentence whose person span any working build of this model scores far
+# above threshold. Deliberately synthetic — never a real person from the
+# tenant data this sidecar sees.
+SELFTEST_SENTENCE = "Anna Schmidt wohnt in Berlin."
+SELFTEST_EXPECT = "Anna Schmidt"
+SELFTEST_MIN_SCORE = float(os.environ.get("SELFTEST_MIN_SCORE", "0.6"))
+
+
+def run_selftest(model):
+    """Prove the loaded model actually predicts, before we serve traffic.
+
+    This exists because of a real, silent production failure: the
+    u8s8-quantized ONNX export (`onnx/model_quantized.onnx`) computes
+    correctly on some CPUs and produces NOISE on others. On the AMD EPYC
+    backing our Fly machines — `avx2` and `fma` present, but no
+    `avx512_vnni` / `avx_vnni` — INT8 matmul saturates, and the model
+    returns near-uniform ~0.15 scores that decay with token position instead
+    of predictions. Nothing raises. `/health` answers 200. Every span falls
+    under threshold, so `/detect` returns `{"spans": []}` for every input
+    and the middleware masks nothing while believing C1 is live.
+
+    A load that "succeeds" is therefore not evidence the detector works.
+    This check is the evidence. Failing closed at startup turns a silent
+    non-masking sidecar into an obvious broken deploy.
+
+    Returns `(ok, detail)`; `detail` never contains request text, only the
+    synthetic sentence's outcome.
+    """
+    try:
+        ents = model.predict_entities(
+            SELFTEST_SENTENCE, ["person", "address"], threshold=0.01
+        )
+    except Exception as err:  # noqa: BLE001 — any failure is a failed selftest
+        return False, f"inference raised {type(err).__name__}"
+    best = None
+    for e in ents:
+        if e.get("label") == "person" and e.get("text") == SELFTEST_EXPECT:
+            if best is None or e["score"] > best:
+                best = e["score"]
+    if best is None:
+        top = max((e["score"] for e in ents), default=0.0)
+        return False, f"expected person span not found; best score {top:.3f}"
+    if best < SELFTEST_MIN_SCORE:
+        return False, f"person span scored {best:.3f} < {SELFTEST_MIN_SCORE}"
+    return True, f"person span scored {best:.3f}"
+
+
 def build_server():
     """The listening server, dual-stack unless explicitly forced to IPv4."""
     if os.environ.get("PII_DETECTOR_BIND_V4_ONLY", "") in ("1", "true", "on"):
@@ -359,6 +408,18 @@ if __name__ == "__main__":
     )
     _load_started = time.monotonic()
     _STATE["model"], _STATE["backend"] = load_model()
+    _selftest_ok, _selftest_detail = run_selftest(_STATE["model"])
+    if not _selftest_ok:
+        print(
+            f"[pii-detector] SELFTEST FAILED ({_selftest_detail}). The model "
+            "loaded but does not detect a known entity — it is producing "
+            "noise, not predictions. Refusing to serve rather than silently "
+            "masking nothing. See the SELFTEST_SENTENCE comment for the "
+            "known cause (u8s8-quantized ONNX on a CPU without VNNI).",
+            flush=True,
+        )
+        raise SystemExit(3)
+    print(f"[pii-detector] selftest ok ({_selftest_detail})", flush=True)
     _server, _bind_desc = build_server()
     print(
         f"[pii-detector] model ready in {time.monotonic() - _load_started:.1f}s; "

--- a/middleware/sidecars/pii-detector/test_server.py
+++ b/middleware/sidecars/pii-detector/test_server.py
@@ -252,5 +252,66 @@ class BindStackTests(unittest.TestCase):
             srv.server_close()
 
 
+class SelfTestTests(unittest.TestCase):
+    """`run_selftest` must reject a model that loads but predicts noise.
+
+    The production failure it guards: a u8s8-quantized ONNX export on a CPU
+    without VNNI returns near-uniform ~0.15 scores instead of predictions.
+    Nothing raises, /health answers 200, and every span falls under
+    threshold — so the sidecar masks nothing while looking healthy.
+    """
+
+    class FakeModel:
+        def __init__(self, ents):
+            self._ents = ents
+
+        def predict_entities(self, text, labels, threshold=0.0):
+            return [e for e in self._ents if e["score"] >= threshold]
+
+    class RaisingModel:
+        def predict_entities(self, *a, **k):
+            raise RuntimeError("session failed")
+
+    def test_accepts_a_model_that_finds_the_known_person(self):
+        m = self.FakeModel(
+            [{"start": 0, "end": 12, "text": "Anna Schmidt", "label": "person", "score": 0.99}]
+        )
+        ok, detail = server.run_selftest(m)
+        self.assertTrue(ok)
+        self.assertIn("0.99", detail)
+
+    def test_rejects_the_noise_signature(self):
+        # Exactly what the broken quantized model returned in production:
+        # every token scored ~0.15, decaying with position.
+        noise = [
+            {"start": 0, "end": 4, "text": "Anna", "label": "person", "score": 0.191},
+            {"start": 5, "end": 12, "text": "Schmidt", "label": "person", "score": 0.174},
+            {"start": 13, "end": 18, "text": "wohnt", "label": "person", "score": 0.159},
+            {"start": 19, "end": 21, "text": "in", "label": "person", "score": 0.150},
+        ]
+        ok, detail = server.run_selftest(self.FakeModel(noise))
+        self.assertFalse(ok)
+        self.assertIn("not found", detail)
+
+    def test_rejects_a_correct_span_scored_below_the_floor(self):
+        m = self.FakeModel(
+            [{"start": 0, "end": 12, "text": "Anna Schmidt", "label": "person", "score": 0.2}]
+        )
+        ok, detail = server.run_selftest(m)
+        self.assertFalse(ok)
+        self.assertIn("<", detail)
+
+    def test_rejects_a_model_whose_inference_raises(self):
+        ok, detail = server.run_selftest(self.RaisingModel())
+        self.assertFalse(ok)
+        self.assertIn("RuntimeError", detail)
+
+    def test_detail_never_leaks_request_text(self):
+        # Only the synthetic sentence may ever appear in the audit line.
+        ok, detail = server.run_selftest(self.FakeModel([]))
+        self.assertFalse(ok)
+        self.assertNotIn("@", detail)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## The symptom

After #973 made the C1 detector reachable, it answered — with `{"spans": []}` for **every** input. Not a tuning problem. At `threshold=0.01`:

```
Anna Schmidt wohnt in Berlin.
  0.191  person  'Anna'
  0.174  person  'Schmidt'
  0.159  person  'wohnt'
  0.150  person  'in'
  0.147  person  'Berlin.'
```

Scores tracking **token position** rather than content is the signature of broken arithmetic, not of an uncertain model. A working build scores `Anna Schmidt` at 1.000 and ignores `wohnt`/`in` entirely.

## Cause

`onnx/model_quantized.onnx` is a **u8s8** export, and INT8 matmul saturates on CPUs without VNNI. The AMD EPYC backing our Fly machines:

```
avx2: YES   fma: YES   sse4_2: YES
avx512_vnni: no   avx_vnni: no
```

onnxruntime raises nothing — it computes garbage quietly.

## Why it was expensive to find

The **same file**, with the **same** `gliner 0.2.27` / `onnxruntime 1.27.0` / `transformers 5.6.2`, scores `Anna Schmidt` at **1.000** on an arm64 dev machine. The artifact is not corrupt, the pins are not wrong, the config is intact — only this CPU is affected.

Two plausible hypotheses were tested and **disproved** before landing on the CPU:

| Hypothesis | Test | Result |
|---|---|---|
| transformers 5.x breaks the tokenizer (there *is* a loud `fix_mistral_regex` warning) | ran 5.6.2 vs 4.56.2 in the container | byte-identical scores — the warning is a red herring |
| Model download damaged / incomplete | verified every file, sizes, `gliner_config.json` | complete and intact |
| **CPU lacks VNNI → u8s8 saturates** | fp32 vs quantized, local arm64 vs Fly EPYC | **confirmed** |

## The fix

Ship `onnx/model.onnx` (fp32): ~1.15 GB of image and memory instead of ~349 MB, correct on every CPU. Correctness wins here — this model decides what reaches a public LLM. Machine memory stays at **4096 MiB** — that turned out to be the hard ceiling for `cpu_kind = 'shared'`; a first attempt at 6 GB failed the deploy with `invalid config.guest.memory_mb, cannot exceed 4096 MiB`. fp32 still fits, but with less slack than the quantized build had, and going higher would need `cpu_kind = 'performance'`. Noted in the deployment config.

**Plus a startup selftest.** `server.py` now runs one known synthetic sentence through the loaded model and **refuses to serve** if the expected person span is missing or scores below a floor. The entire failure mode above was silent: the process ran, the model "loaded", `/health` returned 200, and the middleware masked nothing while believing C1 was live. A load that succeeds is not evidence the detector works — this check is that evidence, and it turns a silently-non-masking sidecar into an obviously broken deploy.

Five tests cover it, including the **exact noise signature** observed in production as a rejection case.

## Impact

Person names were never masked in production — first because the sidecar was unreachable (#973), then because the model returned nothing. C0 (email, IBAN, phone, amounts, dates) was and is unaffected, and nothing leaked past the shield: the middleware's `promptMaskDegraded` path is fail-safe throughout.

## Test plan

- [x] `python3 -m unittest sidecars/pii-detector/test_server.py` — 34 passed (29 + 5 new)
- [x] fp32 and quantized A/B'd locally on arm64: both score 1.000 there, proving the artifact is sound
- [x] CPU flags captured from the live Fly machine
- [ ] Deploy in flight; the startup selftest **is** the on-CPU verification — if fp32 also broke on EPYC, the server would refuse to start rather than serve noise
- [ ] Then: a middleware turn showing `c1-gliner` spans in the privacy receipt

## Follows

#971 (tabular uploads never reach the model as prompt text) and #973 (sidecar reachable at all).
