### PR TITLE
fix: give each agent its own name in prompt and disclosure

### DIFF
--- a/middleware/packages/harness-orchestrator/src/buildOrchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/buildOrchestrator.ts
@@ -133,6 +133,20 @@ export interface AgentRuntimeConfig {
    */
   readonly identityName?: string;
   /**
+   * #967 follow-up — this Agent's authored SELF-DESCRIPTION
+   * (`agent_identities.short_description` / `.long_description`, the operator's
+   * "Steckbrief" tab), already trimmed and non-empty when present.
+   *
+   * LAYERS, LIKE THE NAME, NOT SLOTS. They say what the Agent IS; they never
+   * replace what it was told to DO. See `withAgentIdentity` for the full
+   * precedence and for why the accent colour and avatar are excluded.
+   *
+   * Absent → nothing is added and the prompt is byte-identical, which is what
+   * keeps every Agent that predates the Steckbrief exactly where it was.
+   */
+  readonly identityShortDescription?: string;
+  readonly identityLongDescription?: string;
+  /**
    * W5 memory-ACL — per-Agent rollout switch for chat-context-scoped memory.
    * Read from the `agents.context_memory` column (migration 0050).
    *
@@ -327,6 +341,123 @@ export function withAgentName(
 }
 
 /**
+ * Fold an Agent's authored SELF-DESCRIPTION into the identity text (#967
+ * follow-up) — the operator's "Steckbrief" tab: short and long description.
+ *
+ * THE PROBLEM THIS SOLVES. These two fields described the agent everywhere a
+ * human looked — the Teams store listing, the app package, the operator UI —
+ * and nowhere the agent could read. An operator who wrote "HR-Assistentin für
+ * Urlaub und Zeiterfassung" got a bot that rendered that sentence in a catalog
+ * and could not say it when asked what it does. The identity tabs are a promise
+ * that what you type is what the agent becomes; this is the half of that
+ * promise that was missing.
+ *
+ * APPENDED, NEVER SUBSTITUTED — same rule as {@link withAgentName}, and for a
+ * stronger reason here. `instructions` (via `composed_prompt`) REPLACES the
+ * platform identity outright, which is deliberate and stays (#914): it is the
+ * operator saying "this agent behaves like THIS instead". A description is not
+ * that. It says what the agent is, not how it works, so it can only ever be an
+ * addition — folding it into the replacing slot would let a one-line Steckbrief
+ * silently delete a deployment's whole configured behaviour.
+ *
+ * VERBATIM, UNDER A LABEL. The text is the operator's own; nothing is
+ * paraphrased, summarised or expanded. The labels exist because raw prose
+ * pasted after a system prompt reads as an instruction rather than as a fact
+ * about the agent — the label is framing, not content, and an unauthored field
+ * contributes no label and no line. Nothing is invented for an empty field.
+ *
+ * BOTH, WHEN BOTH ARE THERE. Short and long are not two drafts of one text —
+ * the Teams manifest caps them at 80 and 4000 characters precisely because they
+ * answer different questions ("what is this?" vs "what can it do?"). An agent
+ * asked either question should be able to answer it, so neither is dropped in
+ * favour of the other. Identical values are the operator's own repetition and
+ * are left alone rather than silently de-duplicated.
+ */
+export function withAgentSelfDescription(
+  identity: string | undefined,
+  descriptions: {
+    readonly shortDescription?: string | undefined;
+    readonly longDescription?: string | undefined;
+  },
+): string | undefined {
+  const short = descriptions.shortDescription?.trim();
+  const long = descriptions.longDescription?.trim();
+  const lines: string[] = [];
+  if (short) lines.push(`Kurzbeschreibung deiner Rolle: ${short}`);
+  if (long) lines.push(`Ausführliche Beschreibung deiner Rolle: ${long}`);
+  if (lines.length === 0) return identity;
+  const block = lines.join('\n\n');
+  const trimmedIdentity = identity?.trim();
+  return trimmedIdentity ? `${trimmedIdentity}\n\n${block}` : block;
+}
+
+/**
+ * The whole per-Agent identity layer, composed in ONE place so the precedence
+ * is stated once and cannot drift between callers (#914 / #967).
+ *
+ * THE ORDER IS THE CONTRACT:
+ *
+ *  1. BASE — the platform-wide `assistantIdentity`, REPLACED outright by the
+ *     Agent's own `identityInstructions` when it authored any. That value is
+ *     already `COALESCE(composed_prompt, instructions)`, so the Charakter
+ *     (persona axes) and Grenzen (boundary presets + sycophancy guard) tabs are
+ *     compiled into it upstream by `composeAgentIdentityPrompt` — they are NOT
+ *     unused columns, and nothing here needs to re-derive them. Replacing is
+ *     deliberate and unchanged: it is the operator saying "behave like this
+ *     instead of like the platform default".
+ *
+ *  2. APPENDED — the Steckbrief (short, then long description). Facts about the
+ *     agent, layered ON TOP of whichever text step 1 produced, because a
+ *     description must never be able to delete configured behaviour.
+ *
+ *  3. APPENDED LAST — the name. Last word deliberately: an operator's prose (or
+ *     the platform identity) may mention some other name, and the closing
+ *     instruction is the one that binds. This is why the name goes AFTER the
+ *     descriptions and not directly after the identity text — a long
+ *     description that names a predecessor bot must still lose to the name the
+ *     agent actually wears.
+ *
+ * CONFLICT RULE, in one sentence: later text wins over earlier text, and
+ * nothing appended can remove what step 1 established.
+ *
+ * DELIBERATELY EXCLUDED. `accent_color` and the avatar are rendering decisions
+ * — they exist so a human can tell two bots apart at a glance in Teams. A model
+ * cannot act on either, and describing them in a prompt ("deine Akzentfarbe ist
+ * #3B82F6") would spend tokens on a fact that can only produce noise, or worse,
+ * invite the agent to talk about its own styling. They stay presentation-only
+ * on purpose, not by oversight.
+ *
+ * An Agent that authored nothing gets the platform identity back byte for byte,
+ * which is what keeps every pre-#914 deployment (and its prompt-cache key)
+ * exactly where it was.
+ */
+export function withAgentIdentity(
+  baseIdentity: string | undefined,
+  authored: {
+    readonly identityInstructions?: string | undefined;
+    readonly identityName?: string | undefined;
+    readonly identityShortDescription?: string | undefined;
+    readonly identityLongDescription?: string | undefined;
+  },
+): string | undefined {
+  // Step 1 — replace. A blank authored value is not an identity, so it falls
+  // through rather than silencing the opening section of the system prompt.
+  const base = authored.identityInstructions?.trim() || baseIdentity;
+  // Steps 2 and 3 — append, descriptions before the name.
+  return withAgentName(
+    withAgentSelfDescription(base, {
+      ...(authored.identityShortDescription !== undefined
+        ? { shortDescription: authored.identityShortDescription }
+        : {}),
+      ...(authored.identityLongDescription !== undefined
+        ? { longDescription: authored.identityLongDescription }
+        : {}),
+    }),
+    authored.identityName,
+  );
+}
+
+/**
  * Build one Agent's `Orchestrator`, its optional verifier wrapper, and its
  * `chatAgent` bundle. Each call produces a fully independent instance set —
  * no mutable state is shared between two calls.
@@ -469,22 +600,25 @@ export function buildOrchestratorForAgent(
       console.warn(`[security-audit] ${JSON.stringify(event)}`);
     };
 
-  // #914 — per-Agent identity beats the platform default. A blank authored
-  // value is not an identity, so it falls through rather than silencing the
-  // opening section of the system prompt.
-  const agentAssistantIdentity =
-    config.identityInstructions?.trim() || deps.assistantIdentity;
-  // #967 — and then the Agent's own name is layered on top of whichever text
-  // that resolved to. This is the ONLY place the authored display name enters
-  // the system prompt, and it is deliberately the last word: the platform
-  // identity names the platform's assistant, so a bot provisioned as
-  // `Messias` would otherwise keep introducing itself with that name while
-  // Teams shows another. Overriding beats editing — we cannot know where a
-  // name appears inside operator-written prose.
-  const assistantIdentityWithName = withAgentName(
-    agentAssistantIdentity,
-    config.identityName,
-  );
+  // #914 / #967 — this Agent's authored identity, layered over the platform
+  // default. `withAgentIdentity` owns the whole precedence (replace, then
+  // append the Steckbrief, then append the name last); see its doc comment for
+  // why each field sits where it does and why the accent colour and avatar are
+  // deliberately not in it.
+  const assistantIdentityWithName = withAgentIdentity(deps.assistantIdentity, {
+    ...(config.identityInstructions !== undefined
+      ? { identityInstructions: config.identityInstructions }
+      : {}),
+    ...(config.identityName !== undefined
+      ? { identityName: config.identityName }
+      : {}),
+    ...(config.identityShortDescription !== undefined
+      ? { identityShortDescription: config.identityShortDescription }
+      : {}),
+    ...(config.identityLongDescription !== undefined
+      ? { identityLongDescription: config.identityLongDescription }
+      : {}),
+  });
 
   // domainTools is intentionally empty at construct — sub-agents self-register
   // post-activate via `dynamicAgentRuntime.attachOrchestrator(bundle.raw)`.
@@ -573,6 +707,16 @@ export function buildOrchestratorForAgent(
     // that same resolved value for the same reason.
     ...(assistantIdentityWithName
       ? { assistantIdentity: assistantIdentityWithName }
+      : {}),
+    // #967 — the SAME authored name, handed over separately as well. The
+    // prompt is not the only place an Agent states who it is: the Art. 50
+    // marking names the assistant too and is resolved behind the model, where
+    // the prompt is deliberately out of reach. Without this it had only the
+    // platform-wide `ai_disclosure_assistant_name` — one string for every
+    // Agent — so each provisioned bot signed its answers with whichever single
+    // name the operator had typed there.
+    ...(config.identityName?.trim()
+      ? { identityName: config.identityName.trim() }
       : {}),
     ...(deps.aiDisclosure ? { aiDisclosure: deps.aiDisclosure } : {}),
     ...(deps.aiDisclosureSeenStore

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -689,6 +689,24 @@ export interface OrchestratorOptions {
    */
   assistantIdentity?: string;
   /**
+   * #967 — this Agent's own authored name (`agent_identities.display_name`),
+   * already folded into {@link assistantIdentity} by `withAgentName`.
+   *
+   * Supplied SEPARATELY as well because the system prompt is not the only
+   * surface that states a name: the AI-Act Art. 50 marking names the assistant
+   * too, and it is deliberately resolved behind the model (see
+   * `resolveTurnDisclosure`) where the prompt is out of reach by design. Without
+   * this field that line has only the platform-wide
+   * `ai_disclosure_assistant_name` to go on — ONE operator-typed string for the
+   * whole deployment, which in a multi-agent deployment is right for at most
+   * one Agent and signs every other Agent's answers with a stranger's name.
+   *
+   * An override, not a replacement: absent (or blank) falls through to the
+   * operator's configured name, so a single-Agent deployment that set one is
+   * completely unaffected.
+   */
+  identityName?: string;
+  /**
    * Wave 8 — skills attached to this Agent as direct-answer persona
    * candidates. When non-empty, each turn runs a Haiku classifier
    * ({@link routeTurnPersona}) that picks at most one candidate whose `body`
@@ -1893,6 +1911,9 @@ export class Orchestrator {
   /** Operator persona — first line(s) of the system prompt. See
    *  `OrchestratorOptions.assistantIdentity` / `DEFAULT_ASSISTANT_IDENTITY`. */
   private readonly assistantIdentity: string;
+  /** #967 — this Agent's own authored name. See
+   *  `OrchestratorOptions.identityName`. */
+  private readonly identityName: string | undefined;
   /** #644 — resolved operator disclosure config (undefined → shipping default
    *  on every channel). See {@link AiDisclosureSetup}. */
   private readonly aiDisclosure: AiDisclosureSetup | undefined;
@@ -2008,6 +2029,7 @@ export class Orchestrator {
     this.graphTenantId = options.graphTenantId;
     this.assistantIdentity =
       options.assistantIdentity?.trim() || DEFAULT_ASSISTANT_IDENTITY;
+    this.identityName = options.identityName?.trim() || undefined;
     this.aiDisclosure = options.aiDisclosure;
     this.disclosureSeen =
       options.aiDisclosureSeenStore ?? new InMemoryDisclosureSeenStore();
@@ -3041,7 +3063,9 @@ export class Orchestrator {
       result,
       result.aiDisclosure
         ? {
-            ...(input.sessionScope ? { scope: input.sessionScope } : {}),
+            ...(input.sessionScope
+              ? { scope: this.disclosureFoldScope(input.sessionScope) }
+              : {}),
             seen: this.disclosureSeen,
           }
         : undefined,
@@ -3090,12 +3114,50 @@ export class Orchestrator {
       source,
       ...(setup?.locale ? { locale: setup.locale } : {}),
     };
+    // #967 — THIS Agent's authored name outranks the platform-wide
+    // `ai_disclosure_assistant_name`. The setup field is one string for the
+    // whole deployment, so with several provisioned bots alive it can be
+    // correct for at most one of them and makes every other bot sign its
+    // answers as that one. Same precedence the system prompt already uses
+    // (`config.identityInstructions || deps.assistantIdentity`), applied to
+    // the one other surface that states a name.
+    //
+    // Reading the Agent's OWN name here does not reopen the AC2 hole the
+    // doc-comment above guards: `identityName` is a single operator-authored
+    // name from `agent_identities`, not the prompt, so a branded persona still
+    // cannot reach in and suppress or reword the marking.
+    const assistantName = this.identityName ?? setup?.assistantName;
     return resolveAiDisclosure({
       policy,
       ...(setup?.locale ? { locale: setup.locale } : {}),
-      ...(setup?.assistantName ? { assistantName: setup.assistantName } : {}),
+      ...(assistantName ? { assistantName } : {}),
       ...(setup?.operatorNote ? { operatorNote: setup.operatorNote } : {}),
     });
+  }
+
+  /**
+   * #644 / #967 — the first-turn fold-dedup key for a conversation.
+   *
+   * Agent-QUALIFIED, because the store behind it is process-wide (one
+   * `InMemoryDisclosureSeenStore` in the shared `OrchestratorDeps`, deliberately
+   * so a rebuild does not re-mark an ongoing conversation) while a conversation
+   * scope is NOT exclusive to one Agent. Several provisioned bots share one
+   * Teams group chat — the deployment `identityForChannel` exists to serve — so
+   * on the raw scope the first bot to answer consumed the marking slot for
+   * every other bot in the room, and their answers went out unmarked.
+   *
+   * Same `<agentSlug>::<scope>` convention, and the same reasoning, as
+   * `graphScopeFor`, which agent-qualifies the KG scope built from this
+   * identical `sessionScope`; this was the one remaining consumer of it that
+   * still keyed on the raw value.
+   *
+   * A key change re-marks each live conversation once after the upgrade. That
+   * is the direction #644 asks for on any doubt ("an undeterminable scope folds
+   * rather than omits") — one repeated marking is a non-event, a missing one is
+   * the compliance gap.
+   */
+  private disclosureFoldScope(sessionScope: string | undefined): string | undefined {
+    return sessionScope === undefined ? undefined : `${this.agentId}::${sessionScope}`;
   }
 
   /**
@@ -3116,7 +3178,9 @@ export class Orchestrator {
     if (!aiDisclosure) return done;
     const { text } = applyAiDisclosure(done.answer, {
       disclosure: aiDisclosure,
-      ...(input.sessionScope ? { scope: input.sessionScope } : {}),
+      ...(input.sessionScope
+        ? { scope: this.disclosureFoldScope(input.sessionScope) }
+        : {}),
       seen: this.disclosureSeen,
     });
     return { ...done, answer: text, aiDisclosure };

--- a/middleware/packages/harness-orchestrator/src/registry/applyDiff.ts
+++ b/middleware/packages/harness-orchestrator/src/registry/applyDiff.ts
@@ -261,6 +261,15 @@ export function buildForAgent(
       ...(agent.identityName?.trim()
         ? { identityName: agent.identityName.trim() }
         : {}),
+      // #967 follow-up — the agent's authored Steckbrief. Layered on like the
+      // name (never replacing the behaviour text), so an operator who filled in
+      // what the agent IS gets a bot that can actually say it.
+      ...(agent.identityShortDescription?.trim()
+        ? { identityShortDescription: agent.identityShortDescription.trim() }
+        : {}),
+      ...(agent.identityLongDescription?.trim()
+        ? { identityLongDescription: agent.identityLongDescription.trim() }
+        : {}),
     },
     deps,
   );
@@ -310,6 +319,22 @@ function runtimeChangeReasons(oldAgent: AgentRow, newAgent: AgentRow): string[] 
   // keep hearing the old name in chat until some unrelated edit rebuilt it.
   if ((oldAgent.identityName ?? '') !== (newAgent.identityName ?? '')) {
     reasons.push('identity_display_name');
+  }
+  // #967 follow-up — the Steckbrief is part of the system prompt too, so the
+  // same rule applies as for the name: an edit the operator saved and the UI
+  // confirmed must reach the running Agent, or the agent page and the bot go on
+  // disagreeing until some unrelated change happens to rebuild it.
+  if (
+    (oldAgent.identityShortDescription ?? '') !==
+    (newAgent.identityShortDescription ?? '')
+  ) {
+    reasons.push('identity_short_description');
+  }
+  if (
+    (oldAgent.identityLongDescription ?? '') !==
+    (newAgent.identityLongDescription ?? '')
+  ) {
+    reasons.push('identity_long_description');
   }
   // `name` / `description` are display-only and never warrant a rebuild —
   // they would invalidate sessions for no semantic gain.

--- a/middleware/packages/harness-orchestrator/src/registry/configStore.ts
+++ b/middleware/packages/harness-orchestrator/src/registry/configStore.ts
@@ -88,6 +88,23 @@ export interface AgentRow {
    * verbatim, exactly as before this column was joined.
    */
   readonly identityName?: string | null;
+  /**
+   * #967 follow-up — the agent's authored SELF-DESCRIPTION
+   * (`agent_identities.short_description` / `.long_description`, the operator's
+   * "Steckbrief" tab), joined in beside {@link identityName} and read the same
+   * way: read-only here, written through `platform/agentIdentityStore.ts`.
+   *
+   * These reached the Teams app package and nothing else, so an operator who
+   * filled in what the agent IS got a store listing that said one thing and a
+   * bot that could not say it. They describe the agent rather than instruct it,
+   * which is why they are LAYERED onto the identity text rather than replacing
+   * it — see `withAgentSelfDescription`.
+   *
+   * `null`/absent means "not authored": nothing is added, and the prompt is
+   * byte-identical to one built before these were joined.
+   */
+  readonly identityShortDescription?: string | null;
+  readonly identityLongDescription?: string | null;
   readonly createdAt: Date;
   readonly updatedAt: Date;
 }
@@ -296,6 +313,11 @@ interface AgentDbRow {
   /** #967 — `agent_identities.display_name`, joined in by the same three read
    *  queries and absent on the same write paths as `identity_instructions`. */
   identity_display_name?: string | null;
+  /** #967 follow-up — `agent_identities.short_description` / `.long_description`,
+   *  joined in by the same three read queries and absent on the same write
+   *  paths as `identity_instructions`. */
+  identity_short_description?: string | null;
+  identity_long_description?: string | null;
   created_at: Date;
   updated_at: Date;
 }
@@ -347,6 +369,8 @@ function mapAgent(row: AgentDbRow): AgentRow {
     contextMemory: parseContextMemoryMode(row.context_memory),
     instructions: row.identity_instructions ?? null,
     identityName: row.identity_display_name ?? null,
+    identityShortDescription: row.identity_short_description ?? null,
+    identityLongDescription: row.identity_long_description ?? null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -394,12 +418,21 @@ function mapPlatformSettings(
  * compilers live in the middleware, which this package cannot import; that
  * is why the composition is stored rather than done here.
  *
+ * The two description columns (#967 follow-up) ride along because they are the
+ * other half of what the operator authored about this agent: `composed_prompt`
+ * says how it behaves, they say what it IS. Joining them here rather than in a
+ * per-Agent second query keeps the cost of a rebuild at one round trip.
+ *
  * Only text is joined. The identity's avatar columns are BYTEA and this query
- * runs on every dashboard load and every registry rebuild.
+ * runs on every dashboard load and every registry rebuild — and `accent_color`
+ * is left out for the same reason it never reaches a prompt: it is a rendering
+ * decision, not something an agent can act on.
  */
 const AGENT_SELECT =
   'SELECT a.*, COALESCE(i.composed_prompt, i.instructions) AS identity_instructions, ' +
-  'i.display_name AS identity_display_name ' +
+  'i.display_name AS identity_display_name, ' +
+  'i.short_description AS identity_short_description, ' +
+  'i.long_description AS identity_long_description ' +
   'FROM agents a LEFT JOIN agent_identities i ON i.agent_id = a.id';
 
 export class ConfigStore {

--- a/middleware/src/routes/operatorAgents.ts
+++ b/middleware/src/routes/operatorAgents.ts
@@ -1925,9 +1925,20 @@ export function createOperatorAgentsRouter(
       // reload exists to prevent for `instructions`.
       const nameChanged =
         (before?.displayName ?? '').trim() !== (body.display_name ?? '').trim();
+      // #967 follow-up — and the Steckbrief for exactly the same reason the
+      // name joined this list: both descriptions are part of the system prompt
+      // now (`AgentRow.identityShortDescription` / `…Long…`), so an edit that
+      // does not reload is an edit the agent never speaks. They used to be
+      // manifest-only, which is why they were not here before.
+      const descriptionChanged =
+        (before?.shortDescription ?? '').trim() !==
+          (body.short_description ?? '').trim() ||
+        (before?.longDescription ?? '').trim() !==
+          (body.long_description ?? '').trim();
       if (
         (before?.composed.text ?? null) !== (composed.text ?? null) ||
-        nameChanged
+        nameChanged ||
+        descriptionChanged
       ) {
         await live.registry.reload();
       }

--- a/middleware/test/buildForAgentIdentity.test.ts
+++ b/middleware/test/buildForAgentIdentity.test.ts
@@ -240,3 +240,159 @@ test('an unchanged name does not rebuild anything', () => {
 
   assert.deepEqual(plan.actions, []);
 });
+
+// ---------------------------------------------------------------------------
+// #967 follow-up — the authored SELF-DESCRIPTION (Steckbrief) reaching the prompt
+// ---------------------------------------------------------------------------
+
+/**
+ * `short_description` / `long_description` are what an operator writes to say
+ * what the agent IS. They reached the Teams app package, the store listing and
+ * the operator UI — and no prompt. An operator who filled in "HR-Assistentin
+ * für Urlaub und Zeiterfassung" got a catalog entry that said so and a bot that
+ * could not answer the question.
+ *
+ * These cases pin the LAYERING, which is the part that is easy to get wrong: a
+ * description must never be able to delete configured behaviour, and the name
+ * must still get the last word over it.
+ */
+
+test('an authored short description is layered onto the identity', () => {
+  const identity = String(
+    identityOf(
+      buildForAgent(
+        agentRow({ identityShortDescription: 'HR-Assistentin für byte5.' }),
+        deps(),
+        RUNTIME,
+      ),
+    ),
+  );
+
+  assert.match(identity, /You are the platform assistant\./);
+  assert.match(identity, /Kurzbeschreibung deiner Rolle: HR-Assistentin für byte5\./);
+});
+
+test('an authored long description is layered on too, and both can coexist', () => {
+  const identity = String(
+    identityOf(
+      buildForAgent(
+        agentRow({
+          identityShortDescription: 'HR-Assistentin.',
+          identityLongDescription: 'Beantwortet Fragen zu Urlaub und Zeiterfassung.',
+        }),
+        deps(),
+        RUNTIME,
+      ),
+    ),
+  );
+
+  // Neither is dropped in favour of the other: the Teams manifest caps them at
+  // 80 and 4000 characters precisely because they answer different questions.
+  assert.match(identity, /Kurzbeschreibung deiner Rolle: HR-Assistentin\./);
+  assert.match(
+    identity,
+    /Ausführliche Beschreibung deiner Rolle: Beantwortet Fragen zu Urlaub und Zeiterfassung\./,
+  );
+  assert.ok(
+    identity.indexOf('Kurzbeschreibung') < identity.indexOf('Ausführliche Beschreibung'),
+    'short before long — the summary reads first',
+  );
+});
+
+test('a description NEVER replaces the authored behaviour text', () => {
+  // The failure this guards: folding the Steckbrief into the same slot as
+  // `instructions` would let a one-line description silently delete a whole
+  // deployment's configured behaviour.
+  const identity = String(
+    identityOf(
+      buildForAgent(
+        agentRow({
+          instructions: 'You are the sales agent. Be brief.',
+          identityShortDescription: 'Vertriebsassistent.',
+        }),
+        deps(),
+        RUNTIME,
+      ),
+    ),
+  );
+
+  assert.match(identity, /You are the sales agent\. Be brief\./);
+  assert.match(identity, /Kurzbeschreibung deiner Rolle: Vertriebsassistent\./);
+});
+
+test('the name still gets the LAST word, after the descriptions', () => {
+  // A long description may well name a predecessor bot. The name the agent
+  // actually wears has to outrank it, and appending last is the only safe way
+  // to override a name buried in operator prose.
+  const identity = String(
+    identityOf(
+      buildForAgent(
+        agentRow({
+          identityName: 'Messias',
+          identityLongDescription: 'Löst Karen als HR-Assistenz ab.',
+        }),
+        deps(),
+        RUNTIME,
+      ),
+    ),
+  );
+
+  assert.ok(
+    identity.indexOf('Dein Name ist Messias') >
+      identity.indexOf('Ausführliche Beschreibung deiner Rolle'),
+    'the name line must come after the descriptions it overrides',
+  );
+});
+
+test('blank descriptions add nothing — the prompt stays byte-for-byte', () => {
+  // The no-change guarantee: every agent that predates the Steckbrief reaching
+  // the prompt must compile to the exact same text, down to the cache key.
+  assert.equal(
+    identityOf(
+      buildForAgent(
+        agentRow({ identityShortDescription: '   ', identityLongDescription: null }),
+        deps(),
+        RUNTIME,
+      ),
+    ),
+    PLATFORM_IDENTITY,
+    'whitespace is not a description',
+  );
+});
+
+test('editing a description rebuilds the agent', () => {
+  // Without this the operator edits the Steckbrief, sees it saved, and the bot
+  // keeps describing itself the old way until some unrelated change rebuilds
+  // it — the same silent no-op `identity_instructions` guards against.
+  const plan = diffSnapshots(
+    snapshot(agentRow({ identityShortDescription: 'Alt.' })),
+    snapshot(agentRow({ identityShortDescription: 'Neu.' })),
+  );
+
+  assert.equal(plan.actions.length, 1);
+  const action = plan.actions[0];
+  assert.equal(action?.kind, 'rebuild');
+  assert.match((action as { reason: string }).reason, /identity_short_description/);
+});
+
+test('editing the long description rebuilds the agent', () => {
+  const plan = diffSnapshots(
+    snapshot(agentRow({ identityLongDescription: 'Alt.' })),
+    snapshot(agentRow({ identityLongDescription: 'Neu.' })),
+  );
+
+  assert.equal(plan.actions.length, 1);
+  assert.match(
+    (plan.actions[0] as { reason: string }).reason,
+    /identity_long_description/,
+  );
+});
+
+test('unchanged descriptions do not rebuild anything', () => {
+  const plan = diffSnapshots(
+    snapshot(agentRow({ identityShortDescription: 'Gleich.' })),
+    snapshot(agentRow({ identityShortDescription: 'Gleich.' })),
+  );
+
+  assert.deepEqual(plan.actions, []);
+});

--- a/middleware/test/multiAgentIdentityName.test.ts
+++ b/middleware/test/multiAgentIdentityName.test.ts
@@ -1,0 +1,234 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import Anthropic from '@anthropic-ai/sdk';
+import { InMemoryDisclosureSeenStore } from '@omadia/channel-sdk';
+import { InMemoryNudgeRegistry } from '@omadia/plugin-api';
+import type { EntityRefBus, KnowledgeGraph, MemoryStore } from '@omadia/plugin-api';
+
+import type { OrchestratorDeps } from '../packages/harness-orchestrator/src/buildOrchestrator.js';
+import type { NativeToolRegistry } from '../packages/harness-orchestrator/src/nativeToolRegistry.js';
+import type { AgentRow } from '../packages/harness-orchestrator/src/registry/configStore.js';
+import { buildForAgent } from '../packages/harness-orchestrator/src/registry/applyDiff.js';
+
+/**
+ * #967 follow-up — the agent's name must be per AGENT, on every surface that
+ * states it, when SEVERAL agents are alive in one process.
+ *
+ * WHY A MULTI-AGENT FILE EXISTS AT ALL. Every existing guard around the
+ * authored name (`buildForAgentIdentity.test.ts`) builds exactly ONE agent.
+ * A single-agent test cannot fail on a value that is shared between agents —
+ * with one agent there is nothing to share it with — so an entire class of
+ * defect passes through a suite that looks thorough. Two provisioned Teams
+ * bots in one group chat is the deployment that makes the class visible, and
+ * it is the deployment the operator actually runs.
+ *
+ * Two surfaces state a name, and #967 only fixed the first:
+ *
+ *  1. the SYSTEM PROMPT — `withAgentName`, per agent, already correct;
+ *  2. the AI-Act Art. 50 DISCLOSURE LINE — resolved from the platform-wide
+ *     `ai_disclosure_assistant_name`, one string for every agent in the
+ *     deployment. Whatever the operator typed there, every bot claimed it.
+ *
+ * A third failure sits underneath both: the first-turn-per-scope fold-dedup
+ * is keyed on the raw conversation scope and backed by a PROCESS-WIDE store,
+ * so in a shared group chat only the bot that answers first ever discloses.
+ * Fixing (2) without that leaves the second bot silent, which looks exactly
+ * like the bug it was supposed to fix.
+ */
+
+const PLATFORM_IDENTITY = 'Du bist Willi, der Plattform-Assistent.';
+
+function fakeNativeToolRegistry(): NativeToolRegistry {
+  const names = new Set<string>();
+  return {
+    has: (name: string) => names.has(name),
+    register: (name: string) => {
+      names.add(name);
+      return () => names.delete(name);
+    },
+  } as unknown as NativeToolRegistry;
+}
+
+/**
+ * One deps object, reused for every agent in a test — deliberately, because
+ * that is what `OrchestratorRegistry` does (`this.deps` is built once at
+ * activate() and handed to every `buildForAgent` call). Handing each agent a
+ * private deps object would hide precisely the sharing under test.
+ */
+function sharedDeps(overrides: Partial<OrchestratorDeps> = {}): OrchestratorDeps {
+  return {
+    client: new Anthropic({ apiKey: 'test-key' }),
+    knowledgeGraph: {} as KnowledgeGraph,
+    memoryStore: {} as MemoryStore,
+    entityRefBus: {} as EntityRefBus,
+    nativeToolRegistry: fakeNativeToolRegistry(),
+    nudgeRegistry: new InMemoryNudgeRegistry(),
+    responseGuard: () => undefined,
+    privacyGuard: () => undefined,
+    assistantIdentity: PLATFORM_IDENTITY,
+    ...overrides,
+  } as unknown as OrchestratorDeps;
+}
+
+function agentRow(slug: string, id: string, identityName: string): AgentRow {
+  return {
+    id,
+    slug,
+    name: slug,
+    description: null,
+    privacyProfile: 'default',
+    status: 'enabled',
+    identityName,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  } as unknown as AgentRow;
+}
+
+const RUNTIME = { model: 'm', maxTokens: 100, maxToolIterations: 4 };
+
+const MESSIAS = agentRow('messias', '00000000-0000-0000-0000-0000000000b1', 'Messias');
+const HR = agentRow('hr', '00000000-0000-0000-0000-0000000000a1', 'Karen');
+
+type Built = ReturnType<typeof buildForAgent>;
+
+/** The Orchestrator's private identity slot — same structural-cast convention
+ *  as `buildForAgentIdentity.test.ts`. */
+function identityOf(built: Built): string {
+  return String(
+    (built.orchestrator as unknown as { assistantIdentity?: unknown }).assistantIdentity,
+  );
+}
+
+/**
+ * Fold this turn's disclosure through the real streaming output path.
+ * `discloseDoneEvent` is the whole mechanism — resolve the marker, consult the
+ * shared seen-store, fold the line — and it reaches none of the provider, so a
+ * structural call exercises production behaviour without a wire mock.
+ */
+function discloseAnswer(built: Built, sessionScope: string): string {
+  const orchestrator = built.orchestrator as unknown as {
+    discloseDoneEvent: (
+      done: { type: 'done'; answer: string },
+      input: { sessionScope: string; userMessage: string },
+    ) => { answer: string };
+  };
+  return orchestrator.discloseDoneEvent(
+    { type: 'done', answer: 'Guten Morgen!' },
+    { sessionScope, userMessage: 'Wie heißt du?' },
+  ).answer;
+}
+
+// ---------------------------------------------------------------------------
+// The system prompt
+// ---------------------------------------------------------------------------
+
+test('two agents built in one process each get their OWN name in the system prompt', () => {
+  const deps = sharedDeps();
+  // Built in registry order (`ORDER BY a.slug` → hr before messias), so a
+  // last-build-wins defect would show as "Messias" everywhere rather than as a
+  // draw. Asserting BOTH directions is what makes the order irrelevant.
+  const hr = buildForAgent(HR, deps, RUNTIME);
+  const messias = buildForAgent(MESSIAS, deps, RUNTIME);
+
+  assert.match(identityOf(hr), /Dein Name ist Karen\./);
+  assert.doesNotMatch(
+    identityOf(hr),
+    /Messias/,
+    'one agent must never carry another agent’s name',
+  );
+  assert.match(identityOf(messias), /Dein Name ist Messias\./);
+  assert.doesNotMatch(identityOf(messias), /Karen/);
+});
+
+test('rebuilding one agent does not rewrite the other agent’s name', () => {
+  // A rename is a rebuild (`identity_display_name`), and a rebuild reuses the
+  // same shared deps. An agent that is merely a bystander to someone else's
+  // rename must come out of it saying exactly what it said before.
+  const deps = sharedDeps();
+  const messias = buildForAgent(MESSIAS, deps, RUNTIME);
+  buildForAgent(agentRow('hr', HR.id, 'Karin'), deps, RUNTIME);
+
+  assert.match(identityOf(messias), /Dein Name ist Messias\./);
+  assert.doesNotMatch(identityOf(messias), /Kar(en|in)/);
+});
+
+// ---------------------------------------------------------------------------
+// The Art. 50 disclosure line
+// ---------------------------------------------------------------------------
+
+test('two agents disclose under their OWN name, not the platform-wide one', () => {
+  // `ai_disclosure_assistant_name` is ONE operator-typed string for the whole
+  // deployment. In a multi-agent deployment it can be right for at most one
+  // agent, so every other bot signed its answers with a stranger's name.
+  const deps = sharedDeps({
+    aiDisclosure: { level: 'standard', assistantName: 'Karen' },
+    aiDisclosureSeenStore: new InMemoryDisclosureSeenStore(),
+  } as Partial<OrchestratorDeps>);
+  const hr = buildForAgent(HR, deps, RUNTIME);
+  const messias = buildForAgent(MESSIAS, deps, RUNTIME);
+
+  assert.match(discloseAnswer(hr, 'teams:chat-a'), /von Karen, einem KI-System/);
+  assert.match(
+    discloseAnswer(messias, 'teams:chat-b'),
+    /von Messias, einem KI-System/,
+    'the agent’s authored name outranks the platform-wide disclosure name',
+  );
+});
+
+test('the platform-wide disclosure name still serves an agent that authored none', () => {
+  // The per-agent name is an OVERRIDE, not a replacement of the setup field:
+  // a deployment that configured one name and never authored per-agent ones
+  // must behave exactly as it did before.
+  const deps = sharedDeps({
+    aiDisclosure: { level: 'standard', assistantName: 'Willi' },
+    aiDisclosureSeenStore: new InMemoryDisclosureSeenStore(),
+  } as Partial<OrchestratorDeps>);
+  const unnamed = buildForAgent(
+    { ...HR, identityName: null } as unknown as AgentRow,
+    deps,
+    RUNTIME,
+  );
+
+  assert.match(discloseAnswer(unnamed, 'teams:chat-c'), /von Willi, einem KI-System/);
+});
+
+test('two agents in ONE group chat each fold their own disclosure', () => {
+  // The failure this pins: the fold-dedup store is process-wide and was keyed
+  // on the raw conversation scope, so the first bot to answer in a shared
+  // Teams group chat consumed the marking slot for every OTHER bot in it. The
+  // second bot then shipped an unmarked answer — an Art. 50 gap, and one that
+  // also hid the per-agent name the test above establishes.
+  const deps = sharedDeps({
+    aiDisclosure: { level: 'standard' },
+    aiDisclosureSeenStore: new InMemoryDisclosureSeenStore(),
+  } as Partial<OrchestratorDeps>);
+  const hr = buildForAgent(HR, deps, RUNTIME);
+  const messias = buildForAgent(MESSIAS, deps, RUNTIME);
+  const groupChat = 'teams:19:meeting@thread.v2';
+
+  assert.match(discloseAnswer(hr, groupChat), /KI-System/);
+  assert.match(
+    discloseAnswer(messias, groupChat),
+    /KI-System/,
+    'a second bot in the same chat must still mark its own first answer',
+  );
+});
+
+test('the fold-dedup still suppresses the SAME agent’s repeat in a chat', () => {
+  // Agent-qualifying the key must not turn the dedup off: the whole point of
+  // the store is that one agent marks a conversation once, not every turn.
+  const deps = sharedDeps({
+    aiDisclosure: { level: 'standard' },
+    aiDisclosureSeenStore: new InMemoryDisclosureSeenStore(),
+  } as Partial<OrchestratorDeps>);
+  const messias = buildForAgent(MESSIAS, deps, RUNTIME);
+  const groupChat = 'teams:19:meeting@thread.v2';
+
+  assert.match(discloseAnswer(messias, groupChat), /KI-System/);
+  assert.doesNotMatch(
+    discloseAnswer(messias, groupChat),
+    /KI-System/,
+    'the same agent must not re-mark a conversation it already marked',
+  );
+});


### PR DESCRIPTION
Two Teams bots routed to two different agents introduced themselves with the **same name**. Both said "Karen" — including the one whose identity reads "Messias".

## The prompt was never shared

The obvious suspicion — one composed identity built once and overwritten by whichever agent is built last — is wrong. Building both agents in one process through the real registry path yields:

```
HR      -> "…\n\nDein Name ist Karen. …"
MESSIAS -> "…\n\nDein Name ist Messias. …"
```

The ordering argument does not hold either: `AGENT_SELECT` sorts by slug, so `fallback → hr → messias`, and a last-write-wins would have produced "Messias" everywhere, not "Karen". A sweep of the orchestrator package confirms it independently — `deps` is never mutated, every wrapper is built per call from `config.agentId`.

## The shared name was in the AI disclosure

`resolveTurnDisclosure` took the name exclusively from `ai_disclosure_assistant_name` — an operator string that applies to the whole installation, never from the agent's identity. Reproduced as a red test:

```
'Guten Morgen!\n\nDiese Antwort wurde von Karen, einem KI-System, erzeugt.'
```

That is `messias` saying "Karen".

**A second defect of the same shape sat underneath.** Disclosure de-duplication runs through a process-wide store keyed on the raw conversation scope. Several bots share a group chat by design, so the first one to answer consumed the disclosure slot for all the others — **their replies went out unlabelled.** Beyond the naming bug that is a compliance problem, and without fixing it the name fix would have been invisible on the second bot anyway.

**Where this stops short, stated plainly:** the observed replies read "Ich bin Karen, dein KI-Assistent" — not the disclosure sentence verbatim. This proves that `messias` says "Karen" and why; it does **not** prove that this path produced those two particular sentences. If "Ich bin Karen" survives the deploy, the next trace is the Teams channel plugin, not this repo.

## The whole Steckbrief now reaches the prompt

| # | Field | Mode | Why |
|---|---|---|---|
| 1 | `composed_prompt` ⟵ `instructions` + `persona` + `quality` | **replaces** the platform identity | the operator is saying "behave like this *instead*" (#914, unchanged) |
| 2 | `short_description` | appended | a fact about the agent; must never delete behaviour |
| 3 | `long_description` | appended | same |
| 4 | `display_name` | appended **last** | the last word binds — it beats any name buried in prose |

The conflict rule in one sentence: later text beats earlier, and nothing appended can remove stage 1. The name sits *after* the descriptions on purpose — a long description mentioning a predecessor bot has to lose.

**Deliberately excluded:** accent colour and avatar. Those are presentation choices so a human can tell two bots apart in Teams. A model cannot derive anything from them, and describing them either produces noise or invites the agent to discuss its own styling.

`persona` and `quality` were never dead: `composeAgentIdentityPrompt` compiles them into `composed_prompt` on save, and the registry join prefers it. Only the two descriptions were unused.

The reload gate now includes the descriptions — a field that shapes the prompt has to trigger a rebuild, otherwise an operator edits something that takes effect at the next unrelated change.

## Verification

`npm run build` before every typecheck. middleware: build, typecheck, `typecheck:test` (ratchet 370, no regressions) and lint clean; **8186 tests, 8170 pass, 0 fail**. web-ui: 1137 pass, typecheck, lint and `i18n:check` (4369 keys) clean.

Both fixes are load-bearing: neutralising the name precedence turns 1 test red, neutralising the description layer turns 3 red. The first neutralisation attempt passed because of a mis-indentation — caught and redone, since a green neutralisation is a worthless proof.

## Found in the sweep, not touched here

Three defects of the same class, unrelated to naming: `agents.context_memory` is parsed and never forwarded (every agent effectively runs `off`), `privacyProfile` triggers a rebuild but never reaches the orchestrator, and nudge state is keyed on the literal string `'orchestrator'` for all agents. The first two are silent no-ops in operator switches and deserve their own issue.

Refs #860.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/975"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790831156&installation_model_id=428086&pr_number=975&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F975&signature=d9d8d52c577a62a3c8b1c540c8863e2275af3b15aad79095646fbcdad7b8fac8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->