### PR TITLE
fix: let the FIRST Teams provisioning pick a target instead of typing a GUID

### DIFF
--- a/web-ui/app/operator/agents/[slug]/__tests__/AgentTeamsIdentity.test.tsx
+++ b/web-ui/app/operator/agents/[slug]/__tests__/AgentTeamsIdentity.test.tsx
@@ -24,10 +24,11 @@ import { AgentTeamsIdentity } from '../_components/AgentTeamsIdentity';
  *   - Raw API bodies never reach the UI (web-ui i18n hard rule).
  */
 
-const { mockGet, mockProvision, mockResetIdentity } = vi.hoisted(() => ({
+const { mockGet, mockProvision, mockResetIdentity, mockTargets } = vi.hoisted(() => ({
   mockGet: vi.fn(),
   mockProvision: vi.fn(),
   mockResetIdentity: vi.fn(),
+  mockTargets: vi.fn(),
 }));
 
 // Spread the real module so the error-code parser and the last_error narrower
@@ -41,6 +42,10 @@ vi.mock('../../../../_lib/agents', async (importOriginal) => ({
   // network. Its own behaviour is pinned in `AgentTeamsIdentityReset.test.tsx`;
   // what THIS file cares about is what the panel does once the row is gone.
   resetAgentTeamsIdentity: mockResetIdentity,
+  // The create form offers the tenant's teams and chats now, instead of asking
+  // for a GUID from memory. Stubbed here; the picker's own behaviour lives in
+  // `TeamsTargetPicker.test.tsx`.
+  getAgentTeamsTargets: mockTargets,
 }));
 
 function statusDto(
@@ -77,9 +82,23 @@ function apiError(status: number, code: string): ApiError {
   );
 }
 
+/** One team the operator can pick, so the create form has a real choice. */
+const CREATE_TEAM_ID = '2f1a9c44-1f0e-4f2c-8f1a-9c441f0e4f2c';
+
 beforeEach(() => {
   mockGet.mockReset();
   mockProvision.mockReset();
+  mockTargets.mockReset();
+  mockTargets.mockResolvedValue({
+    ok: true,
+    agent: 'sales-bot',
+    provisioner_installed: true,
+    teams: {
+      available: true,
+      items: [{ id: CREATE_TEAM_ID, displayName: 'Acme Team' }],
+    },
+    chats: { available: false, reason: 'sign_in_required' },
+  });
   mockResetIdentity.mockReset();
   mockResetIdentity.mockResolvedValue({
     ok: true,
@@ -105,7 +124,16 @@ describe('AgentTeamsIdentity (#860 W2a)', () => {
     ).toBeTruthy();
     expect(screen.getByLabelText(/Bot slug/)).toBeTruthy();
     expect(screen.getByLabelText(/Display name/)).toBeTruthy();
-    expect(screen.getByLabelText(/Target team ID/)).toBeTruthy();
+    // The FIRST provisioning is where an operator has nothing to copy from, so
+    // it gets the same pick-or-type control as every other target question —
+    // not a bare id field that sends them hunting for a GUID in Teams.
+    expect(screen.getByLabelText(/Target ID/)).toBeTruthy();
+    // …and the tenant's own teams are offered, so the id can be PICKED. The
+    // options themselves live behind the combobox (its behaviour is pinned in
+    // `TeamsTargetPicker.test.tsx`); what matters here is that this panel asks
+    // for the directory at all, which it never used to.
+    expect(await screen.findByText('Pick a team from the list')).toBeTruthy();
+    expect(mockTargets).toHaveBeenCalledWith('sales-bot');
     // "No identity yet" is the form's trigger, not a failure.
     expect(screen.queryByRole('alert')).toBeNull();
   });
@@ -123,16 +151,20 @@ describe('AgentTeamsIdentity (#860 W2a)', () => {
     renderWithIntl(<AgentTeamsIdentity slug="sales-bot" />);
 
     const user = userEvent.setup();
+    // A TEAM, not the `19:…@thread.tacv2` channel id this test used to send:
+    // that is a channel, never an install target, and the shared field now
+    // refuses it here exactly as it always did on the retarget form — which is
+    // the whole point of sharing the control.
     await user.type(
-      await screen.findByLabelText(/Target team ID/),
-      '19:meeting@thread.tacv2',
+      await screen.findByLabelText(/Target ID/),
+      CREATE_TEAM_ID,
     );
     await user.click(screen.getByRole('button', { name: 'Start provisioning' }));
 
     // Empty optional fields are omitted so the server derives them.
     await waitFor(() =>
       expect(mockProvision).toHaveBeenCalledWith('sales-bot', {
-        team_id: '19:meeting@thread.tacv2',
+        team_id: CREATE_TEAM_ID,
       }),
     );
     expect(
@@ -294,7 +326,7 @@ describe('AgentTeamsIdentity (#860 W2a)', () => {
     await user.type(await screen.findByLabelText(/Bot slug/), 'taken-slug');
     // `team_id` is required by the server, so the form requires it too — the
     // submit button stays disabled until it is filled in.
-    await user.type(screen.getByLabelText(/Target team ID/), '19:team-a');
+    await user.type(screen.getByLabelText(/Target ID/), CREATE_TEAM_ID);
     await user.click(screen.getByRole('button', { name: 'Start provisioning' }));
 
     const alert = await screen.findByRole('alert');

--- a/web-ui/app/operator/agents/[slug]/_components/AgentTeamsIdentity.tsx
+++ b/web-ui/app/operator/agents/[slug]/_components/AgentTeamsIdentity.tsx
@@ -11,7 +11,9 @@ import {
   isTerminalTeamsProvisioningState,
   parseTeamsIdentityErrorCode,
   parseTeamsIdentityLastErrorDetail,
+  getAgentTeamsTargets,
   provisionAgentTeamsIdentity,
+  type AgentTeamsTargetsDto,
   type TeamsIdentityStatusDto,
 } from '../../../../_lib/agents';
 import {
@@ -23,7 +25,13 @@ import {
 } from '../../../../_lib/teamsIdentity';
 import { AgentTeamsProvisioningTimeline } from './AgentTeamsProvisioningTimeline';
 import { AgentTeamsIdentityTarget } from './AgentTeamsIdentityTarget';
-import type { TeamsTargetKind } from '@/app/_lib/teamsInstallTarget';
+import { TeamsTargetField } from './TeamsTargetField';
+import {
+  classifyKnownTeamsTarget,
+  isSubmittableTarget,
+  type KnownTeamsTarget,
+  type TeamsTargetKind,
+} from '@/app/_lib/teamsInstallTarget';
 import { humanizeApiError } from '../../_components/AgentsDashboard';
 import {
   Fact,
@@ -113,6 +121,12 @@ export function AgentTeamsIdentity(
   const [botSlug, setBotSlug] = useState('');
   const [displayName, setDisplayName] = useState('');
   const [teamId, setTeamId] = useState('');
+  // The directory's own answer for the id in the field, held next to the value
+  // it describes and dropped the moment that value changes — same contract as
+  // `AgentTeamsIdentityTarget`, because it is the same question.
+  const [known, setKnown] = useState<KnownTeamsTarget | undefined>(undefined);
+  const [targets, setTargets] = useState<AgentTeamsTargetsDto | null>(null);
+  const [targetsLoading, setTargetsLoading] = useState(true);
   const aliveRef = useRef(true);
 
   useEffect(() => {
@@ -121,6 +135,48 @@ export function AgentTeamsIdentity(
       aliveRef.current = false;
     };
   }, []);
+
+  // The tenant's teams and chats, for the CREATE form.
+  //
+  // This panel had the picker everywhere except the one screen where an
+  // operator has nothing yet: the first provisioning asked for a raw
+  // "ZIEL-TEAM-ID" and left them to find a GUID in the Teams client. The
+  // directory is the same one `AgentTeamsIdentityTarget` and
+  // `AgentTeamsInstalls` already load, so this is a missing wire, not a new
+  // capability.
+  //
+  // ONLY WHILE THE CREATE FORM IS ON SCREEN. Enumerating a tenant costs the
+  // connector real Graph calls — hundreds of chats across paged requests — and
+  // a panel showing an identity that already HAS a target has nothing to pick.
+  // That rule predates this change (`AgentTeamsIdentityTarget` mounts only
+  // when it is needed) and is pinned by its own test; loading unconditionally
+  // here would have spent the budget on every visit to every provisioned
+  // agent.
+  //
+  // Fetched once per agent, not per poll: a tenant's teams do not change while
+  // somebody fills in a form, and this panel re-polls every few seconds.
+  const needsTargetDirectory = view.kind === 'absent';
+  useEffect(() => {
+    if (!needsTargetDirectory) return;
+    let cancelled = false;
+    setTargetsLoading(true);
+    void getAgentTeamsTargets(props.slug)
+      .then((dto) => {
+        if (!cancelled) setTargets(dto);
+      })
+      .catch(() => {
+        // Swallowed like the other callers: the text field still works, and an
+        // error banner for a failed convenience would read as though
+        // provisioning itself were broken.
+        if (!cancelled) setTargets(null);
+      })
+      .finally(() => {
+        if (!cancelled) setTargetsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [props.slug, needsTargetDirectory]);
 
   const localizeError = useCallback(
     (err: unknown): string => {
@@ -194,7 +250,14 @@ export function AgentTeamsIdentity(
   // `team_id` is required by the server (TeamsIdentityProvisionSchema), so it
   // is required here too: omitting it produced a guaranteed 400 `invalid_body`
   // and the primary acceptance path never reached 202.
-  const teamIdReady = teamId.trim().length > 0;
+  //
+  // The gate is now the SAME classification the retarget form uses, not a
+  // non-empty check. A channel id (`19:…@thread.tacv2`) is not an install
+  // target, and letting it through here spent five provisioning steps before
+  // Graph answered `404 No team found with Group Id` — the failure the shared
+  // field exists to catch while the operator is still looking at it.
+  const createTarget = classifyKnownTeamsTarget(teamId, known);
+  const teamIdReady = isSubmittableTarget(createTarget);
 
   function submitCreate(event: React.FormEvent): void {
     event.preventDefault();
@@ -203,6 +266,13 @@ export function AgentTeamsIdentity(
       ...(botSlug.trim() ? { bot_slug: botSlug.trim() } : {}),
       ...(displayName.trim() ? { display_name: displayName.trim() } : {}),
       team_id: teamId.trim(),
+      // The kind the DIRECTORY reported, when the id was picked rather than
+      // typed. Without it the middleware re-derives the kind from the id
+      // string and lands on the same wrong answer one hop later — which is
+      // precisely why `target_kind` travels with the id everywhere else.
+      ...(known !== undefined && known.id === teamId
+        ? { target_kind: known.kind }
+        : {}),
     });
   }
 
@@ -277,13 +347,27 @@ export function AgentTeamsIdentity(
             value={displayName}
             onChange={setDisplayName}
           />
-          <TextField
-            label={t('teamsIdentity.fieldTeamId')}
-            hint={t('teamsIdentity.fieldTeamIdHint')}
-            value={teamId}
-            onChange={setTeamId}
-            required
-          />
+          {/* The target is PICKED here, not typed from memory. Same control
+              and same verdict as the retarget form below, so an operator is
+              never told "19:… is a channel id, not an install target" on one
+              screen and allowed to submit it on the other. */}
+          <div className="sm:col-span-3">
+            <TeamsTargetField
+              targets={targets}
+              targetsLoading={targetsLoading}
+              value={teamId}
+              onChange={(next, knownKind) => {
+                setTeamId(next);
+                setKnown(
+                  knownKind === undefined
+                    ? undefined
+                    : { id: next, kind: knownKind },
+                );
+              }}
+              disabled={busy}
+              known={known}
+            />
+          </div>
           <div className="sm:col-span-3">
             <Button
               type="submit"


### PR DESCRIPTION
The Teams identity panel offered the searchable team/chat picker everywhere
except the one screen where an operator has nothing to copy from: the create
form asked for a raw "Ziel-Team-ID" and left them to hunt a GUID in the Teams
client. The control already existed — `TeamsTargetField`, shared by the
retarget form and the installs panel — it was simply never wired into the
first step.

Two consequences, and the second is the one that cost real time:

  * the id had to be found by hand, on the screen where the operator is least
    likely to know where to look;
  * the create form gated submit on "not empty" while every other target
    question gated on the CLASSIFICATION. A channel id (`19:…@thread.tacv2`)
    sailed through here and failed five provisioning steps later with Graph's
    `404 No team found with Group Id` — the exact failure the shared field
    exists to catch while the operator is still looking at the field. The old
    test even encoded that id as its fixture.

`target_kind` now travels with a PICKED id, as it already does everywhere
else. Without it the middleware re-derives the kind from the id string and
lands on the same wrong answer one hop later.

## The directory is not loaded for free

Enumerating a tenant costs the connector real Graph calls — hundreds of chats
across paged requests — so the fetch is gated on the create form actually being
on screen. That rule is not new: `AgentTeamsIdentityTarget` mounts only when
needed, and `AgentTeamsIdentity.restart.test.tsx` pins it ("does not enumerate
the tenant for an identity that needs no target"). The first version of this
change loaded unconditionally and that test caught it — it would have spent the
budget on every visit to every provisioned agent.

## Verification

web-ui: typecheck, lint, `i18n:check` and the full suite clean — 1140 tests
pass. Neutralising the fetch turns the new assertion red.

The three create-form tests were updated rather than worked around: they
asserted the old label and submitted a channel id, both of which describe the
behaviour this change deliberately replaces.

Refs #860.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790844495&installation_model_id=428086&pr_number=982&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F982&signature=9361c2c8b8ccef5adfe296a3072c8b456a35b3e1b5a42c7671bacece6bf47415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->