### PR TITLE
fix: close the Teams module's silent gaps — chat uninstall, full reset, honest switches

### DIFF
--- a/middleware/packages/harness-orchestrator/src/index.ts
+++ b/middleware/packages/harness-orchestrator/src/index.ts
@@ -123,6 +123,7 @@ export type {
   AgentStatus,
   ChannelBindingInput,
   ChannelBindingRow,
+  ChannelIdentityRow,
   ConfigSnapshot,
   PlatformSettingsRow,
   PrivacyProfile,

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -2208,7 +2208,18 @@ export class Orchestrator {
     if (!stateStore) return;
 
     const sessionScope = input.sessionScope ?? '';
-    const agentId = 'orchestrator';
+    // THIS Agent, not the literal `'orchestrator'` this used to be. The state
+    // store keys cooldowns and open-emission follow-ups on `(agentId,
+    // nudgeId)`, so a shared constant made every Agent in the process share
+    // one nudge budget: agent A emitting a nudge put it on cooldown for agent
+    // B, and B's follow-up matched A's open emission. Single-agent
+    // deployments are unaffected — `this.agentId` defaults to `'default'` and
+    // there is only ever one of them.
+    //
+    // Existing rows keyed `'orchestrator'` are simply no longer read, which
+    // resets cooldowns once. That is the cheap direction of the error: a nudge
+    // fires again, rather than being suppressed by a key nobody owns.
+    const agentId = this.agentId;
     // OB-77 — append THIS iteration's entries onto the turn-cumulative
     // trace BEFORE running the pipeline so the multi-domain trigger sees
     // every tool the agent has used so far in this turn (sub-agents

--- a/middleware/packages/harness-orchestrator/src/registry/applyDiff.ts
+++ b/middleware/packages/harness-orchestrator/src/registry/applyDiff.ts
@@ -270,6 +270,19 @@ export function buildForAgent(
       ...(agent.identityLongDescription?.trim()
         ? { identityLongDescription: agent.identityLongDescription.trim() }
         : {}),
+      // W5 memory-ACL — the agent's own rollout mode. Omitted here until now,
+      // which made `agents.context_memory` a switch with nothing behind it:
+      // the column was written, read back into `AgentRow`, echoed by the API
+      // and rendered in the UI, and then dropped on the floor at exactly the
+      // point where it would have changed behaviour. Every registry-built
+      // agent ran the `'off'` default no matter what its row said.
+      //
+      // Spread conditionally like every other optional above, so an agent on
+      // a DB predating migration 0050 (no column → `undefined`) still yields a
+      // byte-identical config object.
+      ...(agent.contextMemory !== undefined
+        ? { contextMemory: agent.contextMemory }
+        : {}),
     },
     deps,
   );
@@ -335,6 +348,16 @@ function runtimeChangeReasons(oldAgent: AgentRow, newAgent: AgentRow): string[] 
     (newAgent.identityLongDescription ?? '')
   ) {
     reasons.push('identity_long_description');
+  }
+  // W5 memory-ACL — the mode decides which memory stack every turn of this
+  // Agent gets, so it is as runtime-relevant as the model. The rebuild is the
+  // second half of the fix above: forwarding the value only helps agents built
+  // AFTER the flip, and an operator who switches a live agent to `enforce`
+  // would otherwise keep the un-partitioned stack until something unrelated
+  // happened to rebuild it — i.e. a memory-isolation switch that reports
+  // success and does not isolate.
+  if ((oldAgent.contextMemory ?? 'off') !== (newAgent.contextMemory ?? 'off')) {
+    reasons.push('context_memory');
   }
   // `name` / `description` are display-only and never warrant a rebuild —
   // they would invalidate sessions for no semantic gain.

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -56,7 +56,10 @@ import type { TeamsResetEventSink } from './services/teamsIdentityReset.js';
 import { TeamsDelegatedSignInService } from './services/teamsDelegatedSignInService.js';
 import { createOperatorTeamsSignInRouter } from './routes/operatorTeamsSignIn.js';
 import { TeamsProvisioningJobRunner } from './services/teamsProvisioningJob.js';
-import { syncTeamsBotConfig } from './services/teamsBotsConfigSync.js';
+import {
+  dropTeamsBotConfig,
+  syncTeamsBotConfig,
+} from './services/teamsBotsConfigSync.js';
 import {
   buildTeamsBotMessagingEndpoint,
   getTeamsProvisioner,
@@ -3504,6 +3507,20 @@ async function main(): Promise<void> {
           ...(eventStore === undefined ? {} : { events: eventStore }),
           ...(eventWriter === undefined ? {} : { eventWriter }),
           ...(delegatedTokens === undefined ? {} : { delegatedTokens }),
+          // The teardown half of #910. Same registry, same reactivation
+          // funnel and the same serialized write queue as the chain's
+          // `syncBotConfig` above — a reset and a run that finish at the same
+          // moment must not read-modify-write the same config value in
+          // parallel, and they cannot, because both go through the module's
+          // single queue.
+          unsyncBotConfig: (botSlug: string) =>
+            dropTeamsBotConfig(
+              {
+                getInstalledRegistry: () => installedRegistry,
+                reactivate: reactivateAgent,
+              },
+              botSlug,
+            ),
         };
         if (installStore === undefined) return withEvents;
         return { ...withEvents, installs: installStore };

--- a/middleware/src/routes/operatorAgents.ts
+++ b/middleware/src/routes/operatorAgents.ts
@@ -31,8 +31,10 @@ import {
 } from '../services/teamsProvisioningJob.js';
 import {
   supportsChatInstall,
+  supportsChatUninstall,
   supportsTeamUninstall,
   type TeamsProvisionerAccessor,
+  type UninstallFromTeamOutcome,
 } from '../platform/teamsProvisionerService.js';
 import type { DelegatedTokenSet } from '../platform/teamsDelegatedSignIn.js';
 import { loadTeamsTargetDirectory } from '../services/teamsTargetDirectoryService.js';
@@ -49,6 +51,7 @@ import {
 import {
   projectTeamsBotConfig,
   projectTeamsBotsConfigSyncStatus,
+  type TeamsBotsConfigSyncOutcome,
 } from '../services/teamsBotsConfigSync.js';
 import {
   AgentAvatarError,
@@ -525,6 +528,18 @@ export interface OperatorTeamsIdentityDeps {
    * access to a log it does not own.
    */
   readonly eventWriter?: TeamsResetEventSink;
+  /**
+   * Remove this bot's `teams_bots` entry from the channel-teams plugin config
+   * — the teardown half of the automatic write the provisioning chain does
+   * (#910).
+   *
+   * Optional like every other capability here: a mount that never wired the
+   * automatic write has no entry the teardown put there, and the reset simply
+   * reports that step as skipped.
+   */
+  readonly unsyncBotConfig?: (
+    botSlug: string,
+  ) => Promise<TeamsBotsConfigSyncOutcome>;
 }
 
 /**
@@ -885,6 +900,17 @@ export interface TeamsAssignmentCapabilities {
   /** Install into a GROUP CHAT or 1:1 chat — requires a connector that
    *  publishes `installToChat` (M365 connector >= 0.7.0). */
   readonly chat_install: boolean;
+  /**
+   * Remove a CHAT install — requires `uninstallFromChat`, a different
+   * connector method from the one `uninstall` reports.
+   *
+   * SEPARATE FLAG, not a widening of `uninstall`, because the two directions
+   * arrived in different connector versions and a single boolean can only
+   * lie about one of them: reporting the team verdict for a chat row lights
+   * up a control that answers 501, and reporting the chat verdict for a team
+   * row greys out a removal that works.
+   */
+  readonly chat_uninstall: boolean;
   /** Why a `false` above is false, keyed by capability. */
   readonly unsupported_reason: Readonly<Record<string, string>>;
 }
@@ -904,6 +930,13 @@ export const TEAMS_UNINSTALL_UNSUPPORTED_REASON =
  *  a version skew an operator can fix, so the sentence names the version. */
 export const TEAMS_CHAT_INSTALL_UNSUPPORTED_REASON =
   `the installed teamsProvisioner@1 publishes no installToChat method — upgrade @omadia/integration-microsoft365 to >= ${TEAMS_CHAT_INSTALL_MIN_CONNECTOR_VERSION}; until then an agent can only be installed into a team, not into a group chat.`;
+
+/** Reason text for the chat REMOVAL direction. Same version as the chat
+ *  install — `installToChat` and `uninstallFromChat` shipped together — but
+ *  its own sentence, because an operator reading it is looking at an install
+ *  they cannot remove, not one they cannot create. */
+export const TEAMS_CHAT_UNINSTALL_UNSUPPORTED_REASON =
+  `the installed teamsProvisioner@1 publishes no uninstallFromChat method — upgrade @omadia/integration-microsoft365 to >= ${TEAMS_CHAT_INSTALL_MIN_CONNECTOR_VERSION}; until then removing the app from a chat is a manual Teams step.`;
 
 /** Minimum connector that can tear a provisioning run down without making
  *  things worse — see `platform/teamsProvisionerCleanup.ts` on the purge. */
@@ -944,6 +977,7 @@ export function teamsAssignmentCapabilities(
   canUninstall: boolean,
   canMultiTeam = false,
   canChatInstall = false,
+  canChatUninstall = false,
 ): TeamsAssignmentCapabilities {
   return {
     install: true,
@@ -951,12 +985,16 @@ export function teamsAssignmentCapabilities(
     enumerate: false,
     multi_team: canMultiTeam,
     chat_install: canChatInstall,
+    chat_uninstall: canChatUninstall,
     unsupported_reason: {
       ...(canUninstall ? {} : { uninstall: TEAMS_UNINSTALL_UNSUPPORTED_REASON }),
       ...(canMultiTeam ? {} : { multi_team: MULTI_TEAM_UNSUPPORTED_REASON }),
       ...(canChatInstall
         ? {}
         : { chat_install: TEAMS_CHAT_INSTALL_UNSUPPORTED_REASON }),
+      ...(canChatUninstall
+        ? {}
+        : { chat_uninstall: TEAMS_CHAT_UNINSTALL_UNSUPPORTED_REASON }),
       ...STRUCTURAL_UNSUPPORTED_REASONS,
     },
   };
@@ -2489,6 +2527,19 @@ export function createOperatorAgentsRouter(
     );
   }
 
+  /**
+   * The same question for a CHAT install, against the other connector method.
+   *
+   * The store half is identical — a removal that cannot be recorded is not a
+   * removal — so only the provisioner half differs.
+   */
+  function canUninstallChats(deps: OperatorTeamsIdentityDeps): boolean {
+    return (
+      typeof deps.store.clearTeamInstall === 'function' &&
+      supportsChatUninstall(deps.getProvisioner?.())
+    );
+  }
+
   /** Resolve agent + identity row for the team routes, answering the shared
    *  404s. `undefined` means a response was already sent. */
   /**
@@ -2841,6 +2892,9 @@ export function createOperatorAgentsRouter(
                 ? { delegatedTokens: deps.delegatedTokens }
                 : {}),
               ...(deps.eventWriter ? { events: deps.eventWriter } : {}),
+              ...(deps.unsyncBotConfig
+                ? { unsyncBotConfig: deps.unsyncBotConfig }
+                : {}),
             },
             agent.id,
             scope,
@@ -2914,6 +2968,7 @@ export function createOperatorAgentsRouter(
           canUninstallTeams(deps),
           deps.installs !== undefined,
           supportsChatInstall(deps.getProvisioner?.()),
+          canUninstallChats(deps),
         ),
         // Same choke point as GET /:slug/teams-identity — one byte-identical
         // channel-teams `teams_bots[]` entry across every team route.
@@ -3058,7 +3113,17 @@ export function createOperatorAgentsRouter(
       }
       const provisioner = deps.getProvisioner?.();
       const clearTeamInstall = deps.store.clearTeamInstall;
-      if (!supportsTeamUninstall(provisioner) || typeof clearTeamInstall !== 'function') {
+      const canTeam = supportsTeamUninstall(provisioner);
+      // The chat direction is a DIFFERENT connector method, and until now this
+      // route ignored it: a chat install was torn down by handing its
+      // `19:…@thread.v2` conversation id to `uninstallFromTeam`, which
+      // addresses `/teams/{id}/installedApps`. Graph answers that with a 400
+      // and the operator is left with an install no button can remove.
+      const canChat = supportsChatUninstall(provisioner);
+      // Neither direction available (or nowhere to record the removal) is the
+      // historical 501, unchanged — a connector that predates BOTH methods
+      // gets exactly the answer and the reason it got before.
+      if ((!canTeam && !canChat) || typeof clearTeamInstall !== 'function') {
         res.status(501).json({
           error: 'teams_uninstall_unsupported',
           message: TEAMS_UNINSTALL_UNSUPPORTED_REASON,
@@ -3129,23 +3194,57 @@ export function createOperatorAgentsRouter(
         return;
       }
 
-      const uninstall = provisioner?.uninstallFromTeam;
-      if (uninstall === undefined) {
-        // Unreachable after supportsTeamUninstall; narrows for the compiler
-        // without a non-null assertion.
-        res.status(501).json({
-          error: 'teams_uninstall_unsupported',
-          message: TEAMS_UNINSTALL_UNSUPPORTED_REASON,
-          min_connector_version: TEAMS_UNINSTALL_MIN_CONNECTOR_VERSION,
-          agent: agent.slug,
-          team_id: teamId,
+      // WHAT THIS INSTALL ACTUALLY IS, from what was recorded when it was
+      // made — the binding first, the identity row as the pre-0051 fallback,
+      // `'team'` last for a row written before migration 0054 knew about
+      // kinds. Never re-derived from the id: `resolveInstallTarget` reads
+      // strings a human typed, and this id was not typed by a human, it was
+      // stored by the run that installed it.
+      const installedKind: TeamsTargetKind =
+        binding?.targetKind ?? row.targetKind ?? 'team';
+      const removingChat = isChatTarget(installedKind);
+
+      // Both branches answer the same `{ outcome }` shape, so everything
+      // below this point — the binding drop, the state walk-back, the
+      // response — stays one code path for both kinds. The per-kind guards
+      // live inside the branches so the compiler narrows the method itself
+      // rather than trusting the boolean that was computed above.
+      let result: { readonly outcome: UninstallFromTeamOutcome };
+      if (removingChat) {
+        const uninstall = provisioner?.uninstallFromChat;
+        if (uninstall === undefined) {
+          res.status(501).json({
+            error: 'teams_chat_uninstall_unsupported',
+            message: TEAMS_CHAT_UNINSTALL_UNSUPPORTED_REASON,
+            min_connector_version: TEAMS_CHAT_INSTALL_MIN_CONNECTOR_VERSION,
+            agent: agent.slug,
+            team_id: teamId,
+            target_kind: installedKind,
+          });
+          return;
+        }
+        result = await uninstall.call(provisioner, {
+          chatId: installedTeamId,
+          teamsAppId: installedAppId,
         });
-        return;
+      } else {
+        const uninstall = provisioner?.uninstallFromTeam;
+        if (uninstall === undefined) {
+          res.status(501).json({
+            error: 'teams_uninstall_unsupported',
+            message: TEAMS_UNINSTALL_UNSUPPORTED_REASON,
+            min_connector_version: TEAMS_UNINSTALL_MIN_CONNECTOR_VERSION,
+            agent: agent.slug,
+            team_id: teamId,
+            target_kind: installedKind,
+          });
+          return;
+        }
+        result = await uninstall.call(provisioner, {
+          teamId: installedTeamId,
+          teamsAppId: installedAppId,
+        });
       }
-      const result = await uninstall.call(provisioner, {
-        teamId: installedTeamId,
-        teamsAppId: installedAppId,
-      });
 
       // Drop THIS binding. The identity is only walked back to
       // `catalog_uploaded` when nothing is left bound: an agent still
@@ -3167,6 +3266,9 @@ export function createOperatorAgentsRouter(
         ok: true,
         agent: agent.slug,
         team_id: installedTeamId,
+        /** Which direction actually ran — a team removal and a chat removal
+         *  are different Graph calls and the response should not blur them. */
+        target_kind: installedKind,
         // 'already-absent' is the connector's idempotent success: the app was
         // not in the team. The binding is dropped either way — that is the
         // point of an idempotent remove.

--- a/middleware/src/routes/operatorChannels.ts
+++ b/middleware/src/routes/operatorChannels.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 
 import {
   ConfigValidationError,
+  type ChannelIdentityRow,
   type ConfigStore,
   type OrchestratorRegistry,
 } from '@omadia/orchestrator';
@@ -29,6 +30,24 @@ import type { ChannelDirectoryRegistry } from '../channels/channelDirectoryRegis
  * per-Agent editor uses, so the registry's hot-reload pipeline picks
  * the change up automatically (no separate reload trigger needed).
  */
+
+/**
+ * The provisioned-bot keys, or none.
+ *
+ * FEATURE-DETECTED rather than called outright. `listChannelIdentities`
+ * arrived with the per-bot routing fix and the store is injected here through
+ * an interface every test builds its own double for; calling it blind would
+ * turn "this double predates the method" into a 500 on a route that has
+ * nothing to do with Teams. No method, and no rows, mean the same thing to
+ * the guard below: there is no provisioned bot claiming this key.
+ */
+async function listChannelIdentitiesSafely(
+  store: ConfigStore,
+): Promise<readonly ChannelIdentityRow[]> {
+  const list = (store as Partial<ConfigStore>).listChannelIdentities;
+  if (typeof list !== 'function') return [];
+  return list.call(store);
+}
 
 const SetBindingSchema = z.object({
   channel_type: z.string().min(1).max(64),
@@ -220,6 +239,39 @@ export function createOperatorChannelsRouter(
       const target = await live.store.getAgentBySlug(body.agent_slug);
       if (!target) {
         res.status(404).json({ error: 'agent_not_found', slug: body.agent_slug });
+        return;
+      }
+
+      // A PROVISIONED BOT IS NOT A FREE CHANNEL KEY.
+      //
+      // Routing resolves `28:<appId>` from `agent_teams_identities` — the
+      // agent the bot was provisioned FOR — and that wins over a binding.
+      // So a binding pointing such a key at a different agent is a write the
+      // operator saw succeed and that changes nothing: the bot keeps
+      // answering as its own agent, and the channels screen goes on showing
+      // the agent they picked. Refused rather than accepted-and-ignored.
+      //
+      // Re-binding to the SAME agent is allowed and is a no-op by
+      // construction — it agrees with the identity — so it is not worth an
+      // error the operator cannot act on.
+      const identities = await listChannelIdentitiesSafely(live.store);
+      const owner = identities.find(
+        (row) =>
+          row.channelType === body.channel_type &&
+          row.channelKey === body.channel_key,
+      );
+      if (owner !== undefined && owner.agentId !== target.id) {
+        const agents = await live.store.listAgents();
+        const ownerSlug =
+          agents.find((a) => a.id === owner.agentId)?.slug ?? null;
+        res.status(409).json({
+          error: 'channel_owned_by_provisioned_bot',
+          message:
+            `channel '${body.channel_key}' is the Teams bot provisioned for agent '${ownerSlug ?? owner.agentId}' — its identity decides the routing, so a binding to '${target.slug}' would be recorded and never take effect. Re-provision the bot for the other agent, or bind a channel that is not a provisioned bot.`,
+          channel_type: body.channel_type,
+          channel_key: body.channel_key,
+          owned_by_agent_slug: ownerSlug,
+        });
         return;
       }
 

--- a/middleware/src/services/teamsBotsConfigSync.ts
+++ b/middleware/src/services/teamsBotsConfigSync.ts
@@ -288,6 +288,29 @@ export function upsertTeamsBotEntry(
   return { document: { entries, form: doc.form }, changed: true };
 }
 
+/**
+ * Take this bot's entry OUT of the list, carrying every other entry over by
+ * reference.
+ *
+ * The exact counterpart of {@link upsertTeamsBotEntry}, and it matches on the
+ * SLUG alone — never on the app id. A reset exists precisely because the
+ * identity's `app_id` is about to stop being true (or already has), so an
+ * entry is stale exactly when it names a slug whose registration is gone,
+ * whatever id it happens to carry. Matching on the id would leave behind the
+ * one entry that most needs removing: the one already pointing at a purged
+ * app.
+ */
+export function removeTeamsBotEntry(
+  doc: TeamsBotsConfigDocument,
+  botSlug: string,
+): TeamsBotsUpsertResult {
+  const entries = doc.entries.filter((entry) => entrySlug(entry) !== botSlug);
+  if (entries.length === doc.entries.length) {
+    return { document: doc, changed: false };
+  }
+  return { document: { entries, form: doc.form }, changed: true };
+}
+
 // ---------------------------------------------------------------------------
 // The sync itself
 // ---------------------------------------------------------------------------
@@ -393,6 +416,57 @@ async function syncOnce(
   // bounce a plugin that is serving traffic.
   await deps.reactivate?.(pluginId);
   return { status: 'synced', botSlug: projection.botSlug };
+}
+
+/**
+ * Remove this bot's `teams_bots` entry and reload the plugin — the teardown
+ * counterpart of {@link syncTeamsBotConfig}.
+ *
+ * WHY A RESET NEEDS THIS. The provisioning chain writes the entry
+ * automatically (#910), so the reset that undoes the chain has to take it back
+ * out; otherwise a "full reset" leaves channel-teams configured with a bot
+ * whose Entra registration has just been purged. That bot then fails
+ * authentication on every inbound activity, and the next provisioning run
+ * appends a SECOND entry beside the corpse under the same slug.
+ *
+ * Takes the SLUG, not an identity record, because by the time the teardown
+ * gets here the row's `app_id` may already be cleared — and the slug is the
+ * key the list is addressed by anyway.
+ *
+ * Never throws for "nothing to remove": an absent entry is the desired end
+ * state, reported as `unchanged`, exactly like a no-op sync.
+ */
+export function dropTeamsBotConfig(
+  deps: TeamsBotsConfigSyncDeps,
+  botSlug: string,
+): Promise<TeamsBotsConfigSyncOutcome> {
+  return serialized(() => dropOnce(deps, botSlug));
+}
+
+async function dropOnce(
+  deps: TeamsBotsConfigSyncDeps,
+  botSlug: string,
+): Promise<TeamsBotsConfigSyncOutcome> {
+  const slug = botSlug.trim();
+  if (slug === '') return { status: 'skipped', reason: 'identity_incomplete' };
+
+  const pluginId = deps.pluginId ?? CHANNEL_TEAMS_PLUGIN_ID;
+  const registry = deps.getInstalledRegistry();
+  if (!registry) return { status: 'skipped', reason: 'registry_unavailable' };
+
+  const installed = registry.get(pluginId);
+  if (!installed) return { status: 'skipped', reason: 'plugin_not_installed' };
+
+  const doc = readTeamsBotsConfig(installed.config[TEAMS_BOTS_CONFIG_KEY]);
+  const { document, changed } = removeTeamsBotEntry(doc, slug);
+  if (!changed) return { status: 'unchanged', botSlug: slug };
+
+  await registry.updateConfig(pluginId, {
+    ...installed.config,
+    [TEAMS_BOTS_CONFIG_KEY]: serializeTeamsBotsConfig(document),
+  });
+  await deps.reactivate?.(pluginId);
+  return { status: 'synced', botSlug: slug };
 }
 
 // ---------------------------------------------------------------------------

--- a/middleware/src/services/teamsIdentityReset.ts
+++ b/middleware/src/services/teamsIdentityReset.ts
@@ -103,6 +103,7 @@ import {
   supportsCatalogRemoval,
   supportsDeletedAppRegistrationLookup,
 } from '../platform/teamsProvisionerCleanup.js';
+import type { TeamsBotsConfigSyncOutcome } from './teamsBotsConfigSync.js';
 
 // ---------------------------------------------------------------------------
 // Vocabulary
@@ -121,6 +122,7 @@ export const TEAMS_RESET_STEPS = [
   'catalog_removed',
   'bot_deleted',
   'app_deleted',
+  'config_unsynced',
   'identity_reset',
   'identity_deleted',
 ] as const;
@@ -255,6 +257,12 @@ export const TEAMS_RESET_DETAILS = {
    * the connector.
    */
   appTraceRequired: 'app_trace_required',
+  /** No `unsyncBotConfig` is wired on this mount, so the `teams_bots` entry
+   *  was never written automatically either (#910) and there is nothing this
+   *  teardown is responsible for removing. */
+  configUnsyncUnavailable: 'config_unsync_unavailable',
+  /** channel-teams is not installed, so there is no config to clean. */
+  configPluginNotInstalled: 'config_plugin_not_installed',
 } as const;
 
 /** Prefixes for the failure details, mirroring the runner's convention of a
@@ -264,6 +272,7 @@ export const TEAMS_RESET_FAILURE_PREFIXES = {
   bot: 'bot_deletion_failed:',
   appDelete: 'app_deletion_failed:',
   appPurge: 'app_purge_failed:',
+  config: 'config_unsync_failed:',
   identity: 'identity_reset_failed:',
 } as const;
 
@@ -421,6 +430,21 @@ export interface TeamsIdentityResetOptions {
     read(): Promise<DelegatedTokenSet | undefined>;
     write?(tokens: DelegatedTokenSet): Promise<void>;
   };
+  /**
+   * Remove this bot's `teams_bots` entry from the channel-teams plugin config
+   * — the counterpart of the automatic write the chain performs (#910).
+   *
+   * Injected rather than imported for the same reason as `buildBotHandle`:
+   * this module must not reach into the plugin registry itself, and a test
+   * needs to observe the call without standing up an installed registry.
+   *
+   * ABSENT IS A LEGITIMATE MOUNT, not a degraded one. A deployment that never
+   * wired the automatic write has no entry this teardown put there, so there
+   * is nothing to take back out — reported as `skipped`, never as a failure.
+   */
+  readonly unsyncBotConfig?: (
+    botSlug: string,
+  ) => Promise<TeamsBotsConfigSyncOutcome>;
   /** Progress log. Absent = the teardown runs identically, silently. */
   readonly events?: TeamsResetEventSink;
   /** Wall clock, injectable — read only to decide whether the delegated
@@ -577,7 +601,30 @@ export async function resetTeamsIdentity(
     return halt('app_deleted', app.detail ?? 'app_deletion_failed');
   }
 
-  // ── Step 4 — the row and the recorded bindings ──────────────────────────
+  // ── Step 4 — the channel-teams `teams_bots` entry ───────────────────────
+  //
+  // The chain WRITES this entry automatically (#910), so the teardown that
+  // undoes the chain has to take it back out. Without this, a "full reset"
+  // left channel-teams configured with a bot whose Entra registration had
+  // just been purged: every inbound activity for it failed authentication,
+  // and the next run appended a second entry under the same slug beside the
+  // corpse.
+  //
+  // AFTER the registration is gone, deliberately. The entry is a pointer to
+  // that registration, and removing the pointer first would leave a live bot
+  // that nothing routes to if the app deletion then failed.
+  //
+  // THE ONE STEP THAT MAY FAIL WITHOUT STOPPING THE TEARDOWN, and the only
+  // one that has earned that: it is a plugin config value, not an Azure
+  // object. Halting here would leave the identity row pointing at an app that
+  // is already deleted — strictly worse than a stale config entry, which the
+  // next provisioning run overwrites in place anyway (`upsertTeamsBotEntry`
+  // matches on the slug). The failure is still reported as a failed step, so
+  // the timeline says what happened rather than quietly swallowing it.
+  await emit('config_unsynced', 'started');
+  await finish(await unsyncBotConfigEntry(opts, row));
+
+  // ── Step 5 — the row and the recorded bindings ──────────────────────────
   //
   // The ONLY step the two scopes disagree about. Everything above ran
   // identically, which is the point: a full reset is the same teardown with a
@@ -757,6 +804,60 @@ async function removeCatalogEntry(
       step,
       outcome: 'failed',
       detail: `${TEAMS_RESET_FAILURE_PREFIXES.catalog}${errorMessage(err)}`,
+    };
+  }
+}
+
+/**
+ * Take the bot out of the channel-teams `teams_bots` list.
+ *
+ * TOTAL, and every non-removal is a SUCCESS with a name: no hook wired, no
+ * plugin installed, nothing there to remove. The only `failed` here is a
+ * write that actually threw — and even that does not stop the teardown (see
+ * the call site).
+ *
+ * Addressed by SLUG, never by app id: by the time a teardown reaches this
+ * point the registration is already deleted and purged, so the entry that
+ * most needs removing is precisely the one whose id no longer resolves.
+ */
+async function unsyncBotConfigEntry(
+  opts: TeamsIdentityResetOptions,
+  row: TeamsResetIdentityRecord,
+): Promise<TeamsResetStepReport> {
+  const step = 'config_unsynced' as const;
+  const unsync = opts.unsyncBotConfig;
+  if (unsync === undefined) {
+    return {
+      step,
+      outcome: 'skipped',
+      detail: TEAMS_RESET_DETAILS.configUnsyncUnavailable,
+    };
+  }
+  try {
+    const outcome = await unsync(row.botSlug);
+    if (outcome.status === 'synced') return { step, outcome: 'removed' };
+    if (outcome.status === 'unchanged') {
+      // No entry under this slug — the desired end state, reached by somebody
+      // else or by a previous attempt. Same success the Azure steps report.
+      return {
+        step,
+        outcome: 'already-absent',
+        detail: TEAMS_RESET_DETAILS.nothingToRemove,
+      };
+    }
+    return {
+      step,
+      outcome: 'skipped',
+      detail:
+        outcome.reason === 'plugin_not_installed'
+          ? TEAMS_RESET_DETAILS.configPluginNotInstalled
+          : TEAMS_RESET_DETAILS.configUnsyncUnavailable,
+    };
+  } catch (err) {
+    return {
+      step,
+      outcome: 'failed',
+      detail: `${TEAMS_RESET_FAILURE_PREFIXES.config}${errorMessage(err)}`,
     };
   }
 }

--- a/middleware/test/buildForAgentContextMemory.test.ts
+++ b/middleware/test/buildForAgentContextMemory.test.ts
@@ -1,0 +1,139 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import Anthropic from '@anthropic-ai/sdk';
+import { InMemoryNudgeRegistry } from '@omadia/plugin-api';
+import type { EntityRefBus, KnowledgeGraph, MemoryStore } from '@omadia/plugin-api';
+
+import type { OrchestratorDeps } from '../packages/harness-orchestrator/src/buildOrchestrator.js';
+import type { NativeToolRegistry } from '../packages/harness-orchestrator/src/nativeToolRegistry.js';
+import type {
+  AgentRow,
+  ConfigSnapshot,
+} from '../packages/harness-orchestrator/src/registry/configStore.js';
+import {
+  buildForAgent,
+  diffSnapshots,
+} from '../packages/harness-orchestrator/src/registry/applyDiff.js';
+
+/**
+ * W5 memory-ACL — the `agents.context_memory` switch actually switching
+ * something.
+ *
+ * THE FAILURE THIS PINS WAS COMPLETELY SILENT, and it is the same shape as
+ * #914's: the value was persisted by the operator route, read back into
+ * `AgentRow`, echoed by the API and rendered in the UI — and then dropped at
+ * the ONE hand-written field list that decides what a built Agent gets. Every
+ * registry-built Agent ran the `'off'` default no matter what its row said, so
+ * an operator could set `enforce-strict`, see it saved, see it displayed, and
+ * still have chat-context turns writing into the agent-wide memory tier.
+ *
+ * Two halves, both load-bearing:
+ *  - `buildForAgent` forwards the mode, so a NEW build honours it;
+ *  - `diffSnapshots` calls a changed mode a REBUILD, so a LIVE agent honours
+ *    it — without that, the switch only takes effect the next time something
+ *    unrelated happens to rebuild the agent, which is indistinguishable from
+ *    "it works, sometimes".
+ */
+
+function fakeNativeToolRegistry(): NativeToolRegistry {
+  const names = new Set<string>();
+  return {
+    has: (name: string) => names.has(name),
+    register: (name: string) => {
+      names.add(name);
+      return () => names.delete(name);
+    },
+  } as unknown as NativeToolRegistry;
+}
+
+function deps(): OrchestratorDeps {
+  return {
+    client: new Anthropic({ apiKey: 'test-key' }),
+    knowledgeGraph: {} as KnowledgeGraph,
+    memoryStore: {} as MemoryStore,
+    entityRefBus: {} as EntityRefBus,
+    nativeToolRegistry: fakeNativeToolRegistry(),
+    nudgeRegistry: new InMemoryNudgeRegistry(),
+    responseGuard: () => undefined,
+    privacyGuard: () => undefined,
+    assistantIdentity: 'You are the platform assistant.',
+  } as unknown as OrchestratorDeps;
+}
+
+function agentRow(overrides: Partial<AgentRow> = {}): AgentRow {
+  return {
+    id: '00000000-0000-0000-0000-000000000001',
+    slug: 'sales',
+    name: 'Sales Agent',
+    description: null,
+    privacyProfile: 'default',
+    status: 'enabled',
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    ...overrides,
+  };
+}
+
+const RUNTIME = { model: 'm', maxTokens: 100, maxToolIterations: 4 };
+
+/** The binder the Orchestrator was built with — the thing the mode decides.
+ *  Same structural-cast convention as the identity and routing guards. */
+function binderModeOf(built: ReturnType<typeof buildForAgent>): unknown {
+  const orchestrator = built.orchestrator as unknown as {
+    memoryBinder?: { mode?: unknown };
+  };
+  return orchestrator.memoryBinder?.mode;
+}
+
+test('the agent row decides the context-memory mode of the built agent', () => {
+  for (const mode of ['off', 'enforce', 'enforce-strict'] as const) {
+    const built = buildForAgent(agentRow({ contextMemory: mode }), deps(), RUNTIME);
+    assert.equal(
+      binderModeOf(built),
+      mode,
+      `an agent row saying ${mode} must build a binder in ${mode}`,
+    );
+  }
+});
+
+test('an agent whose row predates the column still runs the off default', () => {
+  // The no-flag-day guarantee: a database without migration 0050 reports
+  // `undefined`, which has to keep behaving exactly as it did before.
+  assert.equal(binderModeOf(buildForAgent(agentRow(), deps(), RUNTIME)), 'off');
+});
+
+function snapshot(agent: AgentRow): ConfigSnapshot {
+  return {
+    agents: [agent],
+    agentPlugins: [],
+    channelBindings: [],
+    platformSettings: { fallbackAgentId: null, updatedAt: new Date(0) },
+  } as unknown as ConfigSnapshot;
+}
+
+test('flipping the context-memory mode rebuilds the agent', () => {
+  const plan = diffSnapshots(
+    snapshot(agentRow({ contextMemory: 'off' })),
+    snapshot(agentRow({ contextMemory: 'enforce' })),
+  );
+
+  assert.equal(plan.actions.length, 1);
+  const action = plan.actions[0];
+  assert.equal(action?.kind, 'rebuild');
+  assert.match(
+    (action as { reason: string }).reason,
+    /context_memory/,
+    'the reason names the switch, so an operator can see why sessions rolled',
+  );
+});
+
+test('an absent column and an explicit off are the same state', () => {
+  // Otherwise every boot against a pre-0050 database would rebuild every
+  // agent once for a change that did not happen.
+  const plan = diffSnapshots(
+    snapshot(agentRow()),
+    snapshot(agentRow({ contextMemory: 'off' })),
+  );
+  assert.deepEqual(plan.actions, []);
+});

--- a/middleware/test/nudgeStateIsPerAgent.test.ts
+++ b/middleware/test/nudgeStateIsPerAgent.test.ts
@@ -1,0 +1,156 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import Anthropic from '@anthropic-ai/sdk';
+import { InMemoryNudgeRegistry } from '@omadia/plugin-api';
+import type {
+  EntityRefBus,
+  KnowledgeGraph,
+  MemoryStore,
+  NudgeStateRecord,
+  NudgeStateStore,
+} from '@omadia/plugin-api';
+
+import type { OrchestratorDeps } from '../packages/harness-orchestrator/src/buildOrchestrator.js';
+import type { NativeToolRegistry } from '../packages/harness-orchestrator/src/nativeToolRegistry.js';
+import type { AgentRow } from '../packages/harness-orchestrator/src/registry/configStore.js';
+import { buildForAgent } from '../packages/harness-orchestrator/src/registry/applyDiff.js';
+import { createNudgeTurnCounter } from '../packages/harness-orchestrator/src/nudgePipeline.js';
+
+/**
+ * Nudge state belongs to ONE agent, not to the process.
+ *
+ * The pipeline keys cooldowns, suppressions and open-emission follow-ups on
+ * `(agentId, nudgeId)`. That key was the literal string `'orchestrator'` for
+ * every agent in the process, which is invisible in a single-agent deployment
+ * and wrong in every multi-agent one: agent A emitting a nudge put it on
+ * cooldown for agent B, and B's next turn could mark A's emission as followed.
+ *
+ * A guard rather than a scenario test, because the cost of the bug is not that
+ * something crashes — nothing does — but that two agents quietly share a
+ * budget nobody can see them sharing.
+ */
+
+function fakeNativeToolRegistry(): NativeToolRegistry {
+  const names = new Set<string>();
+  return {
+    has: (name: string) => names.has(name),
+    register: (name: string) => {
+      names.add(name);
+      return () => names.delete(name);
+    },
+    // The pipeline classifies every tool in the turn trace by domain, so the
+    // double has to answer that too — `undefined` is the real "no domain
+    // registered" answer, not a stand-in.
+    getDomain: () => undefined,
+    listWithHandler: () => [],
+  } as unknown as NativeToolRegistry;
+}
+
+/** Records every agent id the pipeline reads state for. */
+class RecordingNudgeStateStore implements NudgeStateStore {
+  readonly reads: Array<{ agentId: string; nudgeId: string }> = [];
+
+  read(agentId: string, nudgeId: string): Promise<NudgeStateRecord | null> {
+    this.reads.push({ agentId, nudgeId });
+    return Promise.resolve(null);
+  }
+
+  recordEmission(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  recordFollow(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  recordRegression(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  suppress(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+function deps(stateStore: NudgeStateStore): OrchestratorDeps {
+  const registry = new InMemoryNudgeRegistry();
+  // One provider, so the pipeline has a reason to read state at all. It never
+  // fires — `evaluate` returning null is the common case and keeps this test
+  // about the KEY rather than about nudge content.
+  registry.register({
+    id: 'test-provider',
+    evaluate: () => Promise.resolve(null),
+  } as never);
+  return {
+    client: new Anthropic({ apiKey: 'test-key' }),
+    knowledgeGraph: {} as KnowledgeGraph,
+    memoryStore: {} as MemoryStore,
+    entityRefBus: {} as EntityRefBus,
+    nativeToolRegistry: fakeNativeToolRegistry(),
+    nudgeRegistry: registry,
+    nudgeStateStore: stateStore,
+    responseGuard: () => undefined,
+    privacyGuard: () => undefined,
+    assistantIdentity: 'You are the platform assistant.',
+  } as unknown as OrchestratorDeps;
+}
+
+function agentRow(slug: string): AgentRow {
+  return {
+    id: `00000000-0000-0000-0000-00000000000${slug.length}`,
+    slug,
+    name: slug,
+    description: null,
+    privacyProfile: 'default',
+    status: 'enabled',
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  } as AgentRow;
+}
+
+const RUNTIME = { model: 'm', maxTokens: 100, maxToolIterations: 4 };
+
+/** Drive one tool result through the private pipeline. */
+async function runPipeline(
+  built: ReturnType<typeof buildForAgent>,
+): Promise<void> {
+  const orchestrator = built.orchestrator as unknown as {
+    applyNudgePipeline(
+      toolUses: unknown[],
+      toolResults: unknown[],
+      counter: unknown,
+      cumulativeTrace: unknown[],
+      input: unknown,
+      turnId: string,
+    ): Promise<void>;
+  };
+  await orchestrator.applyNudgePipeline(
+    [{ type: 'tool_use', id: 'tu-1', name: 'search', input: {} }],
+    [{ type: 'tool_result', tool_use_id: 'tu-1', content: 'ok' }],
+    createNudgeTurnCounter(),
+    [],
+    { userMessage: 'hi', sessionScope: 'chat-1' },
+    'turn-1',
+  );
+}
+
+test('each agent reads its own nudge state, not a process-wide key', async () => {
+  const store = new RecordingNudgeStateStore();
+  const shared = deps(store);
+
+  await runPipeline(buildForAgent(agentRow('hr'), shared, RUNTIME));
+  await runPipeline(buildForAgent(agentRow('sales'), shared, RUNTIME));
+
+  const agentIds = [...new Set(store.reads.map((r) => r.agentId))].sort();
+  assert.deepEqual(
+    agentIds,
+    ['hr', 'sales'],
+    'two agents in one process must not share one nudge-state key',
+  );
+  assert.equal(
+    agentIds.includes('orchestrator'),
+    false,
+    'the literal process-wide key must be gone',
+  );
+});

--- a/middleware/test/operatorAgentsRouter.test.ts
+++ b/middleware/test/operatorAgentsRouter.test.ts
@@ -63,6 +63,7 @@ import {
   type OperatorTeamsInstallRecord,
 } from '../src/routes/operatorAgents.js';
 import type { TeamsProvisionerAccessor } from '../src/platform/teamsProvisionerService.js';
+import type { TeamsTargetKind } from '../src/platform/teamsInstallTarget.js';
 import {
   armNotConfiguredDetail,
   consentMissingDetail,
@@ -299,6 +300,10 @@ interface TeamsIdentityMem {
   tenantId: string | null;
   teamsAppId: string | null;
   teamsAppExternalId: string | null;
+  /** Migration 0054 — what `teamId` actually addresses. Optional, exactly
+   *  like the router's port, so a row seeded without it still reads as the
+   *  historical `'team'`. */
+  targetKind?: TeamsTargetKind;
   lastError: string | null;
   /** Optional exactly like the router's port — a row seeded without
    *  timestamps must stay assignable to `OperatorTeamsIdentityRecord`. */
@@ -390,6 +395,32 @@ class FakeTeamsProvisioner {
     readonly value: { readonly teamId: string; readonly teamsAppId: string };
   }> {
     this.calls.push({ ...input });
+    if (this.error) return Promise.reject(this.error);
+    return Promise.resolve({ outcome: this.outcome, value: { ...input } });
+  }
+}
+
+/**
+ * A connector that can remove a CHAT install too — `uninstallFromChat`, a
+ * different Graph endpoint from `uninstallFromTeam` (`/chats/{id}` versus
+ * `/teams/{id}`).
+ *
+ * A SUBCLASS rather than a flag on the base, so the base keeps modelling the
+ * connector that installs into chats but cannot remove from them — the exact
+ * skew the route has to feature-detect, and the state in which handing a chat
+ * id to `uninstallFromTeam` produced a 400 from Graph.
+ */
+class FakeTeamsChatProvisioner extends FakeTeamsProvisioner {
+  chatCalls: Array<{ chatId: string; teamsAppId: string }> = [];
+
+  uninstallFromChat(input: {
+    readonly chatId: string;
+    readonly teamsAppId: string;
+  }): Promise<{
+    readonly outcome: 'uninstalled' | 'already-absent';
+    readonly value: { readonly chatId: string; readonly teamsAppId: string };
+  }> {
+    this.chatCalls.push({ ...input });
     if (this.error) return Promise.reject(this.error);
     return Promise.resolve({ outcome: this.outcome, value: { ...input } });
   }
@@ -2808,6 +2839,126 @@ describe('createOperatorAgentsRouter', () => {
     assert.equal(teamsStore.rows.get(agent.id)?.teamId, 'aaaaaaaa-0000-4000-8000-000000000001');
     assert.equal(teamsStore.rows.get(agent.id)?.state, 'installed');
     assert.deepEqual(teamsStore.clearTeamInstalls, []);
+  });
+
+  // ── DELETE for a CHAT install ───────────────────────────────────────
+  // The route used to hand every recorded id to `uninstallFromTeam`, so a
+  // chat install was addressed as `/teams/19:…@thread.v2/installedApps` —
+  // a shape Graph rejects. Group chats are a primary use case, which made
+  // this "installed and unremovable".
+
+  const CHAT_ID = '19:aaaaaaaabbbbccccddddeeeeffff0000@thread.v2';
+
+  it('DELETE /:slug/teams/:teamId uses uninstallFromChat for a chat install', async () => {
+    const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
+    seedIdentity(agent.id, {
+      state: 'installed',
+      teamId: CHAT_ID,
+      targetKind: 'group-chat',
+    });
+    const fake = new FakeTeamsChatProvisioner();
+    provisioner = fake;
+
+    const res = await deleteTeam('sales', CHAT_ID);
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      team_id: string;
+      target_kind: string;
+      outcome: string;
+    };
+    assert.equal(body.ok, true);
+    assert.equal(body.team_id, CHAT_ID);
+    // The response names the direction that ran — a team removal and a chat
+    // removal are different calls and must not read the same.
+    assert.equal(body.target_kind, 'group-chat');
+    assert.equal(body.outcome, 'uninstalled');
+
+    // THE POINT: the chat endpoint, keyed `chatId`, and the team endpoint
+    // never touched.
+    assert.deepEqual(fake.chatCalls, [
+      { chatId: CHAT_ID, teamsAppId: 'teams-app-789' },
+    ]);
+    assert.deepEqual(fake.calls, []);
+    assert.deepEqual(teamsStore.clearTeamInstalls, [agent.id]);
+  });
+
+  it('DELETE /:slug/teams/:teamId still uses uninstallFromTeam for a team install', async () => {
+    // The other half of the branch: a connector that CAN do both must not
+    // start routing team removals through the chat endpoint.
+    const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
+    seedIdentity(agent.id, {
+      state: 'installed',
+      teamId: 'aaaaaaaa-0000-4000-8000-000000000001',
+      targetKind: 'team',
+    });
+    const fake = new FakeTeamsChatProvisioner();
+    provisioner = fake;
+
+    const res = await deleteTeam('sales', 'aaaaaaaa-0000-4000-8000-000000000001');
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as { target_kind: string };
+    assert.equal(body.target_kind, 'team');
+    assert.deepEqual(fake.chatCalls, []);
+    assert.deepEqual(fake.calls, [
+      { teamId: 'aaaaaaaa-0000-4000-8000-000000000001', teamsAppId: 'teams-app-789' },
+    ]);
+  });
+
+  it('DELETE /:slug/teams/:teamId → 501 for a chat when the connector has no uninstallFromChat', async () => {
+    const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
+    seedIdentity(agent.id, {
+      state: 'installed',
+      teamId: CHAT_ID,
+      targetKind: 'group-chat',
+    });
+    // The seeded FakeTeamsProvisioner publishes only the TEAM method.
+    const fake = provisioner as FakeTeamsProvisioner;
+
+    const res = await deleteTeam('sales', CHAT_ID);
+    assert.equal(res.status, 501);
+    const body = (await res.json()) as {
+      error: string;
+      message: string;
+      target_kind: string;
+    };
+    assert.equal(body.error, 'teams_chat_uninstall_unsupported');
+    assert.equal(body.target_kind, 'group-chat');
+    assert.match(body.message, /uninstallFromChat/);
+    // Refused, never approximated: handing the chat id to the team endpoint
+    // is exactly the bug, so nothing may have been called and the row stands.
+    assert.deepEqual(fake.calls, []);
+    assert.deepEqual(teamsStore.clearTeamInstalls, []);
+    assert.equal(teamsStore.rows.get(agent.id)?.teamId, CHAT_ID);
+    assert.equal(teamsStore.rows.get(agent.id)?.state, 'installed');
+  });
+
+  it('GET /:slug/teams reports chat_uninstall separately from uninstall', async () => {
+    const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
+    seedIdentity(agent.id);
+
+    // Team-only connector: one direction true, the other false with a reason.
+    const teamOnly = (await (await fetch(`${baseUrl}/sales/teams`)).json()) as {
+      capabilities: Record<string, unknown> & {
+        unsupported_reason: Record<string, string>;
+      };
+    };
+    assert.equal(teamOnly.capabilities['uninstall'], true);
+    assert.equal(teamOnly.capabilities['chat_uninstall'], false);
+    assert.match(
+      teamOnly.capabilities.unsupported_reason['chat_uninstall'] ?? '',
+      /uninstallFromChat/,
+    );
+
+    provisioner = new FakeTeamsChatProvisioner();
+    const both = (await (await fetch(`${baseUrl}/sales/teams`)).json()) as {
+      capabilities: Record<string, unknown> & {
+        unsupported_reason: Record<string, string>;
+      };
+    };
+    assert.equal(both.capabilities['chat_uninstall'], true);
+    assert.equal(both.capabilities.unsupported_reason['chat_uninstall'], undefined);
+    assert.equal(agent.slug, 'sales');
   });
 
   it('GET /:slug/teams reports uninstall: false against a connector that is too old', async () => {

--- a/middleware/test/operatorChannelsBindingGuard.test.ts
+++ b/middleware/test/operatorChannelsBindingGuard.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import express from 'express';
+import type { Express } from 'express';
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import type {
+  ChannelKeyDirectory,
+  ChannelKeyEntry,
+} from '@omadia/channel-sdk';
+import type { ConfigStore, OrchestratorRegistry } from '@omadia/orchestrator';
+
+import { ChannelDirectoryRegistry } from '../src/channels/channelDirectoryRegistry.js';
+import { createOperatorChannelsRouter } from '../src/routes/operatorChannels.js';
+
+/**
+ * A PROVISIONED BOT IS NOT A FREE CHANNEL KEY.
+ *
+ * Routing resolves `28:<appId>` from `agent_teams_identities` — the agent the
+ * bot was provisioned FOR — and that beats a `channel_bindings` row. So a
+ * binding pointing such a key at a DIFFERENT agent used to be accepted,
+ * written, confirmed with a 200, rendered on the channels screen as the
+ * operator's choice — and changed nothing at all. The bot went on answering
+ * as its own agent while every screen said otherwise.
+ *
+ * Accepted-and-ignored is the worst of the three possible behaviours (honour
+ * it, refuse it, ignore it), because it is the only one an operator cannot
+ * see. This is the refusal, plus the two cases that must NOT be refused.
+ */
+
+const BOT_KEY = '28:11111111-2222-3333-4444-555555555555';
+
+function fakeDirectory(entries: readonly ChannelKeyEntry[]): ChannelKeyDirectory {
+  return {
+    channelType: 'teams',
+    originPluginId: '@omadia/channel-teams',
+    listKeys: async () => entries,
+  };
+}
+
+interface Harness {
+  baseUrl: string;
+  /** Every binding write the route performed, in order. */
+  readonly created: Array<{ agentId: string; channelKey: string }>;
+  readonly reloads: number[];
+  close(): Promise<void>;
+}
+
+interface HarnessInput {
+  /** Provisioned bots, as `listChannelIdentities` projects them. */
+  readonly identities?: ReadonlyArray<{
+    channelType: string;
+    channelKey: string;
+    agentId: string;
+  }>;
+  /** Omit the method entirely — a store predating per-bot routing. */
+  readonly withoutIdentityListing?: boolean;
+}
+
+async function makeHarness(input: HarnessInput = {}): Promise<Harness> {
+  const directory = new ChannelDirectoryRegistry();
+  directory.register(fakeDirectory([{ key: BOT_KEY, label: 'HR Bot' }]));
+
+  const created: Array<{ agentId: string; channelKey: string }> = [];
+  const reloads: number[] = [];
+
+  const base = {
+    listAgents: async () => [
+      { id: 'a-hr', slug: 'hr', name: 'HR', status: 'enabled' },
+      { id: 'a-sales', slug: 'sales', name: 'Sales', status: 'enabled' },
+    ],
+    listChannelBindings: async () => [],
+    getPlatformSettings: async () => ({ fallbackAgentId: 'a-hr' }),
+    getAgentBySlug: async (slug: string) =>
+      slug === 'hr'
+        ? { id: 'a-hr', slug: 'hr' }
+        : slug === 'sales'
+          ? { id: 'a-sales', slug: 'sales' }
+          : undefined,
+    createChannelBinding: async (
+      agentId: string,
+      binding: { channelType: string; channelKey: string },
+    ) => {
+      created.push({ agentId, channelKey: binding.channelKey });
+      return undefined;
+    },
+    removeChannelBinding: async () => undefined,
+  };
+
+  const store = (
+    input.withoutIdentityListing
+      ? base
+      : {
+          ...base,
+          listChannelIdentities: async () => input.identities ?? [],
+        }
+  ) as unknown as ConfigStore;
+
+  const orchestratorRegistry = {
+    reload: async () => {
+      reloads.push(1);
+      return undefined;
+    },
+  } as unknown as OrchestratorRegistry;
+
+  const app: Express = express();
+  app.use(express.json());
+  app.use(
+    '/api/v1/operator/channels',
+    createOperatorChannelsRouter({
+      getConfigStore: () => store,
+      getRegistry: () => orchestratorRegistry,
+      getDirectoryRegistry: () => directory,
+    }),
+  );
+  const server = await new Promise<Server>((resolve) => {
+    const s = app.listen(0, () => resolve(s));
+  });
+  const { port } = server.address() as AddressInfo;
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    created,
+    reloads,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      ),
+  };
+}
+
+function putBinding(
+  harness: Harness,
+  agentSlug: string | null,
+  channelKey = BOT_KEY,
+): Promise<globalThis.Response> {
+  return fetch(`${harness.baseUrl}/api/v1/operator/channels/binding`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      channel_type: 'teams',
+      channel_key: channelKey,
+      agent_slug: agentSlug,
+    }),
+  });
+}
+
+describe('PUT /operator/channels/binding — provisioned bots', () => {
+  let harness: Harness | undefined;
+  afterEach(async () => {
+    await harness?.close();
+    harness = undefined;
+  });
+
+  it('refuses to point a provisioned bot at another agent', async () => {
+    harness = await makeHarness({
+      identities: [
+        { channelType: 'teams', channelKey: BOT_KEY, agentId: 'a-hr' },
+      ],
+    });
+
+    const res = await putBinding(harness, 'sales');
+    assert.equal(res.status, 409);
+    const body = (await res.json()) as {
+      error: string;
+      message: string;
+      owned_by_agent_slug: string;
+    };
+    assert.equal(body.error, 'channel_owned_by_provisioned_bot');
+    // The refusal names the agent that DOES own the bot — without it the
+    // operator has to go and find out which one is in the way.
+    assert.equal(body.owned_by_agent_slug, 'hr');
+    assert.match(body.message, /would be recorded and never take effect/);
+
+    // Nothing written, nothing rolled.
+    assert.deepEqual(harness.created, []);
+    assert.deepEqual(harness.reloads, []);
+  });
+
+  it('allows binding a provisioned bot to the agent it belongs to', async () => {
+    // Agrees with the identity, so it is a no-op by construction — not worth
+    // an error the operator cannot act on.
+    harness = await makeHarness({
+      identities: [
+        { channelType: 'teams', channelKey: BOT_KEY, agentId: 'a-hr' },
+      ],
+    });
+
+    const res = await putBinding(harness, 'hr');
+    assert.equal(res.status, 200);
+    assert.deepEqual(harness.created, [{ agentId: 'a-hr', channelKey: BOT_KEY }]);
+  });
+
+  it('leaves an ordinary channel key alone', async () => {
+    // The guard must not turn into "no bindings allowed": a group chat, a
+    // Telegram chat, anything that is not a provisioned bot still binds.
+    harness = await makeHarness({
+      identities: [
+        { channelType: 'teams', channelKey: BOT_KEY, agentId: 'a-hr' },
+      ],
+    });
+
+    const res = await putBinding(harness, 'sales', '19:group@thread.v2');
+    assert.equal(res.status, 200);
+    assert.deepEqual(harness.created, [
+      { agentId: 'a-sales', channelKey: '19:group@thread.v2' },
+    ]);
+  });
+
+  it('degrades to "no provisioned bots" against a store without the listing', async () => {
+    // The method arrived with per-bot routing. A store double (or a mount)
+    // that predates it must not turn this route into a 500 — there is simply
+    // no bot claiming the key.
+    harness = await makeHarness({ withoutIdentityListing: true });
+
+    const res = await putBinding(harness, 'sales');
+    assert.equal(res.status, 200);
+    assert.deepEqual(harness.created, [
+      { agentId: 'a-sales', channelKey: BOT_KEY },
+    ]);
+  });
+
+  it('never blocks CLEARING a binding', async () => {
+    // Clearing removes a row that was doing nothing anyway. Refusing it would
+    // trap an operator with a binding they can neither use nor delete.
+    harness = await makeHarness({
+      identities: [
+        { channelType: 'teams', channelKey: BOT_KEY, agentId: 'a-hr' },
+      ],
+    });
+
+    const res = await putBinding(harness, null);
+    assert.equal(res.status, 200);
+  });
+});

--- a/middleware/test/teamsBotsConfigSync.test.ts
+++ b/middleware/test/teamsBotsConfigSync.test.ts
@@ -10,9 +10,11 @@ import {
   TEAMS_BOTS_CONFIG_KEY,
   TeamsBotsConfigSyncError,
   defaultTeamsBotSecretRef,
+  dropTeamsBotConfig,
   projectTeamsBotConfig,
   projectTeamsBotsConfigSyncStatus,
   readTeamsBotsConfig,
+  removeTeamsBotEntry,
   serializeTeamsBotsConfig,
   syncTeamsBotConfig,
   teamsBotConfigEntry,
@@ -488,5 +490,147 @@ describe('projectTeamsBotsConfigSyncStatus', () => {
     );
     assert.equal(status.plugin_id, CHANNEL_TEAMS_PLUGIN_ID);
     assert.equal(status.config_key, 'teams_bots');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The teardown half — taking back out what the chain wrote
+// ---------------------------------------------------------------------------
+
+/**
+ * A reset that leaves the entry behind is not a reset. The registration it
+ * names has just been deleted AND purged, so what stays behind is a bot that
+ * fails authentication on every inbound activity — and the next run appends a
+ * second entry under the same slug beside it.
+ *
+ * The properties that matter are the mirror image of the sync's: remove
+ * exactly one entry, disturb nothing else, and never fail for "already gone".
+ */
+
+/** The entry the chain would have written for {@link IDENTITY}. */
+const hrEntry = (): Record<string, unknown> => {
+  const projection = projectTeamsBotConfig(IDENTITY);
+  assert.ok(projection, 'fixture must project');
+  return teamsBotConfigEntry(projection) as Record<string, unknown>;
+};
+
+function docWith(
+  entries: readonly Record<string, unknown>[],
+): ReturnType<typeof readTeamsBotsConfig> {
+  return readTeamsBotsConfig(
+    serializeTeamsBotsConfig({ entries: [...entries], form: 'string' }),
+  );
+}
+
+describe('removeTeamsBotEntry', () => {
+  it('drops the named slug and carries every other entry over untouched', () => {
+    const doc = docWith([LEGACY_ENTRY, hrEntry(), FOREIGN_ENTRY]);
+    const { document, changed } = removeTeamsBotEntry(doc, 'hr-bot');
+    assert.equal(changed, true);
+    assert.deepEqual(
+      document.entries.map((e) => (e as Record<string, unknown>)['botSlug']),
+      ['default', 'sales-bot'],
+    );
+    // Entry 0 is the legacy scalar-shimmed bot answering live traffic, and
+    // the foreign entry is somebody's hand-tuned row. Byte-equal, not merely
+    // still present.
+    assert.deepEqual(document.entries[0], LEGACY_ENTRY);
+    assert.deepEqual(document.entries[1], FOREIGN_ENTRY);
+  });
+
+  it('reports unchanged, and returns the SAME document, when nothing matched', () => {
+    const doc = docWith([LEGACY_ENTRY]);
+    const { document, changed } = removeTeamsBotEntry(doc, 'hr-bot');
+    assert.equal(changed, false);
+    assert.equal(document, doc);
+  });
+
+  it('matches on the SLUG, not on the app id', () => {
+    // The teardown runs AFTER the registration is purged, so the entry that
+    // most needs removing is precisely the one whose app id no longer
+    // resolves. Matching on the id would leave exactly that one behind.
+    const doc = docWith([{ ...hrEntry(), appId: 'app-already-purged' }]);
+    const { document, changed } = removeTeamsBotEntry(doc, 'hr-bot');
+    assert.equal(changed, true);
+    assert.deepEqual(document.entries, []);
+  });
+});
+
+describe('dropTeamsBotConfig', () => {
+  it('writes the shortened list and reactivates the plugin', async () => {
+    const registry = registryWith({
+      [TEAMS_BOTS_CONFIG_KEY]: serializeTeamsBotsConfig({
+        entries: [LEGACY_ENTRY, hrEntry()],
+        form: 'string',
+      }),
+    });
+    const reactivated: string[] = [];
+    const outcome = await dropTeamsBotConfig(
+      {
+        getInstalledRegistry: () => registry,
+        reactivate: async (id: string) => {
+          reactivated.push(id);
+        },
+      },
+      'hr-bot',
+    );
+    assert.deepEqual(outcome, { status: 'synced', botSlug: 'hr-bot' });
+    assert.deepEqual(
+      storedEntries(registry).map((e) => e['botSlug']),
+      ['default'],
+    );
+    assert.deepEqual(reactivated, [CHANNEL_TEAMS_PLUGIN_ID]);
+  });
+
+  it('does not bounce a live plugin when there was nothing to remove', async () => {
+    const registry = registryWith({
+      [TEAMS_BOTS_CONFIG_KEY]: serializeTeamsBotsConfig({
+        entries: [LEGACY_ENTRY],
+        form: 'string',
+      }),
+    });
+    const reactivated: string[] = [];
+    const outcome = await dropTeamsBotConfig(
+      {
+        getInstalledRegistry: () => registry,
+        reactivate: async (id: string) => {
+          reactivated.push(id);
+        },
+      },
+      'hr-bot',
+    );
+    assert.deepEqual(outcome, { status: 'unchanged', botSlug: 'hr-bot' });
+    assert.deepEqual(reactivated, []);
+    assert.deepEqual(storedEntries(registry), [LEGACY_ENTRY]);
+  });
+
+  it('skips, never throws, when the registry or the plugin is absent', async () => {
+    assert.deepEqual(
+      await dropTeamsBotConfig({ getInstalledRegistry: () => undefined }, 'hr-bot'),
+      { status: 'skipped', reason: 'registry_unavailable' },
+    );
+    assert.deepEqual(
+      await dropTeamsBotConfig(
+        { getInstalledRegistry: () => new InMemoryInstalledRegistry() },
+        'hr-bot',
+      ),
+      { status: 'skipped', reason: 'plugin_not_installed' },
+    );
+  });
+
+  it('refuses to clobber a stored value it cannot read', async () => {
+    // Same posture as the sync: an unparsable value may be an operator's
+    // hand-written list, and rewriting it would destroy work this module has
+    // no way to reconstruct.
+    await assert.rejects(
+      dropTeamsBotConfig(
+        {
+          getInstalledRegistry: () =>
+            registryWith({ [TEAMS_BOTS_CONFIG_KEY]: '{ not json' }),
+        },
+        'hr-bot',
+      ),
+      TeamsBotsConfigSyncError,
+    );
   });
 });

--- a/middleware/test/teamsIdentityReset.test.ts
+++ b/middleware/test/teamsIdentityReset.test.ts
@@ -1072,3 +1072,151 @@ describe('teams identity reset — the tenant sign-in', () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+
+/**
+ * The `teams_bots` entry the provisioning chain writes automatically (#910).
+ *
+ * A teardown that leaves it behind is the one failure mode that is INVISIBLE
+ * in Azure and still breaks the tenant: channel-teams keeps an adapter for a
+ * bot whose registration was just purged, every inbound activity for it fails
+ * authentication, and the operator sees a "reset" that did not reset.
+ */
+describe('teams identity reset — the channel-teams config entry', () => {
+  it('removes the entry, by slug, after the registration is gone', async () => {
+    const store = memoryStore({});
+    const provisioner = stubProvisioner();
+    const dropped: string[] = [];
+
+    const result = await resetTeamsIdentity(
+      options(store, provisioner, {
+        unsyncBotConfig: async (botSlug: string) => {
+          // ORDER IS PART OF THE CONTRACT: the entry points at the
+          // registration, so it may only go once the registration has.
+          assert.ok(
+            provisioner.calls.some((c) => c.startsWith('deleteAppRegistration:')),
+            'the app must already be deleted when the entry is removed',
+          );
+          dropped.push(botSlug);
+          return { status: 'synced', botSlug };
+        },
+      }),
+      'agent-1',
+    );
+
+    assert.deepEqual(dropped, ['acme']);
+    assert.deepEqual(outcomeOf(result.steps, 'config_unsynced'), {
+      step: 'config_unsynced',
+      outcome: 'removed',
+    });
+    assert.equal(result.status, 'reset');
+  });
+
+  it('reports an absent entry as a success, not as a failure', async () => {
+    const store = memoryStore({});
+    const result = await resetTeamsIdentity(
+      options(store, stubProvisioner(), {
+        unsyncBotConfig: async (botSlug: string) => ({
+          status: 'unchanged',
+          botSlug,
+        }),
+      }),
+      'agent-1',
+    );
+    assert.equal(outcomeOf(result.steps, 'config_unsynced')?.outcome, 'already-absent');
+    assert.equal(result.status, 'reset');
+  });
+
+  it('skips when no hook is wired, and names which of the two reasons', async () => {
+    // A mount that never wired the automatic write has no entry this teardown
+    // put there. Reported, not hidden — an operator comparing two deployments
+    // should see WHY one of them cleaned nothing.
+    const withoutHook = await resetTeamsIdentity(
+      options(memoryStore({}), stubProvisioner()),
+      'agent-1',
+    );
+    assert.deepEqual(outcomeOf(withoutHook.steps, 'config_unsynced'), {
+      step: 'config_unsynced',
+      outcome: 'skipped',
+      detail: TEAMS_RESET_DETAILS.configUnsyncUnavailable,
+    });
+
+    const withoutPlugin = await resetTeamsIdentity(
+      options(memoryStore({}), stubProvisioner(), {
+        unsyncBotConfig: async () => ({
+          status: 'skipped',
+          reason: 'plugin_not_installed',
+        }),
+      }),
+      'agent-1',
+    );
+    assert.equal(
+      outcomeOf(withoutPlugin.steps, 'config_unsynced')?.detail,
+      TEAMS_RESET_DETAILS.configPluginNotInstalled,
+    );
+  });
+
+  it('does NOT stop the teardown when the config write fails', async () => {
+    // The one step allowed to fail without halting, and the reason is
+    // asymmetric damage: halting here leaves the identity row pointing at an
+    // app that is already deleted and purged, which is strictly worse than a
+    // stale config entry the next run overwrites in place.
+    const store = memoryStore({});
+    const result = await resetTeamsIdentity(
+      options(store, stubProvisioner(), {
+        unsyncBotConfig: async () => {
+          throw new Error('plugin registry is down');
+        },
+      }),
+      'agent-1',
+    );
+
+    const step = outcomeOf(result.steps, 'config_unsynced');
+    assert.equal(step?.outcome, 'failed');
+    assert.match(String(step?.detail), /^config_unsync_failed:/);
+    // The row still went back to pending — the teardown finished.
+    assert.equal(result.status, 'reset');
+    assert.equal(store.resetCalls, 1);
+  });
+
+  it('runs for the full reset too, before the row is dropped', async () => {
+    const store = memoryStore({});
+    const seen: string[] = [];
+    const result = await resetTeamsIdentity(
+      options(store, stubProvisioner(), {
+        unsyncBotConfig: async (botSlug: string) => {
+          // The row is what holds the slug, so the entry has to go while it
+          // is still readable.
+          assert.equal(store.deleteCalls, 0);
+          seen.push(botSlug);
+          return { status: 'synced', botSlug };
+        },
+      }),
+      'agent-1',
+      'identity',
+    );
+    assert.deepEqual(seen, ['acme']);
+    assert.equal(store.deleteCalls, 1);
+    assert.equal(result.status, 'reset');
+  });
+
+  it('is not reached when an earlier step halted the teardown', async () => {
+    // The entry names a live bot as long as the registration is alive.
+    // Removing it after a failed app deletion would take the bot off the air
+    // while leaving it in Azure — the worst of both.
+    let called = 0;
+    const result = await resetTeamsIdentity(
+      options(memoryStore({}), stubProvisioner({ failOn: 'catalog' }), {
+        unsyncBotConfig: async (botSlug: string) => {
+          called += 1;
+          return { status: 'synced', botSlug };
+        },
+      }),
+      'agent-1',
+    );
+    assert.equal(result.status, 'incomplete');
+    assert.equal(called, 0);
+    assert.equal(outcomeOf(result.steps, 'config_unsynced'), undefined);
+  });
+});

--- a/web-ui/app/_lib/__tests__/teamsIdentityMessageCoverage.test.ts
+++ b/web-ui/app/_lib/__tests__/teamsIdentityMessageCoverage.test.ts
@@ -1,0 +1,81 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { TEAMS_IDENTITY_LAST_ERROR_CODES } from '../agents';
+
+/**
+ * The Teams provisioning error panel renders KEYS, not strings.
+ *
+ * `teamsIdentityErrorMessages` builds `errors.<code>.what` and
+ * `errors.<code>.next` for every code without exception, so a catalogue entry
+ * written as a FLAT string satisfies every existing gate and still renders the
+ * raw key path at the operator. That is precisely what happened to
+ * `rsc_permissions_mismatch`: the copy was written, reviewed and translated
+ * into both locales as one sentence, the parity gate compared it against its
+ * equally-flat twin and passed, and the panel showed
+ * `operatorAgents.teamsIdentity.errors.rsc_permissions_mismatch.what` in
+ * production.
+ *
+ * Neither of the two existing catalogue gates could catch it. `i18n:check`
+ * asks whether de and en agree with each other; `errorHelpCoverage` asks
+ * whether a middleware code has copy at all. This one asks the question the
+ * renderer actually asks — does the SHAPE the component reads exist — and it
+ * is driven by the same exported code list the component's builder is, so a
+ * new code cannot be added without its two lines.
+ */
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const MESSAGES_DIR = path.resolve(HERE, '..', '..', '..', 'messages');
+const LOCALES = ['de', 'en'] as const;
+
+type Catalogue = Record<string, unknown>;
+
+function load(locale: string): Catalogue {
+  const raw = fs.readFileSync(path.join(MESSAGES_DIR, `${locale}.json`), 'utf8');
+  return JSON.parse(raw) as Catalogue;
+}
+
+/** The `errors` namespace the panel resolves its keys against. */
+function errorsOf(locale: string): Record<string, unknown> {
+  const root = load(locale);
+  const operatorAgents = root['operatorAgents'] as Record<string, unknown>;
+  const teamsIdentity = operatorAgents['teamsIdentity'] as Record<
+    string,
+    unknown
+  >;
+  return teamsIdentity['errors'] as Record<string, unknown>;
+}
+
+describe('teams identity error catalogue', () => {
+  for (const locale of LOCALES) {
+    it(`[${locale}] every last-error code has .what and .next`, () => {
+      const errors = errorsOf(locale);
+      const missing: string[] = [];
+      for (const code of TEAMS_IDENTITY_LAST_ERROR_CODES) {
+        const entry = errors[code];
+        // A string here is the exact failure mode this guard exists for: the
+        // copy is present, the parity gate is happy, and the panel renders the
+        // key path because it asked for `.what` of a string.
+        if (typeof entry !== 'object' || entry === null) {
+          missing.push(`${code} (not an object)`);
+          continue;
+        }
+        const shape = entry as Record<string, unknown>;
+        if (typeof shape['what'] !== 'string') missing.push(`${code}.what`);
+        if (typeof shape['next'] !== 'string') missing.push(`${code}.next`);
+      }
+      expect(missing).toEqual([]);
+    });
+  }
+
+  it('both locales describe the same set of codes', () => {
+    // The parity gate already compares the catalogues wholesale; this narrows
+    // the same claim to the one namespace this file is about, so a failure
+    // points at the panel instead of at a 4000-key diff.
+    expect(Object.keys(errorsOf('de')).sort()).toEqual(
+      Object.keys(errorsOf('en')).sort(),
+    );
+  });
+});

--- a/web-ui/app/_lib/agents.ts
+++ b/web-ui/app/_lib/agents.ts
@@ -1105,6 +1105,7 @@ export const TEAMS_ASSIGNMENT_CAPABILITY_KEYS = [
   'enumerate',
   'multi_team',
   'chat_install',
+  'chat_uninstall',
 ] as const;
 
 export type TeamsAssignmentCapabilityKey =
@@ -1148,6 +1149,7 @@ const TEAMS_ASSIGNMENT_CAPABILITIES_CLOSED: TeamsAssignmentCapabilitiesDto = {
   enumerate: false,
   multi_team: false,
   chat_install: false,
+  chat_uninstall: false,
   unsupported_reason: {},
 };
 
@@ -1371,6 +1373,10 @@ export interface TeamsResetStepDto {
     | 'catalog_removed'
     | 'bot_deleted'
     | 'app_deleted'
+    /** The channel-teams `teams_bots` entry the chain wrote automatically
+     *  (#910) — removed so a "full reset" does not leave the plugin
+     *  configured with a bot whose registration has just been purged. */
+    | 'config_unsynced'
     /** The `'run'` scope's last step: the row is back at `pending`. */
     | 'identity_reset'
     /** The `'identity'` scope's last step: the row is gone. */

--- a/web-ui/app/operator/agents/[slug]/__tests__/AgentTeamsInstalls.test.tsx
+++ b/web-ui/app/operator/agents/[slug]/__tests__/AgentTeamsInstalls.test.tsx
@@ -61,9 +61,12 @@ function capabilities(
     enumerate: false,
     multi_team: false,
     chat_install: false,
+    chat_uninstall: false,
     unsupported_reason: {
       uninstall:
         'the installed teamsProvisioner@1 publishes no uninstallFromTeam method',
+      chat_uninstall:
+        'the installed teamsProvisioner@1 publishes no uninstallFromChat method',
       enumerate: 'teamsProvisioner@1 publishes no installation-listing method',
       multi_team: 'agent_teams_identities stores ONE team_id per agent',
     },

--- a/web-ui/app/operator/agents/[slug]/_components/AgentTeamsInstalls.tsx
+++ b/web-ui/app/operator/agents/[slug]/_components/AgentTeamsInstalls.tsx
@@ -384,6 +384,16 @@ export function AgentTeamsInstalls({
                 // the confusion this feature removes — so every entry names
                 // its own kind.
                 const kind = parseInstalledTargetKind(team);
+                // PER ROW, not per panel. Removing from a team and removing
+                // from a chat are different connector methods that arrived in
+                // different versions, so one flag for the whole list has to be
+                // wrong about one of the two kinds — a chat row with a live
+                // button that answers 501, or a team row greyed out because
+                // the connector cannot do chats.
+                const canRemove =
+                  kind === 'team'
+                    ? data.capabilities.uninstall
+                    : data.capabilities.chat_uninstall;
                 return (
                   <div
                     key={team.team_id}
@@ -441,7 +451,7 @@ export function AgentTeamsInstalls({
                       className="ml-auto"
                       size="sm"
                       variant="danger"
-                      disabled={!data.capabilities.uninstall || inFlight}
+                      disabled={!canRemove || inFlight}
                       busy={busy === `uninstall:${team.team_id}`}
                       busyLabel={t('uninstallBusy')}
                       onClick={() => setConfirmUninstall(team)}
@@ -452,8 +462,16 @@ export function AgentTeamsInstalls({
                 );
               })
             )}
-            {!data.capabilities.uninstall ? (
+            {/* One note per capability that is actually relevant to what is
+                listed: a deployment with only team installs must not be told
+                about a chat method it never reaches for, and vice versa. */}
+            {!data.capabilities.uninstall &&
+            installed.some((team) => parseInstalledTargetKind(team) === 'team') ? (
               <CapabilityNote {...unsupportedReason(data, 'uninstall')} />
+            ) : null}
+            {!data.capabilities.chat_uninstall &&
+            installed.some((team) => parseInstalledTargetKind(team) !== 'team') ? (
+              <CapabilityNote {...unsupportedReason(data, 'chat_uninstall')} />
             ) : null}
           </div>
 

--- a/web-ui/app/operator/agents/[slug]/_components/TeamsTargetPicker.tsx
+++ b/web-ui/app/operator/agents/[slug]/_components/TeamsTargetPicker.tsx
@@ -132,9 +132,14 @@ export function TeamsTargetPicker({
           items.map((team) => ({ id: team.id, label: team.displayName }))
         }
         kindOf={() => 'team'}
-        unavailableText={(reason) =>
-          t(`unavailable.teams.${reason}`, { scope: 'Chat.ReadBasic' })
-        }
+        // NO SCOPE ARGUMENT HERE, and that is the fix rather than an omission:
+        // team enumeration is app-only, so the one sentence that names a scope
+        // (`scope_missing`) can never be about `Chat.ReadBasic` on this half.
+        // Passing it anyway printed the chat permission under the team list
+        // and sent an operator to grant something unrelated. The teams copy
+        // now names no scope at all, because the DTO does not carry which one
+        // was missing and inventing a second guess would repeat the mistake.
+        unavailableText={(reason) => t(`unavailable.teams.${reason}`)}
       />
       <TargetSelect
         label={t('chatsLabel')}

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -2018,7 +2018,8 @@
         "uninstall": "Das Entfernen der App aus einem Team braucht den Microsoft-365-Connector 0.4.0 oder neuer. Der hier installierte Connector ist älter und veröffentlicht keine Deinstallation — aktualisiere das Plugin, oder lass die App von einem Teams-Admin manuell entfernen.",
         "enumerate": "Der Connector kann Installationen nicht auflisten. Diese Ansicht zeigt daher, was der Provisionierungs-Datensatz belegt, nicht den aktuellen Stand in Teams.",
         "multi_team": "Pro Orchestrator wird ein Team geführt. Ein zweites Team würde die erste Installation ungeführt zurücklassen und wird deshalb abgelehnt.",
-        "chat_install": "Die Installation in einen Chat braucht den Microsoft-365-Connector 0.7.0 oder neuer. Der hier installierte Connector ist älter — aktualisiere das Plugin, oder wähle ein Team als Ziel."
+        "chat_install": "Die Installation in einen Chat braucht den Microsoft-365-Connector 0.7.0 oder neuer. Der hier installierte Connector ist älter — aktualisiere das Plugin, oder wähle ein Team als Ziel.",
+        "chat_uninstall": "Das Entfernen der App aus einem Chat braucht den Microsoft-365-Connector 0.7.0 oder neuer. Der hier installierte Connector ist älter — aktualisiere das Plugin, oder lass die App im Chat manuell entfernen."
       },
       "unsupportedTechnical": "Server-Begründung: {detail}",
       "notice": {
@@ -2308,7 +2309,10 @@
           "reason": "Von Microsoft gemeldet: {reason}",
           "next": "Prüfe, ob die Publisher-App des Microsoft-365-Connectors Device-Code-Anmeldungen als öffentlicher Client erlaubt und ob eine Conditional-Access-Richtlinie sie blockiert. Ein erneuter Versuch ändert ohne diese Anpassung nichts."
         },
-        "rsc_permissions_mismatch": "Microsoft Graph hat die Installation abgelehnt: Das Teams-App-Paket dieses Orchestrators fordert ressourcenspezifische Berechtigungen, die die installierende Identität nicht erteilen darf. Die Ziel-ID ist korrekt — es fehlt eine Rolle. Weise der Entra-App des M365-Connectors die Rolle TeamsAppInstallation.ReadWriteAndConsentForTeam.All (Team) bzw. …ForChat.All (Chat) zu, erteile die Admin-Zustimmung und starte die Provisionierung erneut."
+        "rsc_permissions_mismatch": {
+          "what": "Microsoft Graph hat die Installation abgelehnt: Das Teams-App-Paket dieses Orchestrators fordert ressourcenspezifische Berechtigungen, die die installierende Identität nicht erteilen darf. Die Ziel-ID ist korrekt — es fehlt eine Rolle.",
+          "next": "Weise der Entra-App des M365-Connectors die Rolle TeamsAppInstallation.ReadWriteAndConsentForTeam.All (Team) bzw. …ForChat.All (Chat) zu, erteile die Admin-Zustimmung und starte die Provisionierung erneut."
+        }
       },
       "teamsBot": {
         "heading": "Konfiguration für das Teams-Channel-Plugin",
@@ -2357,7 +2361,7 @@
           "connector_unavailable": "Ohne aktiven M365-Connector gibt es keine Teamliste — trage die ID unten von Hand ein.",
           "connector_unsupported": "Der installierte Connector kann keine Teams auflisten. Nach einem Upgrade erscheint hier eine Auswahl; bis dahin trage die ID unten ein.",
           "sign_in_required": "Für die Teamliste fehlt die Tenant-Anmeldung. Melde dich einmal an oder trage die ID unten ein.",
-          "scope_missing": "Die gespeicherte Anmeldung kennt die Berechtigung {scope} noch nicht. Eine erneute Anmeldung schaltet die Liste frei.",
+          "scope_missing": "Die gespeicherte Anmeldung kennt eine Berechtigung nicht, die für die Teamliste nötig ist. Eine erneute Anmeldung schaltet die Liste frei.",
           "consent_required": "Dem Tenant fehlt die Zustimmung zum Auflisten von Teams. Bis dahin trage die ID unten ein.",
           "lookup_failed": "Die Teamliste konnte gerade nicht geladen werden. Lade die Seite neu oder trage die ID unten ein.",
           "sign_in_expired": "Die Tenant-Anmeldung ist abgelaufen und ließ sich nicht automatisch erneuern. Melde dich einmal neu an oder trage die ID unten ein."
@@ -2396,6 +2400,7 @@
         "catalog_removed": "Katalogeintrag",
         "bot_deleted": "Azure-Bot",
         "app_deleted": "App-Registrierung",
+        "config_unsynced": "Teams-Bot-Eintrag",
         "identity_reset": "Datenbankzeile",
         "identity_deleted": "Identität"
       },
@@ -2414,6 +2419,8 @@
         "app_absent_unpurgeable": "Die App-Registrierung ist bereits weg, ließ sich aber nicht mehr im Papierkorb nachschlagen. Sie könnte den Namen noch bis zu 30 Tage belegen — wähle im Zweifel einen anderen Bot-Slug.",
         "app_provably_gone": "Die App-Registrierung ist weg und liegt auch nicht im Papierkorb — der Name ist wieder frei.",
         "arm_not_configured": "Ohne ARM-Konfiguration wurde nie ein Bot-Dienst angelegt.",
+        "config_unsync_unavailable": "Diese Installation schreibt den teams_bots-Eintrag nicht automatisch — es gab also auch keinen, den das Zurücksetzen entfernen müsste.",
+        "config_plugin_not_installed": "Der Teams-Channel ist nicht installiert, es gibt also keine Konfiguration aufzuräumen.",
         "tenant_sign_in_expired": "Die Tenant-Anmeldung ist abgelaufen und ließ sich nicht automatisch erneuern. Melde dich einmal neu an und starte das Zurücksetzen erneut — eine zusätzliche Berechtigung ist dafür nicht nötig.",
         "app_trace_required": "Die Identität bleibt bestehen: Die App-Registrierung ließ sich nicht im Papierkorb nachschlagen, und die Zeile ist die einzige Spur zu ihr. Nutze „Lauf zurücksetzen“ oder aktualisiere den Connector, damit der Papierkorb geprüft werden kann."
       },

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -2018,7 +2018,8 @@
         "uninstall": "Removing the app from a team needs Microsoft 365 connector 0.4.0 or newer. The connector installed here is older and publishes no uninstall — upgrade the plugin, or have a Teams administrator remove the app manually.",
         "enumerate": "The connector cannot list installs, so this view reports what the provisioning record proves rather than what Teams currently holds.",
         "multi_team": "One orchestrator is tracked in one team. Assigning a second team would leave the first install untracked, so it is refused.",
-        "chat_install": "Installing into a chat needs the Microsoft 365 connector 0.7.0 or newer. The connector installed here is older — update the plugin, or choose a team as the target."
+        "chat_install": "Installing into a chat needs the Microsoft 365 connector 0.7.0 or newer. The connector installed here is older — update the plugin, or choose a team as the target.",
+        "chat_uninstall": "Removing the app from a chat needs the Microsoft 365 connector 0.7.0 or newer. The connector installed here is older — update the plugin, or remove the app inside the chat manually."
       },
       "unsupportedTechnical": "Server reason: {detail}",
       "notice": {
@@ -2308,7 +2309,10 @@
           "reason": "Reported by Microsoft: {reason}",
           "next": "Check that the Microsoft 365 connector's publisher app allows device-code sign-ins as a public client, and that no Conditional Access policy blocks them. Retrying changes nothing without that adjustment."
         },
-        "rsc_permissions_mismatch": "Microsoft Graph refused the install: this orchestrator’s Teams app package declares resource-specific permissions the installing identity may not consent to. The target id is correct — a role is missing. Grant the M365 connector’s Entra app the role TeamsAppInstallation.ReadWriteAndConsentForTeam.All (team) or …ForChat.All (chat), admin-consent it, then re-run provisioning."
+        "rsc_permissions_mismatch": {
+          "what": "Microsoft Graph refused the install: this orchestrator’s Teams app package declares resource-specific permissions the installing identity may not consent to. The target id is correct — a role is missing.",
+          "next": "Grant the M365 connector’s Entra app the role TeamsAppInstallation.ReadWriteAndConsentForTeam.All (team) or …ForChat.All (chat), admin-consent it, then re-run provisioning."
+        }
       },
       "teamsBot": {
         "heading": "Teams channel plugin configuration",
@@ -2357,7 +2361,7 @@
           "connector_unavailable": "Without an active M365 connector there is no team list — type the id into the field below.",
           "connector_unsupported": "The installed connector cannot list teams. A list appears here after an upgrade; until then type the id below.",
           "sign_in_required": "The team list needs the tenant sign-in. Sign in once, or type the id below.",
-          "scope_missing": "The stored sign-in does not yet carry the {scope} permission. Signing in again unlocks the list.",
+          "scope_missing": "The stored sign-in is missing a permission the team list needs. Signing in again unlocks the list.",
           "consent_required": "The tenant has not consented to listing teams. Until it does, type the id below.",
           "lookup_failed": "The team list could not be loaded just now. Reload the page, or type the id below.",
           "sign_in_expired": "The tenant sign-in expired and could not be renewed automatically. Sign in once more, or type the id below."
@@ -2396,6 +2400,7 @@
         "catalog_removed": "Catalog entry",
         "bot_deleted": "Azure bot",
         "app_deleted": "App registration",
+        "config_unsynced": "Teams bot entry",
         "identity_reset": "Database row",
         "identity_deleted": "Identity"
       },
@@ -2414,6 +2419,8 @@
         "app_absent_unpurgeable": "The app registration is already gone but could no longer be looked up in the recycle bin. It may still hold the name for up to 30 days — pick a different bot slug if in doubt.",
         "app_provably_gone": "The app registration is gone and is not in the recycle bin either — the name is free again.",
         "arm_not_configured": "Without ARM configured, no bot service was ever created.",
+        "config_unsync_unavailable": "This deployment does not write the teams_bots entry automatically, so there was none for the reset to remove.",
+        "config_plugin_not_installed": "The Teams channel is not installed, so there is no configuration to clean up.",
         "tenant_sign_in_expired": "The tenant sign-in expired and could not be renewed automatically. Sign in once more and start the reset again — no extra permission is needed for it.",
         "app_trace_required": "The identity is kept: the app registration could not be looked up in the recycle bin, and this row is the only trace of it. Use \"reset the run\", or upgrade the connector so the recycle bin can be searched."
       },


### PR DESCRIPTION
Six defects left standing after epic #860, chosen because they share one shape:
the operator acts, the system confirms, and nothing happens.

  * A CHAT install could not be removed. The DELETE route handed every
    recorded id to `uninstallFromTeam`, so a `19:…@thread.v2` conversation was
    addressed as `/teams/{id}/installedApps` and Graph refused it. Group chats
    are a primary use case, which made those installs permanent. The route now
    branches on the recorded `target_kind` and calls `uninstallFromChat`, with
    its own capability flag (`chat_uninstall`) and its own 501 — one flag for
    both directions has to lie about one of them.

  * A reset left the bot configured. The chain writes the channel-teams
    `teams_bots` entry automatically (#910); the teardown never took it back
    out, so a "full reset" left the plugin holding a bot whose Entra
    registration had just been purged. New `config_unsynced` step, after the
    registration is gone and before the row — and the ONE step allowed to fail
    without halting, because a stale config entry is strictly less damage than
    a row pointing at a deleted app.

  * `agents.context_memory` switched nothing. The value was persisted, read
    back, echoed by the API and rendered in the UI, then dropped at the field
    list that builds the agent — every agent ran the `off` default. Forwarded
    now, and a flip rebuilds the agent, or it would only take effect at the
    next unrelated change.

  * Nudge state was shared by every agent. The store keys cooldowns and
    follow-ups on `(agentId, nudgeId)`, and the agent id was the literal
    `'orchestrator'`, so one agent's nudge silenced another's.

  * An operator could point `28:<appId>` at a foreign agent. The bot's
    identity decides the routing, so the binding was written, confirmed and
    ignored. Refused with 409 now, naming the agent that owns the bot;
    re-binding to that same agent still works.

  * `rsc_permissions_mismatch` rendered its own key path. The panel resolves
    `errors.<code>.what` and `.next` for every code; this one shipped as a
    flat string, which both catalogue gates were happy with. Split, plus a
    guard that asks the question the renderer asks.

Not touched, deliberately: `agents.privacy_profile` is read, diffed and
rebuilt on, and nothing consumes it — but nothing ever defined what `strict`
should DO, and inventing a meaning is a product decision, not a bug fix.

Verification: middleware build, typecheck, typecheck:test (ratchet 370, no
regressions) and lint clean; 8213 tests, 8197 pass, 0 fail. web-ui typecheck,
lint, i18n:check (4374 keys) clean; 1140 tests pass.

Neutralising each fix turns its own tests red — proven for the context-memory
forwarding (2 of 4), the chat branch (2 of 100) and the i18n guard (1 of 3).

Refs #860.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790833706&installation_model_id=428086&pr_number=977&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F977&signature=9f8e9849357af3c143cc6863a3547415c5f39810dbe635755a7555a77fa5291d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->