### PR TITLE
perf: cache C1 results per turn — and stop retrying a dead sidecar

### DIFF
--- a/middleware/packages/harness-plugin-privacy-guard/src/service.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/service.ts
@@ -32,6 +32,7 @@ import type {
   PrivacyV4ToolSpec,
   PromptMaskedSpanInfo,
   PromptPiiDetector,
+  PromptPiiSpan,
 } from '@omadia/plugin-api';
 
 import { createDatasetStore } from './v4/datasetStore.js';
@@ -253,6 +254,50 @@ export function createPrivacyGuardService(deps?: {
   // ingested attachment tail) so surrogates stay stable; inverted over the
   // final answer by `restorePromptPseudonyms`; dropped by `finalizeTurn`.
   const promptMaskMaps = new Map<string, PseudonymMap>();
+
+  // #977 — per-turn C1 result cache, keyed by the exact text.
+  //
+  // A single turn calls `maskUserPrompt` roughly a dozen times over
+  // overlapping text: the user message, live chat history, ingested
+  // attachment text, recalled prior context, plus the fact-extraction,
+  // routing and excerpt passes. Each call used to hit the sidecar again for
+  // text it had already classified. Measured on the live instance, one
+  // 2.6 KB turn spent ~20 s that way at ~2.3 s per identical call.
+  //
+  // Two reasons this is safe to memoize: the detector is deterministic for
+  // a given (text, labels, threshold), and the labels/threshold are fixed
+  // per detector instance — so the text alone is a complete key.
+  //
+  // FAILURES are cached too, and that is the more important half. C1's
+  // timeout is 15 s (deliberately generous, see c1Detector.ts); without
+  // this, an unreachable sidecar would make a turn burn twelve consecutive
+  // 15 s timeouts — three minutes of wall clock to produce exactly the C0
+  // fallback it reached after the first one. Fail once, degrade once.
+  //
+  // Scoped PER TURN and dropped by `finalizeTurn`, like `promptMaskMaps`:
+  // cached spans carry real PII values, so they must not outlive the turn
+  // that produced them or be reachable from another user's turn.
+  type C1CacheEntry =
+    | { ok: true; spans: readonly PromptPiiSpan[] }
+    | { ok: false };
+  const c1Cache = new Map<string, Map<string, C1CacheEntry>>();
+  const c1CacheGet = (
+    turnId: string,
+    text: string,
+  ): C1CacheEntry | undefined => c1Cache.get(turnId)?.get(text);
+  const c1CacheSet = (
+    turnId: string,
+    text: string,
+    entry: C1CacheEntry,
+  ): void => {
+    let perTurn = c1Cache.get(turnId);
+    if (perTurn === undefined) {
+      perTurn = new Map<string, C1CacheEntry>();
+      c1Cache.set(turnId, perTurn);
+    }
+    perTurn.set(text, entry);
+  };
+
   // #760 — per-service fingerprint cache for the operator deny-list detector.
   const resolveCustomDetector = makeCustomDetectorResolver();
   // Slice 2 — cached, Haiku-backed schema PII classifier. Process-scoped
@@ -536,15 +581,29 @@ export function createPrivacyGuardService(deps?: {
         // baseline down with it (tier-1 degrade, audited); its spans are
         // memoized into a pass-through detector for the mask pass.
         const c1 = deps.c1Detector;
-        try {
-          const c1Spans = await c1.detect(request.text);
-          detectors.push({ id: c1.id, detect: async () => c1Spans });
-        } catch (err) {
-          degraded = true;
-          console.warn(
-            `[privacy-guard v4] promptMaskDegraded turn=${request.turnId} ` +
-              `detector=${c1.id}: ${err instanceof Error ? err.message : String(err)}`,
-          );
+        const cached = c1CacheGet(request.turnId, request.text);
+        if (cached !== undefined) {
+          if (cached.ok) {
+            detectors.push({ id: c1.id, detect: async () => cached.spans });
+          } else {
+            // A failure earlier in THIS turn. Do not retry: with a dead
+            // sidecar each attempt burns the full timeout, and a turn makes
+            // roughly a dozen mask calls.
+            degraded = true;
+          }
+        } else {
+          try {
+            const c1Spans = await c1.detect(request.text);
+            c1CacheSet(request.turnId, request.text, { ok: true, spans: c1Spans });
+            detectors.push({ id: c1.id, detect: async () => c1Spans });
+          } catch (err) {
+            degraded = true;
+            c1CacheSet(request.turnId, request.text, { ok: false });
+            console.warn(
+              `[privacy-guard v4] promptMaskDegraded turn=${request.turnId} ` +
+                `detector=${c1.id}: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
         }
       }
       try {
@@ -659,6 +718,9 @@ export function createPrivacyGuardService(deps?: {
       // #361 — drop the prompt-surrogate map. `restorePromptPseudonyms`
       // must have run over the final answer before this point.
       promptMaskMaps.delete(turnId);
+      // #977 — cached C1 spans carry real PII values; drop them with the
+      // rest of the turn's server-side state.
+      c1Cache.delete(turnId);
       const accum = receipts.get(turnId);
       receipts.delete(turnId);
       const piiValues = turnPiiValues.get(turnId);

--- a/middleware/test/privacyPromptMask.test.ts
+++ b/middleware/test/privacyPromptMask.test.ts
@@ -575,6 +575,116 @@ describe('PrivacyGuardService.maskUserPrompt', () => {
     if (result.outcome !== 'masked') return;
     assert.equal(result.degraded, false);
   });
+
+  /**
+   * #977 — a turn calls maskUserPrompt roughly a dozen times over
+   * overlapping text (message, priorTurns, ingested attachment, recalled
+   * context, fact-extraction/routing/excerpt passes). Each call used to hit
+   * the sidecar again for text it had already classified: measured, one
+   * 2.6 KB turn spent ~20 s at ~2.3 s per identical call.
+   */
+  describe('per-turn C1 result cache', () => {
+    function countingC1(): { detector: PromptPiiDetector; calls: () => number } {
+      let calls = 0;
+      return {
+        detector: {
+          id: 'c1-counting',
+          detect: async () => {
+            calls += 1;
+            return [];
+          },
+        },
+        calls: () => calls,
+      };
+    }
+
+    it('calls the sidecar once for repeated identical text in one turn', async () => {
+      const c1 = countingC1();
+      const svc = createPrivacyGuardService({
+        readConfig: () => 'on',
+        c1Detector: c1.detector,
+      });
+      for (let i = 0; i < 5; i += 1) {
+        await svc.maskUserPrompt!(req('t-cache'));
+      }
+      assert.equal(c1.calls(), 1, 'identical text must hit the sidecar once');
+    });
+
+    it('still calls the sidecar for DIFFERENT text in the same turn', async () => {
+      const c1 = countingC1();
+      const svc = createPrivacyGuardService({
+        readConfig: () => 'on',
+        c1Detector: c1.detector,
+      });
+      await svc.maskUserPrompt!({
+        sessionId: 's',
+        turnId: 't-diff',
+        text: 'Anna Schmidt schreibt.',
+      });
+      await svc.maskUserPrompt!({
+        sessionId: 's',
+        turnId: 't-diff',
+        text: 'Bob Miller ruft an.',
+      });
+      assert.equal(c1.calls(), 2);
+    });
+
+    /**
+     * The important half. C1's timeout is 15 s; without caching failures, an
+     * unreachable sidecar makes one turn burn a dozen consecutive timeouts —
+     * three minutes of wall clock to reach the same C0 fallback the first
+     * attempt already reached.
+     */
+    it('retries a failed sidecar at most once per turn', async () => {
+      let calls = 0;
+      const failing: PromptPiiDetector = {
+        id: 'c1-dead',
+        detect: async () => {
+          calls += 1;
+          throw new Error('sidecar timed out after 15000ms');
+        },
+      };
+      const svc = createPrivacyGuardService({
+        readConfig: () => 'on',
+        c1Detector: failing,
+      });
+      for (let i = 0; i < 6; i += 1) {
+        const r = await svc.maskUserPrompt!(req('t-dead'));
+        assert.equal(r.outcome, 'masked');
+        if (r.outcome !== 'masked') return;
+        // Every call still reports the degrade honestly.
+        assert.equal(r.degraded, true, `call ${String(i)} must stay degraded`);
+      }
+      assert.equal(calls, 1, 'a dead sidecar must be attempted once per turn');
+    });
+
+    it('does not reuse one turn cache for another turn', async () => {
+      const c1 = countingC1();
+      const svc = createPrivacyGuardService({
+        readConfig: () => 'on',
+        c1Detector: c1.detector,
+      });
+      await svc.maskUserPrompt!(req('t-a'));
+      await svc.maskUserPrompt!(req('t-b'));
+      assert.equal(c1.calls(), 2, 'cache must be scoped per turn');
+    });
+
+    it('drops cached spans at finalizeTurn (they carry real PII)', async () => {
+      const c1 = countingC1();
+      const svc = createPrivacyGuardService({
+        readConfig: () => 'on',
+        c1Detector: c1.detector,
+      });
+      await svc.maskUserPrompt!(req('t-fin'));
+      await svc.finalizeTurn('t-fin');
+      await svc.maskUserPrompt!(req('t-fin'));
+      assert.equal(
+        c1.calls(),
+        2,
+        'after finalizeTurn the cache must be gone, not silently reused',
+      );
+    });
+  });
 });
 
 describe('PrivacyTurnHandle prompt-mask delegation', () => {


### PR DESCRIPTION
## The measurement

Verifying #976 on the live instance, a 2.6 KB turn took **19.9 s**, and the privacy receipt read:

```
SPANS: {"c1-gliner/person":12, "c0-regex/email":3, "c0-regex/phone":3, "c0-regex/date":5}
```

Twelve person spans in a text containing exactly **one** person. Queried directly, the sidecar returns precisely one span (`Andre Derjagin`, 0.997, 2298 ms) — no false positives.

So the twelve are twelve **calls**. One turn invokes `maskUserPrompt` roughly a dozen times over overlapping text: the user message, live chat history, ingested attachment text, recalled prior context, plus the fact-extraction, routing and excerpt passes. Each hit the sidecar again for text it had already classified — twelve correct maskings of the same name, paid for twelve times.

## The fix

Cache per turn, keyed by the exact text. Safe to memoize: the detector is deterministic for a given `(text, labels, threshold)`, and labels/threshold are fixed per detector instance, so the text alone is a complete key.

## The important half: cached failures

This closes a regression **#976 introduced**. Raising C1's timeout from 1.5 s to 15 s was right for correctness — but it meant an unreachable sidecar now cost a turn **twelve consecutive 15 s timeouts**: three minutes of wall clock to arrive at exactly the C0 fallback the first attempt already reached.

| Sidecar state | before #976 | after #976 | with this PR |
|---|---|---|---|
| healthy, 2.6 KB turn | fast, but degraded to C0 (useless) | ~20 s, correct | **~2.3 s, correct** |
| unreachable | ~18 s | **~180 s** | ~15 s (one attempt) |

Every call still reports `degraded: true` honestly — the cache suppresses the retry, not the audit.

## Scoping is deliberate

The cache is per-turn state, dropped by `finalizeTurn` alongside `promptMaskMaps`. Cached spans carry **real PII values**, so they must not outlive the turn that produced them or be reachable from another user's turn. A process-wide cache would be faster still and is exactly the wrong trade here.

## Test plan

- [x] `npm test` (middleware) — **8224 tests, 0 fail**, 16 pre-existing skips
- [x] Identical text hits the sidecar **once** per turn
- [x] Different text in the same turn still calls it
- [x] A dead sidecar is attempted **once per turn**, while all six calls keep reporting `degraded: true`
- [x] Caches do not cross turn boundaries
- [x] `finalizeTurn` really drops them (a later call re-fetches rather than silently reusing PII)
- [ ] After deploy: same 2.6 KB turn should show one `c1-gliner` sidecar call and a turn time in the low seconds

## Follows

#973, #974, #976.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790837380&installation_model_id=428086&pr_number=979&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F979&signature=1760c0cdd7b6e4d54235c4b49e1e83af198e4867911cb615abf96848b9f19ec8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->