### PR TITLE
fix: mask what the turn already knows, even when this pass detects nothing

### DIFF
--- a/middleware/packages/harness-plugin-privacy-guard/src/promptMask.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/promptMask.ts
@@ -575,9 +575,24 @@ export async function maskPrompt(
   }
   const spans = dedupSpans(text, detected);
   if (spans.length === 0) {
+    // NOTHING DETECTED IN *THIS* TEXT IS NOT NOTHING TO MASK.
+    //
+    // The turn's map already holds every real value masked by earlier calls,
+    // and this text may well repeat one of them — a follow-up question naming
+    // the same person, an attachment tail, a retry after the C1 detector
+    // degraded. Returning the raw text here handed that value straight to the
+    // wire, and the service's post-mask assertion (which checks the WHOLE
+    // turn's map) then had to block the turn: correctly, because the value
+    // really was about to leak, but the operator sees only "prompt masking
+    // failed" on a message that looks harmless.
+    //
+    // So the known-value sweep runs even with zero fresh spans. It is the same
+    // sweep as below and it can only ADD masking — it substitutes values this
+    // turn already decided are PII, and never touches anything else.
+    const carried = existingMap ?? { forward: new Map(), reverse: new Map() };
     return {
-      maskedText: text,
-      map: existingMap ?? { forward: new Map(), reverse: new Map() },
+      maskedText: sweepKnownValues(text, carried),
+      map: carried,
       spans,
     };
   }
@@ -595,16 +610,30 @@ export async function maskPrompt(
     if (surrogate === undefined) continue;
     masked = masked.slice(0, span.start) + surrogate + masked.slice(span.end);
   }
-  // Belt and braces: a detected value may occur AGAIN at a position no
-  // detector flagged (e.g. an email repeated mid-sentence in a shape the
-  // regex misses after boundary extension). Sweep every known real value —
-  // including ones from earlier calls this turn via `existingMap` — longest
-  // first, so the service's post-mask `findIdentityLeaks` assertion is a
-  // true invariant, not a coin flip.
+  return { maskedText: sweepKnownValues(masked, map), map, spans };
+}
+
+/**
+ * Replace every real value the turn's map knows about, longest first.
+ *
+ * Belt and braces for the span pass: a detected value may occur AGAIN at a
+ * position no detector flagged (an email repeated mid-sentence in a shape the
+ * regex misses after boundary extension), and a value masked EARLIER in the
+ * turn may reappear in a later text this pass's detectors say nothing about.
+ * Both are the same operation, so both run through this one function — that is
+ * what makes the service's post-mask `findIdentityLeaks` assertion a true
+ * invariant rather than a coin flip.
+ *
+ * Longest first, because a shorter known value may be a substring of a longer
+ * one's surrogate; doing the long ones first leaves the short sweep to clean up
+ * whatever it re-introduced, never the other way round.
+ */
+function sweepKnownValues(text: string, map: PseudonymMap): string {
+  let masked = text;
   for (const [real, surrogate] of [...map.forward.entries()].sort(
     (a, b) => b[0].length - a[0].length,
   )) {
     if (masked.includes(real)) masked = masked.split(real).join(surrogate);
   }
-  return { maskedText: masked, map, spans };
+  return masked;
 }

--- a/middleware/test/privacyPromptMask.test.ts
+++ b/middleware/test/privacyPromptMask.test.ts
@@ -346,6 +346,66 @@ describe('maskPrompt', () => {
     }
     assert.equal(resolvePseudonyms(result.maskedText, result.map), text);
   });
+
+  /**
+   * A LATER CALL IN THE SAME TURN THAT DETECTS NOTHING MUST STILL MASK.
+   *
+   * Observed in production: a Teams turn was refused with "prompt masking
+   * failed (residual PII span survived substitution)" on a message that named
+   * nobody. The name had been masked by an EARLIER call in the same turn, and
+   * this call's detectors found nothing in their own text — so `maskPrompt`
+   * returned early, skipped the known-value sweep, and handed the raw text
+   * back. The service then asserted against the whole turn's map, found the
+   * value, and blocked. The guard was right; the masker had simply not tried.
+   *
+   * Detecting nothing in THIS text is not the same as having nothing to mask,
+   * because the map is turn-scoped. Both directions are pinned: the value gets
+   * substituted, and the post-mask invariant the service relies on holds.
+   */
+  it('applies the turn map even when this pass detects no new spans', async () => {
+    const blind: PromptPiiDetector = { id: 'c1-blind', detect: async () => [] };
+    const seeing: PromptPiiDetector = {
+      id: 'c1-seeing',
+      detect: async (text: string) => {
+        const at = text.indexOf('Marcel Wege');
+        return at === -1
+          ? []
+          : [{ start: at, end: at + 'Marcel Wege'.length, type: 'person', confidence: 0.9 }];
+      },
+    };
+
+    const first = await maskPrompt('Es geht um Marcel Wege!', [seeing]);
+    assert.equal(findIdentityLeaks(first.maskedText, ['Marcel Wege']).length, 0);
+
+    const followUp = 'Und wieviel Urlaub hat Marcel Wege noch?';
+    const second = await maskPrompt(followUp, [blind], first.map);
+
+    assert.equal(second.spans.length, 0, 'this pass genuinely detects nothing');
+    assert.equal(
+      findIdentityLeaks(second.maskedText, [...second.map.forward.keys()]).length,
+      0,
+      'the value masked earlier in the turn must not survive into the wire text',
+    );
+    // The same surrogate as the first call — a turn-stable mapping is the
+    // whole point of threading the map through.
+    assert.equal(
+      second.maskedText,
+      followUp.replace('Marcel Wege', first.map.forward.get('Marcel Wege') ?? '?'),
+    );
+    // And it is reversible, so the operator still reads the real name back.
+    assert.equal(resolvePseudonyms(second.maskedText, second.map), followUp);
+  });
+
+  it('is a no-op when there is no map and nothing to detect', async () => {
+    // The other half: without an existing map the early return must still hand
+    // back byte-identical text, or every clean message would pay for this.
+    const blind: PromptPiiDetector = { id: 'c1-blind', detect: async () => [] };
+    const text = 'Zeig mir alle genehmigten Urlaube dieses Jahr.';
+    const result = await maskPrompt(text, [blind]);
+    assert.equal(result.maskedText, text);
+    assert.equal(result.spans.length, 0);
+    assert.equal(result.map.forward.size, 0);
+  });
 });
 
 describe('C0 locale patterns (#482 — es/fr/nl miss classes)', () => {


### PR DESCRIPTION
A Teams conversation started refusing every message with "privacy protection
for your text could not be guaranteed (prompt masking failed)" — including
messages that named nobody at all. The guard was right to refuse. The masker
had simply not tried.

## What happens

`maskPrompt` returns early when ITS OWN detectors find no span in the text it
was handed:

    const spans = dedupSpans(text, detected);
    if (spans.length === 0) return { maskedText: text, map: existingMap ?? …, spans };

That skips the known-value sweep. But the map is TURN-scoped and threaded
through every call of the turn (`existingMap`), so "nothing detected in this
text" is not "nothing to mask": a follow-up naming the same person, an
attachment tail, or a retry after the C1 transformer degraded all arrive with
values the turn has already masked. The raw text went back, and
`maskUserPrompt`'s post-mask assertion — which checks the WHOLE turn's map —
found the value and blocked the turn.

Both halves were behaving as designed, and together they refused the
conversation. The invariant the service asserts was simply stronger than the
masker's early return.

Reproduced before fixing:

    pass 1 masked: Es geht um <surrogate>!
    pass 2 masked: Und wieviel Urlaub hat <REAL NAME> noch?
    pass 2 spans : 0
    residual     : [ { path: '$', value: '<REAL NAME>' } ]   → turn BLOCKED

## The fix

The sweep runs on the early-return path too, against the map the turn already
holds. It is the same sweep as the span path — now one function,
`sweepKnownValues`, instead of two copies of the loop — so the two paths cannot
drift.

**This only ever ADDS masking.** It substitutes values this turn has already
decided are PII; it cannot expose anything, and a turn with no map and no
detections still returns byte-identical text (pinned by its own test).

## Verification

Both directions are pinned: the earlier value is substituted with the SAME
surrogate (turn-stable mapping is why the map is threaded at all) and stays
reversible, and the no-map case stays a true no-op. Neutralising the sweep call
turns the first test red.

middleware: build, typecheck, `typecheck:test` (ratchet 370, no regressions)
and lint clean; **8221 tests, 8205 pass, 0 fail**.

## Note for operators

`mask_user_prompt` is a privacy-guard setup field and ships default-off. A
deployment hit by this can turn it off for immediate relief without a deploy;
this fix is what makes turning it back on safe.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/981"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790844130&installation_model_id=428086&pr_number=981&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F981&signature=b319e78186bffc4f37aecc4604a304174cbb354ce42a2814051040058a797f5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->