### PR TITLE
fix: tell the model an upload's privacy facts instead of letting it guess

### DIFF
--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -7388,7 +7388,7 @@ export class Orchestrator {
             attachmentFileName,
           );
           if (!result.ok) continue;
-          // #975 — the honest counterpart to `[dataset-imported]`'s privacy
+          // #976 — the honest counterpart to `[dataset-imported]`'s privacy
           // fact. This IS the inlined-text path (PDF/DOCX/TXT/MD have no
           // structured equivalent), so say so rather than letting the model
           // invent either a reassurance or an alarm. Whether the prompt-mask
@@ -7510,7 +7510,7 @@ export class Orchestrator {
         `scannedCells=${String(scannedCells)} maskedCells=${String(maskedCells)}`,
     );
 
-    // #975 — state the privacy FACTS for this file in the prompt.
+    // #976 — state the privacy FACTS for this file in the prompt.
     //
     // Without them the model is left to guess what happened to an upload,
     // and it guesses badly: it told a user "der Privacy Shield greift bei

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -1413,6 +1413,14 @@ a) **Jede Datenantwort (Tabelle, Liste, Ranking, Einzelwert) endet zwingend mit 
 
 b) **Behaupte NIEMALS, Daten seien „gefiltert", „maskiert" oder „aus Datenschutzgründen nicht verfügbar".** Kein „⚠️ Datenschutzfilter aktiv", kein „wende dich an einen Administrator". Du siehst \`[masked]\` — der User bekommt den echten Wert. Erfinde maskierte Werte niemals selbst.
 
+b2) **Aussagen über den Schutz-STATUS von Daten sind Tatsachenbehauptungen — nur belegte sind erlaubt.** Du weißt über den Datenschutz-Status einer Datei oder eines Tool-Ergebnisses **ausschließlich** das, was in einem \`PRIVACY STATUS\`-Satz, einem \`[dataset-imported]\`-, \`[attachment-content]\`- oder \`[attachment-not-ingested]\`-Block oder im Digest steht. Gib genau das wieder — wörtlich, nicht ausgeschmückt.
+
+   **Verboten**, weil du es nicht wissen kannst: „der Privacy Shield greift hier nicht", „der Inhalt liegt im Klartext vor", „die Daten wurden anonymisiert", „das ist DSGVO-konform", „bei Datei-Uploads gibt es keinen Schutz" — und jede andere Aussage darüber, was das System mit den Daten getan oder nicht getan hat, die nicht wörtlich in einem der genannten Blöcke steht.
+
+   Ein **falscher Alarm ist schlimmer als gar kein Hinweis**: der User handelt danach. Steht kein \`PRIVACY STATUS\` dabei, sag „dazu liegt mir keine Angabe vor" oder schweig zum Thema — rate nicht, und leite nichts aus früheren Gesprächen, Transkripten oder deinem Allgemeinwissen ab. Das Verhalten des Systems ändert sich mit Releases; ein Transkript von letzter Woche ist **kein** Beleg für heute.
+
+   Ungefragte Datenschutz-Hinweise („⚠️ Datenschutz-Hinweis", „DSGVO-Rechtsgrundlage beachten") gehören nicht in deine Antwort, außer der User fragt danach oder ein Block sagt dir ausdrücklich, dass etwas nicht verarbeitet wurde.
+
 c) **Join-Back-Rezept für Rankings/Aggregate mit Namen:** \`v4_aggregate\`/\`v4_group\`/\`v4_join\` arbeiten nur über **safe (nicht-maskierte)** Schlüssel — Gruppieren nach einem maskierten Namen ist nicht möglich, ein Aggregat verliert daher die Namens-Spalte. Um sie zurückzuholen:
    1. Hole **beide** Datasets: die Transaktionsdaten (z.B. Urlaubsanträge) UND das Stammdaten-Directory (z.B. Mitarbeiterliste mit \`employee_id\` + Name) — das sind in der Regel zwei Fach-Agent-Aufrufe.
    2. \`v4_aggregate\` die Transaktionen über den safe Schlüssel (z.B. \`employee_id\`).
@@ -7316,8 +7324,21 @@ export class Orchestrator {
             attachmentFileName,
           );
           if (!result.ok) continue;
+          // #975 — the honest counterpart to `[dataset-imported]`'s privacy
+          // fact. This IS the inlined-text path (PDF/DOCX/TXT/MD have no
+          // structured equivalent), so say so rather than letting the model
+          // invent either a reassurance or an alarm. Whether the prompt-mask
+          // layer additionally redacted spans here depends on the operator's
+          // `mask_user_prompt` setting, which this code cannot observe — so
+          // it claims nothing about it.
           textBlocks.push(
-            `\n\n[attachment-content: ${label}]\n${result.text}\n[/attachment-content]`,
+            `\n\n[attachment-content: ${label}]\n${result.text}\n` +
+              `PRIVACY STATUS OF THIS FILE (state only this, never speculate): this is ` +
+              `extracted document text placed directly into the prompt. It did NOT go ` +
+              `through the dataset store's per-field PII scan — that path exists only for ` +
+              `tabular files (CSV/XLSX). Say this plainly if asked; do not claim a ` +
+              `protection that is not listed here, and do not claim the file was withheld.` +
+              `\n[/attachment-content]`,
           );
         } catch (err) {
           console.warn(
@@ -7400,6 +7421,8 @@ export class Orchestrator {
     }
     if (!imported.ok) return refuse(imported.reason);
 
+    let scannedCells = 0;
+    let maskedCells = 0;
     const lines = imported.imported.map((t) => {
       const { truncatedCellCount, truncatedColumns } = t.truncation;
       // Only claim "not truncated" when that is actually true for this table
@@ -7409,11 +7432,39 @@ export class Orchestrator {
           ? ` ${String(truncatedCellCount)} cell(s) in column(s) [${truncatedColumns.join(', ')}] exceeded the per-cell length cap and were truncated on import.`
           : ' No cells were truncated on import.';
       const sheet = t.sheetName ? ` sheet='${t.sheetName}'` : '';
+      scannedCells += t.privacyScan.scannedCells;
+      maskedCells += t.privacyScan.maskedCells;
       return `dataset_id=${t.result.datasetId}, rows=${String(t.result.rowCount)}${sheet}.${truncationNote}`;
     });
 
+    // Observability: a successful import used to log nothing at all, so the
+    // only way to confirm one had happened was to infer it from a later
+    // `query_dataset` call's column names. Say it plainly instead.
+    console.log(
+      `[harness-orchestrator] ingestAttachments: ${format} imported ${label} — ` +
+        `datasets=${String(imported.imported.length)} ` +
+        `scannedCells=${String(scannedCells)} maskedCells=${String(maskedCells)}`,
+    );
+
+    // #975 — state the privacy FACTS for this file in the prompt.
+    //
+    // Without them the model is left to guess what happened to an upload,
+    // and it guesses badly: it told a user "der Privacy Shield greift bei
+    // Datei-Uploads nicht — der Inhalt liegt im Klartext vor" about a file
+    // that had in fact been imported with 16 of 23 fields masked. A wrong
+    // reassurance is bad; a wrong ALARM is worse, because the user acts on
+    // it. Neither a prompt rule nor a disclaimer fixes a model that lacks
+    // the fact — so ship the fact.
+    const privacyFact =
+      `PRIVACY STATUS OF THIS FILE (state only this, never speculate): its rows were ` +
+      `imported into the privacy-scanned dataset store, NOT inlined into this prompt. ` +
+      `Every string cell passed the PII scan (${String(scannedCells)} cell(s) scanned, ` +
+      `${String(maskedCells)} masked). You do not have this file's raw contents; ` +
+      `\`${QUERY_DATASET_TOOL_NAME}\` returns values under the same Privacy Shield ` +
+      `boundary as any other tool result.`;
+
     return (
-      `\n\n[dataset-imported: ${label}]\n${lines.join('\n')}\n` +
+      `\n\n[dataset-imported: ${label}]\n${lines.join('\n')}\n${privacyFact}\n` +
       `Use the \`${QUERY_DATASET_TOOL_NAME}\` tool with a dataset_id above to filter/aggregate this data — ` +
       `do not ask the user to re-paste it.\n[/dataset-imported]`
     );

--- a/middleware/packages/harness-plugin-privacy-guard/src/c1Detector.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/c1Detector.ts
@@ -46,7 +46,25 @@ export interface C1HttpDetectorOptions {
   readonly threshold?: number;
 }
 
-const DEFAULT_TIMEOUT_MS = 1500;
+/**
+ * Hard cap per detect() call.
+ *
+ * 1500 ms was calibrated against a short chat message and silently starved
+ * every realistic turn: GLiNER inference is chunked and scales with text
+ * length, so measured against the live sidecar a 46-character sentence takes
+ * 69-133 ms while a 3.4 KB prompt (one modest attachment) takes 3.7-3.8 s.
+ * Everything above the cap logged `promptMaskDegraded` and fell back to
+ * C0 — meaning person names, the whole reason the C1 tier exists, went
+ * unmasked on exactly the turns that carried the most of them. It went
+ * unnoticed because the sidecar was unreachable anyway until #973/#974.
+ *
+ * 15 s covers the `MAX_TEXT_CHARS` (20 KB) ceiling with headroom at the
+ * measured ~1.1 ms/char. It is a fail-CLOSED bound, not a latency budget:
+ * exceeding it degrades to C0 rather than blocking, so a generous value
+ * costs a slow turn in the worst case and buys correct masking in the
+ * normal one. Override with `PRIVACY_C1_TIMEOUT_MS`.
+ */
+export const DEFAULT_TIMEOUT_MS = 15_000;
 const DEFAULT_LABELS: readonly string[] = ['person', 'address'];
 const DEFAULT_THRESHOLD = 0.5;
 
@@ -62,10 +80,28 @@ interface SidecarSpan {
   readonly score: number;
 }
 
+/** `PRIVACY_C1_TIMEOUT_MS` override. Ignores anything not a positive finite
+ *  number so a typo cannot silently produce a 0 ms (always-degrade) cap. */
+export function resolveTimeoutFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): number | undefined {
+  const raw = env['PRIVACY_C1_TIMEOUT_MS']?.trim();
+  if (raw === undefined || raw === '') return undefined;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    console.warn(
+      `[privacy-guard v4] ignoring invalid PRIVACY_C1_TIMEOUT_MS=${raw}; ` +
+        `using ${String(DEFAULT_TIMEOUT_MS)}ms`,
+    );
+    return undefined;
+  }
+  return parsed;
+}
+
 export function createC1HttpDetector(
   opts: C1HttpDetectorOptions,
 ): PromptPiiDetector {
-  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const timeoutMs = opts.timeoutMs ?? resolveTimeoutFromEnv() ?? DEFAULT_TIMEOUT_MS;
   const fetchFn = opts.fetchFn ?? globalThis.fetch;
   const labels = opts.labels ?? DEFAULT_LABELS;
   const threshold = opts.threshold ?? DEFAULT_THRESHOLD;

--- a/middleware/test/orchestratorCsvDatasetIdentity.test.ts
+++ b/middleware/test/orchestratorCsvDatasetIdentity.test.ts
@@ -138,6 +138,44 @@ describe('#430 fixup — CSV dataset-import ACL identity resolution', () => {
     assert.equal(owned.length, 1);
   });
 
+  /**
+   * #975 — the model must be TOLD what happened to an upload, not left to
+   * guess. Asked whether a file was protected, it told a user "der Privacy
+   * Shield greift bei Datei-Uploads nicht — der Inhalt liegt im Klartext
+   * vor" about a file that had in fact been imported with most fields
+   * masked. A wrong reassurance is bad; a wrong ALARM is worse, because the
+   * user acts on it. No prompt rule fixes a model that lacks the fact.
+   */
+  it('states the privacy facts of a successful import in the prompt', async () => {
+    const requests: LlmRequest[] = [];
+    const graph = new InMemoryKnowledgeGraph();
+    const orch = new Orchestrator(options(requests, graph));
+
+    await orch.runTurn({
+      userMessage: CSV_MANIFEST,
+      sessionScope: 'sess-1',
+      userId: 'a1b2c3d4-0000-0000-0000-000000000002',
+    });
+
+    const wire = JSON.stringify(requests);
+    assert.ok(wire.includes('[dataset-imported:'), 'import block missing');
+    assert.ok(
+      wire.includes('PRIVACY STATUS OF THIS FILE'),
+      'the prompt must carry the privacy facts, not leave them to the model',
+    );
+    assert.ok(
+      wire.includes('never speculate'),
+      'the block must forbid speculation explicitly',
+    );
+    assert.ok(
+      wire.includes('NOT inlined into this prompt'),
+      'the block must state that rows did not reach the prompt as text',
+    );
+    // And the raw rows genuinely are absent.
+    assert.equal(wire.includes('Ada'), false);
+    assert.equal(wire.includes('Grace'), false);
+  });
+
   it('refuses the file WITHOUT leaking its rows as plain text when the uploading user cannot be resolved', async () => {
     const requests: LlmRequest[] = [];
     const graph = new InMemoryKnowledgeGraph();

--- a/middleware/test/orchestratorCsvDatasetIdentity.test.ts
+++ b/middleware/test/orchestratorCsvDatasetIdentity.test.ts
@@ -139,7 +139,7 @@ describe('#430 fixup — CSV dataset-import ACL identity resolution', () => {
   });
 
   /**
-   * #975 — the model must be TOLD what happened to an upload, not left to
+   * #976 — the model must be TOLD what happened to an upload, not left to
    * guess. Asked whether a file was protected, it told a user "der Privacy
    * Shield greift bei Datei-Uploads nicht — der Inhalt liegt im Klartext
    * vor" about a file that had in fact been imported with most fields

--- a/middleware/test/privacyPromptC1Detector.test.ts
+++ b/middleware/test/privacyPromptC1Detector.test.ts
@@ -24,6 +24,8 @@ import type { PromptPiiSpan } from '@omadia/plugin-api';
 import {
   C1_DETECTOR_ID,
   createC1HttpDetector,
+  DEFAULT_TIMEOUT_MS as DEFAULT_C1_TIMEOUT_MS,
+  resolveTimeoutFromEnv,
 } from '@omadia/plugin-privacy-guard/dist/c1Detector.js';
 import { createPrivacyGuardService } from '@omadia/plugin-privacy-guard/dist/index.js';
 import { findIdentityLeaks } from '@omadia/plugin-privacy-guard/dist/v4/onTheWire.js';
@@ -346,5 +348,61 @@ describe('createC1HttpDetector × createPrivacyGuardService', () => {
       `We should pay ${surrogate} more.`,
     );
     assert.equal(restored, 'We should pay Anna Schmidt more.');
+  });
+});
+
+describe('C1 detect timeout budget', () => {
+  /**
+   * #975 — the 1500 ms default starved every realistic turn. Measured
+   * against the live sidecar: a 46-char sentence takes 69-133 ms, a 3.4 KB
+   * prompt (one modest attachment) takes 3.7-3.8 s. Everything over the cap
+   * logged `promptMaskDegraded` and fell back to C0, so person names went
+   * unmasked on exactly the turns carrying the most of them.
+   */
+  it('defaults well above the measured cost of a realistic prompt', () => {
+    // A 3.4 KB prompt measured 3.8 s; the default must clear it with room.
+    assert.ok(
+      DEFAULT_C1_TIMEOUT_MS >= 10_000,
+      `default ${String(DEFAULT_C1_TIMEOUT_MS)}ms is too tight for a multi-KB prompt`,
+    );
+  });
+
+  it('honours a valid PRIVACY_C1_TIMEOUT_MS override', () => {
+    assert.equal(resolveTimeoutFromEnv({ PRIVACY_C1_TIMEOUT_MS: '2500' }), 2500);
+  });
+
+  it('ignores an unset or blank override', () => {
+    assert.equal(resolveTimeoutFromEnv({}), undefined);
+    assert.equal(resolveTimeoutFromEnv({ PRIVACY_C1_TIMEOUT_MS: '   ' }), undefined);
+  });
+
+  it('ignores a malformed override rather than degrading every turn', () => {
+    // A 0 or negative cap would make detect() abort instantly, i.e. silently
+    // turn C1 off for the whole install. Fall back to the default instead.
+    for (const bad of ['0', '-1', 'abc', 'NaN', 'Infinity']) {
+      assert.equal(
+        resolveTimeoutFromEnv({ PRIVACY_C1_TIMEOUT_MS: bad }),
+        undefined,
+        `expected ${bad} to be rejected`,
+      );
+    }
+  });
+
+  it('actually applies the configured timeout to a hanging sidecar', async () => {
+    const detector = createC1HttpDetector({
+      resolveUrl: () => 'http://sidecar.invalid:8812',
+      timeoutMs: 40,
+      fetchFn: (async (_url: string, init?: { signal?: AbortSignal }) =>
+        await new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () =>
+            reject(new Error('aborted')),
+          );
+          // never settles on its own
+        })) as unknown as typeof fetch,
+    });
+    await assert.rejects(
+      () => detector.detect('Anna Schmidt wohnt in Berlin.'),
+      /timed out after 40ms/,
+    );
   });
 });

--- a/middleware/test/privacyPromptC1Detector.test.ts
+++ b/middleware/test/privacyPromptC1Detector.test.ts
@@ -353,7 +353,7 @@ describe('createC1HttpDetector × createPrivacyGuardService', () => {
 
 describe('C1 detect timeout budget', () => {
   /**
-   * #975 — the 1500 ms default starved every realistic turn. Measured
+   * #976 — the 1500 ms default starved every realistic turn. Measured
    * against the live sidecar: a 46-char sentence takes 69-133 ms, a 3.4 KB
    * prompt (one modest attachment) takes 3.7-3.8 s. Everything over the cap
    * logged `promptMaskDegraded` and fell back to C0, so person names went


### PR DESCRIPTION
## What the agent told a user

> "Die Datei enthält **personenbezogene Daten** (Namen, E-Mail-Adressen, Profil-URLs von 48 Personen). Da sie als **Datei-Upload** kam, greift der Privacy Shield hier **nicht automatisch** — der Inhalt liegt im Klartext vor."

The logs for that same turn:

```
[teams-attachments] stored name=ki-events-kontakte.xlsx bytes=26300
[privacy-guard v4] intern tool=query_dataset ds_72049492 rows=3 fields=23 masked=16
[privacy-guard v4] pii-classifier: fields=23
    pii=[Name, Email, Member ID, URL of Member Profile, ...]
```

The `.xlsx` went through the dataset store with **16 of 23 fields masked**. The model never held the raw rows. It invented a claim about its own plumbing and dressed it as a DSGVO warning.

A wrong reassurance is bad. A wrong **alarm** is worse: the user acts on it, and a privacy tool that cries wolf teaches people to ignore it.

## Why a rule alone would not have helped

The prompt **already** forbade claiming data was "filtered" or "unavailable for privacy reasons" (rule b). The model broke that rule anyway, because the missing piece was not a rule — it was a **fact**. Nothing in the turn told it what had happened to the file, so it filled the gap from stale context: a session transcript from **31.08.**, a day when "no protection for uploads" was still the correct answer, before #971 landed.

## Three parts

**1. Ship the fact.** `[dataset-imported]` now carries a `PRIVACY STATUS` line: rows went to the privacy-scanned dataset store rather than into the prompt, with the real scanned/masked cell counts from the import.

`[attachment-content]` — the PDF/DOCX/TXT path that genuinely *does* inline text — states the honest opposite. It deliberately claims **nothing** about the prompt-mask layer, because whether `mask_user_prompt` is on is an operator setting this code cannot observe. Better silent than wrong in either direction.

**2. Forbid the invention.** New prompt rule **b2**: statements about protection *status* are factual claims, admissible only from a `PRIVACY STATUS` line or an attachment/digest block. Named and banned by example: *"der Privacy Shield greift hier nicht"*, *"der Inhalt liegt im Klartext vor"*, *"die Daten wurden anonymisiert"*. With no such line: say "dazu liegt mir keine Angabe vor" or stay silent — and never infer from earlier transcripts, because **system behaviour changes with releases; last week's transcript is not evidence about today.**

**3. Log the success.** A successful import logged nothing at all. Confirming that yours had worked meant inferring it from a later `query_dataset` call's column names — which is how this investigation actually had to proceed.

## Also: the C1 timeout (same investigation)

The logs showed `promptMaskDegraded detector=c1-gliner: C1 sidecar timed out after 1500ms`, repeatedly. Measured against the live sidecar:

| Text | Duration | vs. 1500 ms cap |
|---|---|---|
| 46 chars (the smoke test that "proved" C1 worked) | 69–133 ms | ✅ |
| 3.4 KB (one modest attachment) | **3692–3805 ms** | ❌ |

1500 ms was calibrated on a short chat message. GLiNER inference is chunked and scales with length, so every realistic turn degraded to C0 — person names went unmasked on exactly the turns carrying the most of them. It was invisible until now because the sidecar was unreachable at all until #973/#974.

Now **15 s**, which clears the 20 KB `MAX_TEXT_CHARS` ceiling at the measured ~1.1 ms/char. This is a fail-*closed* bound, not a latency budget: exceeding it degrades to C0 rather than blocking, so a generous value costs a slow turn at worst and buys correct masking normally. Overridable via `PRIVACY_C1_TIMEOUT_MS`; a malformed value (`0`, `-1`, `abc`) is rejected with a warning rather than silently disabling C1 install-wide.

## Test plan

- [x] `npm test` (middleware) — **8178 tests, 0 fail**, 16 pre-existing skips
- [x] New: import block states the facts, forbids speculation, and the raw rows are verifiably absent from the wire
- [x] New: timeout default sanity, env override, malformed-override rejection, and a hanging-sidecar abort that proves the cap is applied
- [ ] After deploy: re-upload the same `.xlsx` and confirm the agent reports the import correctly instead of warning about cleartext

## Follows

#971 (tabular uploads never inlined), #973 (sidecar reachable), #974 (model computes correctly).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/976"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790832262&installation_model_id=428086&pr_number=976&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F976&signature=122e241361b003228c880b51b818e2c51ec10a6fe410ec88ba66c7b708471162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->