### PR TITLE
fix: latch the C1 degrade per turn, not per text

### DIFF
--- a/middleware/packages/harness-plugin-privacy-guard/src/service.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/service.ts
@@ -255,47 +255,53 @@ export function createPrivacyGuardService(deps?: {
   // final answer by `restorePromptPseudonyms`; dropped by `finalizeTurn`.
   const promptMaskMaps = new Map<string, PseudonymMap>();
 
-  // #977 — per-turn C1 result cache, keyed by the exact text.
+  // #979 / #980 — per-turn C1 state. TWO mechanisms, because the two things
+  // being avoided have different keys.
   //
-  // A single turn calls `maskUserPrompt` roughly a dozen times over
-  // overlapping text: the user message, live chat history, ingested
-  // attachment text, recalled prior context, plus the fact-extraction,
-  // routing and excerpt passes. Each call used to hit the sidecar again for
-  // text it had already classified. Measured on the live instance, one
-  // 2.6 KB turn spent ~20 s that way at ~2.3 s per identical call.
+  // A single turn calls `maskUserPrompt` roughly a dozen times: the user
+  // message, each prior turn, ingested attachment text, recalled context,
+  // plus the fact-extraction, routing and excerpt passes. #979 assumed those
+  // passes largely repeat the SAME text and cached results keyed by text.
+  // Measured after deploying it, the turn time did not move (20.0 s vs
+  // 19.9 s): the passes carry DIFFERENT text, so a text-keyed cache almost
+  // always misses. It is kept — repeats do happen, and a hit is free — but
+  // it is not the thing that matters.
   //
-  // Two reasons this is safe to memoize: the detector is deterministic for
-  // a given (text, labels, threshold), and the labels/threshold are fixed
-  // per detector instance — so the text alone is a complete key.
+  // What matters is the failure path, and #979 got its key wrong. C1's
+  // timeout is 15 s (deliberately generous, see c1Detector.ts). A sidecar
+  // that is DOWN is down for every text, so keying the "already failed"
+  // memo by text meant a dozen distinct texts each paid a fresh 15 s
+  // timeout: ~3 minutes of wall clock to reach the C0 fallback the first
+  // attempt already reached. Before the timeout was raised the same failure
+  // cost 18 s, so that was a regression, and the text-keyed memo did not
+  // close it.
   //
-  // FAILURES are cached too, and that is the more important half. C1's
-  // timeout is 15 s (deliberately generous, see c1Detector.ts); without
-  // this, an unreachable sidecar would make a turn burn twelve consecutive
-  // 15 s timeouts — three minutes of wall clock to produce exactly the C0
-  // fallback it reached after the first one. Fail once, degrade once.
+  // Hence a per-TURN latch: the first failure marks the turn degraded and
+  // every later call in it skips the network entirely. Correctness is
+  // unaffected — those calls degrade to C0 exactly as they would have after
+  // waiting, and each still reports `degraded: true` honestly.
   //
-  // Scoped PER TURN and dropped by `finalizeTurn`, like `promptMaskMaps`:
-  // cached spans carry real PII values, so they must not outlive the turn
-  // that produced them or be reachable from another user's turn.
-  type C1CacheEntry =
-    | { ok: true; spans: readonly PromptPiiSpan[] }
-    | { ok: false };
-  const c1Cache = new Map<string, Map<string, C1CacheEntry>>();
+  // Both structures are per-turn state dropped by `finalizeTurn`, like
+  // `promptMaskMaps`: cached spans carry real PII values, so they must not
+  // outlive the turn that produced them or be reachable from another user's
+  // turn.
+  const c1Cache = new Map<string, Map<string, readonly PromptPiiSpan[]>>();
+  const c1FailedTurns = new Set<string>();
   const c1CacheGet = (
     turnId: string,
     text: string,
-  ): C1CacheEntry | undefined => c1Cache.get(turnId)?.get(text);
+  ): readonly PromptPiiSpan[] | undefined => c1Cache.get(turnId)?.get(text);
   const c1CacheSet = (
     turnId: string,
     text: string,
-    entry: C1CacheEntry,
+    spans: readonly PromptPiiSpan[],
   ): void => {
     let perTurn = c1Cache.get(turnId);
     if (perTurn === undefined) {
-      perTurn = new Map<string, C1CacheEntry>();
+      perTurn = new Map<string, readonly PromptPiiSpan[]>();
       c1Cache.set(turnId, perTurn);
     }
-    perTurn.set(text, entry);
+    perTurn.set(text, spans);
   };
 
   // #760 — per-service fingerprint cache for the operator deny-list detector.
@@ -582,26 +588,26 @@ export function createPrivacyGuardService(deps?: {
         // memoized into a pass-through detector for the mask pass.
         const c1 = deps.c1Detector;
         const cached = c1CacheGet(request.turnId, request.text);
-        if (cached !== undefined) {
-          if (cached.ok) {
-            detectors.push({ id: c1.id, detect: async () => cached.spans });
-          } else {
-            // A failure earlier in THIS turn. Do not retry: with a dead
-            // sidecar each attempt burns the full timeout, and a turn makes
-            // roughly a dozen mask calls.
-            degraded = true;
-          }
+        if (c1FailedTurns.has(request.turnId)) {
+          // C1 already failed once in THIS turn. A down sidecar is down for
+          // every text, so retrying only buys another full timeout — a dozen
+          // of which is ~3 minutes for the C0 result the first attempt
+          // already produced. Degrade immediately, still audited below.
+          degraded = true;
+        } else if (cached !== undefined) {
+          detectors.push({ id: c1.id, detect: async () => cached });
         } else {
           try {
             const c1Spans = await c1.detect(request.text);
-            c1CacheSet(request.turnId, request.text, { ok: true, spans: c1Spans });
+            c1CacheSet(request.turnId, request.text, c1Spans);
             detectors.push({ id: c1.id, detect: async () => c1Spans });
           } catch (err) {
             degraded = true;
-            c1CacheSet(request.turnId, request.text, { ok: false });
+            c1FailedTurns.add(request.turnId);
             console.warn(
               `[privacy-guard v4] promptMaskDegraded turn=${request.turnId} ` +
-                `detector=${c1.id}: ${err instanceof Error ? err.message : String(err)}`,
+                `detector=${c1.id}: ${err instanceof Error ? err.message : String(err)} ` +
+                `(C1 disabled for the remainder of this turn)`,
             );
           }
         }
@@ -718,9 +724,12 @@ export function createPrivacyGuardService(deps?: {
       // #361 — drop the prompt-surrogate map. `restorePromptPseudonyms`
       // must have run over the final answer before this point.
       promptMaskMaps.delete(turnId);
-      // #977 — cached C1 spans carry real PII values; drop them with the
-      // rest of the turn's server-side state.
+      // #979 — cached C1 spans carry real PII values; drop them with the
+      // rest of the turn's server-side state. The degrade latch goes too, so
+      // the next turn gets a fresh attempt at a sidecar that may have
+      // recovered.
       c1Cache.delete(turnId);
+      c1FailedTurns.delete(turnId);
       const accum = receipts.get(turnId);
       receipts.delete(turnId);
       const piiValues = turnPiiValues.get(turnId);

--- a/middleware/test/privacyPromptMask.test.ts
+++ b/middleware/test/privacyPromptMask.test.ts
@@ -658,6 +658,74 @@ describe('PrivacyGuardService.maskUserPrompt', () => {
       assert.equal(calls, 1, 'a dead sidecar must be attempted once per turn');
     });
 
+    /**
+     * #980 — the case #979 got wrong, and the reason its measured effect was
+     * zero. A turn's dozen mask passes carry DIFFERENT text (the message,
+     * each prior turn, ingested attachment, recalled context, …), so keying
+     * the "already failed" memo by text meant every distinct text paid a
+     * fresh 15 s timeout: ~3 minutes to reach the C0 answer the first
+     * attempt already had. The latch is per TURN, because a down sidecar is
+     * down for every text.
+     */
+    it('does not retry a dead sidecar for DIFFERENT text in the same turn', async () => {
+      let calls = 0;
+      const failing: PromptPiiDetector = {
+        id: 'c1-dead',
+        detect: async () => {
+          calls += 1;
+          throw new Error('sidecar timed out after 15000ms');
+        },
+      };
+      const svc = createPrivacyGuardService({
+        readConfig: () => 'on',
+        c1Detector: failing,
+      });
+      // Distinct texts, exactly as the real mask passes produce.
+      for (const text of [
+        'Anna Schmidt schreibt aus Berlin.',
+        'Bob Miller ruft aus London an.',
+        'Carla Rossi mailt aus Rom.',
+        'Dieter Fuchs faxt aus Wien.',
+      ]) {
+        const r = await svc.maskUserPrompt!({ sessionId: 's', turnId: 't-dead-multi', text });
+        assert.equal(r.outcome, 'masked');
+        if (r.outcome !== 'masked') return;
+        assert.equal(r.degraded, true);
+      }
+      assert.equal(
+        calls,
+        1,
+        'the degrade latch is per turn, not per text — otherwise each text pays a full timeout',
+      );
+    });
+
+    it('gives a recovered sidecar a fresh attempt on the next turn', async () => {
+      let calls = 0;
+      let broken = true;
+      const flaky: PromptPiiDetector = {
+        id: 'c1-flaky',
+        detect: async () => {
+          calls += 1;
+          if (broken) throw new Error('down');
+          return [];
+        },
+      };
+      const svc = createPrivacyGuardService({
+        readConfig: () => 'on',
+        c1Detector: flaky,
+      });
+      await svc.maskUserPrompt!(req('t-1'));
+      await svc.maskUserPrompt!(req('t-1')); // latched, no second call
+      assert.equal(calls, 1);
+      await svc.finalizeTurn('t-1');
+      broken = false;
+      const r = await svc.maskUserPrompt!(req('t-2'));
+      assert.equal(calls, 2, 'a new turn must try again');
+      assert.equal(r.outcome, 'masked');
+      if (r.outcome !== 'masked') return;
+      assert.equal(r.degraded, false, 'a recovered sidecar must stop reporting degraded');
+    });
+
     it('does not reuse one turn cache for another turn', async () => {
       const c1 = countingC1();
       const svc = createPrivacyGuardService({


### PR DESCRIPTION
## What #979 claimed, and what it actually did

#979 cached C1 results per turn, keyed by the exact prompt text, on the assumption that a turn's ~12 mask passes largely repeat the same text. It predicted a turn going from ~20 s to ~2.3 s.

Measured on the live instance after deploying it:

| | before #979 | after #979 |
|---|---|---|
| 2.6 KB turn | 19.9 s | **20.0 s** |
| `c1-gliner/person` spans | 12 | 12 |

No change. The assumption was wrong: those passes carry **different** text — the user message, each prior turn separately, ingested attachment text, recalled context, plus the fact-extraction, routing and excerpt passes. A text-keyed cache almost always misses, and the ~20 s is genuine C1 work over a dozen distinct inputs.

**That part is not cacheable, and this PR does not pretend to fix it.** #979's "~2.3 s" was never measured; it was an expectation stated as a result.

## What the wrong key actually broke

The failure path — which was the half that mattered.

C1's timeout is 15 s. A sidecar that is **down is down for every text**, but #979 memoised "already failed" *by text*. So each of a dozen distinct texts paid its own fresh 15 s timeout: roughly **three minutes** of wall clock to arrive at the C0 fallback the very first attempt already produced.

Before #976 raised the timeout, that same failure cost 18 s. So the regression #979 set out to close stayed open the whole time.

## The fix

Split the two mechanisms along their real keys:

- **successes** stay keyed by text — a repeat is free when it happens, and the comment now says plainly that repeats are rare;
- **failures** set a per-**turn** latch. The first failure marks the turn degraded; every later pass skips the network entirely.

| Sidecar | before #976 | after #976 | after #979 | this PR |
|---|---|---|---|---|
| healthy, 2.6 KB | fast but C0 (useless) | ~20 s, correct | ~20 s, correct | ~20 s, correct |
| **unreachable** | ~18 s | ~180 s | **~180 s** | **~15 s** |

Correctness is untouched: latched passes degrade to C0 exactly as they would have after waiting out the timeout, and each still reports `degraded: true` honestly. The latch is dropped by `finalizeTurn` alongside the cache, so a recovered sidecar gets a fresh attempt on the next turn.

## Tests that #979's suite missed

- A dead sidecar hit with **four different texts** in one turn must be attempted **once**. This assertion fails against #979 — its per-text memo would allow four calls.
- A sidecar that recovers between turns must be retried and must stop reporting `degraded`.

Full suite: **8226 tests, 0 fail**, 16 pre-existing skips.

## Still open

The ~20 s on the healthy path is real C1 latency across a dozen distinct texts. Reducing it needs a different lever — fewer mask passes, parallel dispatch, or sending C1 less text — not caching. Worth its own issue rather than another guess.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790840787&installation_model_id=428086&pr_number=980&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F980&signature=583cbaa0621553d5636b75e246a07dc94a0fefb7d664d7e01d80baa7b2a85d01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->