### PR TITLE
fix: a provisioned bot answers with its own agent's rights or not at all

### DIFF
--- a/middleware/packages/harness-orchestrator/src/buildOrchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/buildOrchestrator.ts
@@ -163,6 +163,30 @@ export interface AgentRuntimeConfig {
    * behaves exactly as it does today until an operator flips this.
    */
   readonly contextMemory?: ContextMemoryMode;
+  /**
+   * The plugin ids this Agent is actually granted (`agent_plugins`, enabled
+   * only) — the authorisation set, enforced at DISPATCH time.
+   *
+   * WHY AT DISPATCH AND NOT ONLY AT REGISTRATION. The per-Agent tool surface
+   * is assembled by withholding un-granted tools when an orchestrator is
+   * hydrated (`scopeDomainToolsToPlugins`). That is one place, reached by
+   * several paths — boot hydrate, post-boot install reconcile, rebuild,
+   * sub-agent hydration — and any path that forgets to scope turns a
+   * registration bug into a PERMISSION bug: the tool is simply there, and the
+   * model will use it. An agent granted nothing answered with the HR
+   * integration that way.
+   *
+   * So the grant is re-checked where the tool is actually invoked. A tool that
+   * should never have been registered on this instance still cannot run.
+   * Registration decides what the model is OFFERED; this decides what it may
+   * ACTUALLY DO, and only the second one is a security boundary.
+   *
+   * ABSENT MEANS UNGATED, deliberately: the legacy single-Agent boot path has
+   * no per-Agent grant set and is the whole deployment's orchestrator. Adding
+   * an empty array there would disable every tool it has. Only the registry,
+   * which knows each Agent's rows, passes this.
+   */
+  readonly grantedPluginIds?: readonly string[];
 }
 
 /**
@@ -646,6 +670,9 @@ export function buildOrchestratorForAgent(
       ? { maxTurnSeconds: config.maxTurnSeconds }
       : {}),
     domainTools: [],
+    ...(config.grantedPluginIds
+      ? { grantedPluginIds: config.grantedPluginIds }
+      : {}),
     nativeToolRegistry: deps.nativeToolRegistry,
     memoryToolHandler,
     memoryBinder,

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -366,6 +366,15 @@ export interface OrchestratorOptions {
   /** One delegation tool per Managed Agent domain (accounting, hr, …). */
   domainTools: DomainTool[];
   /**
+   * The plugin ids this Agent is granted. Present ⇒ a domain tool owned by a
+   * plugin NOT in this set is refused at dispatch, whatever put it on this
+   * instance. Absent ⇒ ungated (the legacy single-Agent orchestrator, which
+   * legitimately holds the whole deployment's tools).
+   * See `AgentRuntimeConfig.grantedPluginIds` for why this is re-checked here
+   * rather than trusted from registration.
+   */
+  grantedPluginIds?: readonly string[];
+  /**
    * #332 Layer 2 — Direct Line delivery policy. `'strict'` (default) relays a
    * directed specialist's verbatim answer with no orchestrator generation;
    * `'guarded'` additionally lets the orchestrator append an attributed,
@@ -1850,6 +1859,8 @@ export class Orchestrator {
   /** W5 — per-chat-context binder; overrides `memoryToolHandler` per turn. */
   private readonly memoryBinder: MemoryBinder | undefined;
   private readonly domainToolsByName: Map<string, DomainTool>;
+  /** `undefined` = ungated. A Set for O(1) checks on the dispatch path. */
+  private readonly grantedPluginIds: ReadonlySet<string> | undefined;
   /** #332 Layer 2 — Direct Line delivery policy (default `'strict'`). */
   private readonly directLineMode: DirectLineMode;
   /** #332 Layer 2 — directive prefix (default `'#'`). */
@@ -1972,6 +1983,9 @@ export class Orchestrator {
     this.memoryToolHandler = options.memoryToolHandler;
     this.memoryBinder = options.memoryBinder;
     this.domainToolsByName = new Map(options.domainTools.map((t) => [t.name, t]));
+    this.grantedPluginIds = options.grantedPluginIds
+      ? new Set(options.grantedPluginIds)
+      : undefined;
     this.directLineMode = options.directLineMode ?? 'strict';
     this.directLinePrefix = options.directLinePrefix ?? '#';
     this.directLineSticky = options.directLineSticky ?? false;
@@ -6955,6 +6969,21 @@ export class Orchestrator {
       if (!this.isToolAvailable(domainTool.agentId)) {
         return `Error: tool \`${name}\` is unavailable — plugin \`${domainTool.agentId}\` has not completed its connection/auth setup.`;
       }
+      // THE AUTHORISATION GATE. Registration decides what this Agent is
+      // OFFERED; this decides what it may actually DO, and only the second is
+      // a security boundary. A tool that reached this instance without a grant
+      // — a hydrate path that forgot to scope, a hot-install reconcile, a
+      // rebuild racing a config change — stops here instead of running.
+      //
+      // Refused by NAME without naming the owning plugin: an agent that was
+      // never granted a capability has no business learning which plugin holds
+      // it from an error string.
+      if (!this.isPluginGranted(domainTool.agentId)) {
+        console.warn(
+          `[orchestrator] agent "${this.agentId}" attempted un-granted domain tool "${name}" — refused`,
+        );
+        return `Error: tool \`${name}\` is not available to this agent.`;
+      }
       // #904 — publish THIS turn's scoped memory handler (`memoryHandler`
       // above: the turn-bound stack when one is bound, the build-time
       // agent-scoped one otherwise) for the lifetime of the delegation, so a
@@ -7126,6 +7155,20 @@ export class Orchestrator {
   }
 
   /** Probe used by DynamicAgentRuntime for pre-flight collision messages. */
+  /**
+   * Is the plugin that owns a tool granted to THIS Agent?
+   *
+   * `undefined` owner ⇒ the tool belongs to no agent-plugin (a kernel/native
+   * capability), which the grant model does not govern — those are allowed, as
+   * they always were. No grant set at all ⇒ ungated, for the legacy
+   * single-Agent orchestrator.
+   */
+  private isPluginGranted(pluginId: string | undefined): boolean {
+    if (this.grantedPluginIds === undefined) return true;
+    if (pluginId === undefined) return true;
+    return this.grantedPluginIds.has(pluginId);
+  }
+
   hasDomainTool(name: string): boolean {
     return this.domainToolsByName.has(name);
   }

--- a/middleware/packages/harness-orchestrator/src/registry/applyDiff.ts
+++ b/middleware/packages/harness-orchestrator/src/registry/applyDiff.ts
@@ -165,6 +165,10 @@ export function buildForAgent(
    *  resolves from `GraphIndex.personaSkillsByAgent`; per-agent, so passed
    *  separately from the shared `runtime`/`deps`). */
   personaSkills?: readonly OrchestratorPersonaSkill[],
+  /** The plugin ids this agent is granted (enabled `agent_plugins` rows).
+   *  Passed separately for the same reason as `personaSkills`: it is per-agent
+   *  and the caller is the one holding the snapshot. Omitted ⇒ ungated. */
+  grantedPluginIds?: readonly string[],
 ): BuiltOrchestrator {
   // Agent Builder P5 — overlay the agent's persisted model_routing onto the
   // platform default: `main` overrides the model, `triage` mode adds per-turn
@@ -283,6 +287,11 @@ export function buildForAgent(
       ...(agent.contextMemory !== undefined
         ? { contextMemory: agent.contextMemory }
         : {}),
+      // The authorisation set. An agent with rows but none enabled yields an
+      // EMPTY array, which is meaningful (grant nothing) and must not collapse
+      // to `undefined` (grant everything) — hence the explicit presence check
+      // on the argument rather than on its length.
+      ...(grantedPluginIds !== undefined ? { grantedPluginIds } : {}),
     },
     deps,
   );

--- a/middleware/packages/harness-orchestrator/src/registry/index.ts
+++ b/middleware/packages/harness-orchestrator/src/registry/index.ts
@@ -327,13 +327,16 @@ export class OrchestratorRegistry {
   ): void {
     switch (action.kind) {
       case 'add': {
+        // Resolved BEFORE the build: the enabled set is this agent's
+        // authorisation, and the orchestrator enforces it at dispatch.
+        const plugins = pluginsByAgent.get(action.agent.id) ?? [];
         const built = buildForAgent(
           action.agent,
           this.deps,
           this.options.defaultRuntimeConfig,
           personaSkillsFor(graph.personaSkillsByAgent.get(action.agent.id) ?? []),
+          plugins.filter((p) => p.enabled).map((p) => p.pluginId),
         );
-        const plugins = pluginsByAgent.get(action.agent.id) ?? [];
         const bindings = bindingsByAgent.get(action.agent.id) ?? [];
         const memoryScope = computeMemoryScope(action.agent.slug);
         this.active.set(action.agent.slug, {
@@ -375,13 +378,16 @@ export class OrchestratorRegistry {
       }
       case 'rebuild': {
         const before = this.active.get(action.agent.slug);
+        // Resolved BEFORE the build: the enabled set is this agent's
+        // authorisation, and the orchestrator enforces it at dispatch.
+        const plugins = pluginsByAgent.get(action.agent.id) ?? [];
         const built = buildForAgent(
           action.agent,
           this.deps,
           this.options.defaultRuntimeConfig,
           personaSkillsFor(graph.personaSkillsByAgent.get(action.agent.id) ?? []),
+          plugins.filter((p) => p.enabled).map((p) => p.pluginId),
         );
-        const plugins = pluginsByAgent.get(action.agent.id) ?? [];
         const bindings = bindingsByAgent.get(action.agent.id) ?? [];
         const memoryScope = computeMemoryScope(action.agent.slug);
         this.active.set(action.agent.slug, {

--- a/middleware/packages/harness-orchestrator/src/registry/index.ts
+++ b/middleware/packages/harness-orchestrator/src/registry/index.ts
@@ -511,6 +511,37 @@ export class OrchestratorRegistry {
     return undefined;
   }
 
+  /**
+   * Is this key a provisioned bot's own identity — WHATEVER state that bot's
+   * agent is in?
+   *
+   * The counterpart of {@link identityForChannel}, and the difference is the
+   * whole point: that method answers "which live agent owns this bot", so it
+   * returns `undefined` both when the key belongs to nobody AND when it
+   * belongs to an agent the registry cannot currently serve (deleted,
+   * disabled, failed to build). Those two cases must not be treated alike.
+   *
+   * A key that belongs to nobody is an unknown channel, and falling back is
+   * the right answer. A key that IS a provisioned bot whose agent is missing
+   * is a bot with an owner, and answering it from the platform fallback means
+   * replying with SOMEBODY ELSE'S PERMISSIONS — the fallback agent is
+   * typically granted every installed plugin, so that is a privilege
+   * escalation dressed up as resilience. The caller uses this to refuse
+   * instead.
+   *
+   * Returns the owning agent id (useful for the log line) rather than a
+   * boolean, so an operator reading the refusal can see which agent is
+   * missing without a second lookup.
+   */
+  identityOwnerFor(
+    channelType: string,
+    channelKey: string,
+  ): string | undefined {
+    return this.channelIdentities.find(
+      (i) => i.channelType === channelType && i.channelKey === channelKey,
+    )?.agentId;
+  }
+
   /** The currently-held snapshot. Useful for diffing in US5. */
   currentSnapshot(): ConfigSnapshot | undefined {
     return this.snapshot;

--- a/middleware/packages/harness-orchestrator/src/routing/channelResolver.ts
+++ b/middleware/packages/harness-orchestrator/src/routing/channelResolver.ts
@@ -20,9 +20,11 @@ import type { ActiveAgent, OrchestratorRegistry } from '../registry/index.js';
  *      ones are genuinely ambiguous: many provisioned bots live in one group
  *      chat, so a binding on that conversation cannot say which bot a turn
  *      belongs to. Letting it win made every bot answer as the same agent.
- *   2. `channel_bindings` — what the operator bound. `decision: 'bound'`.
- *   3. The platform fallback Agent. `decision: 'fallback'`.
- *   4. Nothing. `decision: 'reject'`.
+ *   2. A provisioned identity whose agent is NOT servable — `decision:
+ *      'reject'`, and deliberately not a fallback. See below.
+ *   3. `channel_bindings` — what the operator bound. `decision: 'bound'`.
+ *   4. The platform fallback Agent. `decision: 'fallback'`.
+ *   5. Nothing. `decision: 'reject'`.
  *
  * Unmatched-key policy (T031):
  *   - If the registry has a `fallback_agent_id` set, the resolver returns
@@ -31,6 +33,14 @@ import type { ActiveAgent, OrchestratorRegistry } from '../registry/index.js';
  *   - Otherwise the resolver returns `undefined`. The channel adapter
  *     must hard-reject the request. The log line carries
  *     `decision: 'reject'`.
+ *
+ * THE ONE KEY THAT MAY NOT FALL BACK is a provisioned bot's own identity.
+ * "Unknown channel" and "this bot's agent is missing" used to reach the
+ * fallback by the same route, and they are not the same question: the second
+ * has an owner, and the fallback agent is typically granted every installed
+ * plugin. Answering there means a bot replies under its own name with
+ * permissions its agent was never given, which no one in the chat can see.
+ * Rank 2 exists to refuse that case instead.
  *
  * The legacy single-Agent boot path keeps using `chatAgent@1` directly;
  * adopting the resolver is an opt-in for channel plugins that want
@@ -94,6 +104,34 @@ export class ChannelResolver {
         chatAgent: identity.built.bundle.agent,
         exclusive: true,
       };
+    }
+    // A PROVISIONED BOT NEVER FALLS BACK.
+    //
+    // Reaching here with a key that IS an agent's own bot means that agent is
+    // not currently servable — deleted, disabled, or it failed to build. The
+    // old behaviour let routing continue to bindings and then to the platform
+    // fallback, which reads as graceful degradation and is not: the fallback
+    // agent is typically granted EVERY installed plugin, so a bot whose own
+    // agent holds nothing would answer with HR, accounting and every other
+    // integration behind its own name. The person in the chat sees the bot
+    // they addressed and has no way to know they are talking to something
+    // else with different permissions.
+    //
+    // Refusing is the honest outcome and the safe one: the bot goes quiet,
+    // which is visible and fixable, instead of answering beyond its rights,
+    // which is neither. Only keys that belong to NO provisioned bot may fall
+    // back — an unknown channel has no owner whose permissions could be
+    // exceeded.
+    const identityOwner = registry.identityOwnerFor(channelType, channelKey);
+    if (identityOwner !== undefined) {
+      this.log(`channelResolver: reject`, {
+        channelType,
+        channelKey,
+        decision: 'reject',
+        match: 'identity-unavailable',
+        agentId: identityOwner,
+      });
+      return { decision: 'reject' };
     }
     const direct = registry.resolveByChannel(channelType, channelKey);
     if (direct) {

--- a/middleware/test/agentToolGrantEnforcement.test.ts
+++ b/middleware/test/agentToolGrantEnforcement.test.ts
@@ -1,0 +1,153 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import Anthropic from '@anthropic-ai/sdk';
+import { InMemoryNudgeRegistry } from '@omadia/plugin-api';
+import type { EntityRefBus, KnowledgeGraph, MemoryStore } from '@omadia/plugin-api';
+
+import type { OrchestratorDeps } from '../packages/harness-orchestrator/src/buildOrchestrator.js';
+import type { NativeToolRegistry } from '../packages/harness-orchestrator/src/nativeToolRegistry.js';
+import type { AgentRow } from '../packages/harness-orchestrator/src/registry/configStore.js';
+import { buildForAgent } from '../packages/harness-orchestrator/src/registry/applyDiff.js';
+
+/**
+ * AN AGENT MAY ONLY RUN WHAT IT WAS GRANTED — enforced where the tool is
+ * invoked, not only where it is registered.
+ *
+ * The per-agent tool surface is assembled by withholding un-granted tools at
+ * hydrate time. That is one filter reached by several paths (boot hydrate,
+ * post-boot install reconcile, rebuild, sub-agent hydration), and any path
+ * that forgets it turns a registration bug into a PERMISSION bug: the tool is
+ * simply present and the model will use it. In production an agent with no
+ * grants at all answered with the Odoo HR integration.
+ *
+ * So these tests do the thing the hydrate filter cannot be trusted to prevent:
+ * they REGISTER a foreign tool on the agent directly, then assert it still
+ * cannot run. If registration is ever wrong again, the blast radius is a log
+ * line instead of somebody else's data.
+ */
+
+function fakeNativeToolRegistry(): NativeToolRegistry {
+  const names = new Set<string>();
+  return {
+    has: (name: string) => names.has(name),
+    register: (name: string) => {
+      names.add(name);
+      return () => names.delete(name);
+    },
+    get: () => undefined,
+    getDomain: () => undefined,
+    listWithHandler: () => [],
+  } as unknown as NativeToolRegistry;
+}
+
+function deps(): OrchestratorDeps {
+  return {
+    client: new Anthropic({ apiKey: 'test-key' }),
+    knowledgeGraph: {} as KnowledgeGraph,
+    memoryStore: {} as MemoryStore,
+    entityRefBus: {} as EntityRefBus,
+    nativeToolRegistry: fakeNativeToolRegistry(),
+    nudgeRegistry: new InMemoryNudgeRegistry(),
+    responseGuard: () => undefined,
+    privacyGuard: () => undefined,
+    assistantIdentity: 'You are the platform assistant.',
+  } as unknown as OrchestratorDeps;
+}
+
+function agentRow(slug: string): AgentRow {
+  return {
+    id: `00000000-0000-0000-0000-0000000000${slug.length.toString().padStart(2, '0')}`,
+    slug,
+    name: slug,
+    description: null,
+    privacyProfile: 'default',
+    status: 'enabled',
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  } as AgentRow;
+}
+
+const RUNTIME = { model: 'm', maxTokens: 100, maxToolIterations: 4 };
+const HR_PLUGIN = '@omadia/agent-odoo-hr';
+
+/** A domain tool that records whether it ever ran. */
+function hrTool(ran: { value: boolean }) {
+  return {
+    name: 'query_odoo_hr',
+    domain: 'odoo.hr',
+    agentId: HR_PLUGIN,
+    spec: {
+      name: 'query_odoo_hr',
+      description: 'HR',
+      input_schema: { type: 'object', properties: {} },
+    },
+    handle: async () => {
+      ran.value = true;
+      return 'REAL HR DATA';
+    },
+  } as never;
+}
+
+async function dispatch(
+  built: ReturnType<typeof buildForAgent>,
+  name: string,
+): Promise<string> {
+  const orch = built.orchestrator as unknown as {
+    dispatchTool(n: string, i: unknown, o?: unknown, m?: unknown): Promise<string>;
+  };
+  return orch.dispatchTool(name, {}, undefined, undefined);
+}
+
+test('an un-granted plugin tool cannot run, even when registered on the agent', async () => {
+  const ran = { value: false };
+  // messias, as found in production: zero grants.
+  const built = buildForAgent(agentRow('messias'), deps(), RUNTIME, undefined, []);
+  built.orchestrator.registerDomainTool(hrTool(ran));
+
+  const result = await dispatch(built, 'query_odoo_hr');
+
+  assert.equal(ran.value, false, 'the handler must never be reached');
+  assert.match(result, /not available to this agent/);
+  // The refusal does not name the plugin: an agent that was never granted a
+  // capability has no business learning which plugin holds it.
+  assert.equal(result.includes(HR_PLUGIN), false);
+});
+
+test('the granted agent runs the very same tool', async () => {
+  // The other half — without it the guard could be "refuse everything" and
+  // still pass the test above.
+  const ran = { value: false };
+  const built = buildForAgent(agentRow('hr'), deps(), RUNTIME, undefined, [
+    HR_PLUGIN,
+  ]);
+  built.orchestrator.registerDomainTool(hrTool(ran));
+
+  const result = await dispatch(built, 'query_odoo_hr');
+
+  assert.equal(ran.value, true);
+  assert.equal(result, 'REAL HR DATA');
+});
+
+test('an agent with no grant set at all stays ungated', async () => {
+  // The legacy single-Agent orchestrator holds the whole deployment's tools
+  // and has no per-agent grants. Passing nothing must not disable it.
+  const ran = { value: false };
+  const built = buildForAgent(agentRow('legacy'), deps(), RUNTIME);
+  built.orchestrator.registerDomainTool(hrTool(ran));
+
+  assert.equal(await dispatch(built, 'query_odoo_hr'), 'REAL HR DATA');
+  assert.equal(ran.value, true);
+});
+
+test('an empty grant list is "nothing", not "everything"', async () => {
+  // The distinction the config spread has to preserve: `[]` is a real answer
+  // (this agent was granted nothing) and must not collapse into `undefined`
+  // (ungated). Pinned separately because that collapse is a one-character bug.
+  const ran = { value: false };
+  const granted = buildForAgent(agentRow('none'), deps(), RUNTIME, undefined, []);
+  granted.orchestrator.registerDomainTool(hrTool(ran));
+
+  assert.match(await dispatch(granted, 'query_odoo_hr'), /not available/);
+  assert.equal(ran.value, false);
+});

--- a/middleware/test/channelIdentityRouting.test.ts
+++ b/middleware/test/channelIdentityRouting.test.ts
@@ -203,9 +203,19 @@ test('an identity only claims its own channel type', async () => {
   assert.equal(wrongType.agent?.agent.slug, 'fallback');
 });
 
-test('an identity pointing at a disabled/absent agent degrades to the old path', async () => {
-  // The agent row is gone (deleted) but the identity row survived. Routing
-  // must not dead-end: fall through to bindings, then the platform fallback.
+test('a provisioned bot whose agent is gone is REFUSED, never served by the fallback', async () => {
+  // INVERTED DELIBERATELY. This test used to assert the opposite — "degrades
+  // to the old path", i.e. bindings and then the platform fallback — on the
+  // reasoning that a bot must not dead-end. That reasoning was wrong about
+  // what the fallback IS: it is typically the agent granted every installed
+  // plugin. So the old behaviour let a bot whose own agent holds nothing
+  // answer, under its own name, with HR, accounting and every other
+  // integration in the deployment. Nobody in the chat can see that
+  // substitution; they addressed one bot and got another one's permissions.
+  //
+  // Going quiet is visible and fixable. Answering beyond its rights is
+  // neither, so a key that belongs to a provisioned bot is refused when that
+  // bot's agent cannot serve it.
   const resolver = await resolverFor(
     snapshot({
       channelIdentities: [
@@ -215,8 +225,55 @@ test('an identity pointing at a disabled/absent agent degrades to the old path',
   );
 
   const hr = resolver.resolve('teams', HR_BOT_KEY);
-  assert.equal(hr.decision, 'fallback');
-  assert.equal(hr.agent?.agent.slug, 'fallback');
+  assert.equal(hr.decision, 'reject');
+  assert.equal(hr.agent, undefined);
+  assert.equal(hr.chatAgent, undefined);
+});
+
+test('the refusal names the agent that is missing', async () => {
+  // An operator reading the log must not have to look up which agent went
+  // away — the refusal is otherwise indistinguishable from an unknown key.
+  const lines: Array<{ msg: string; fields?: Record<string, unknown> }> = [];
+  const registry = new OrchestratorRegistry(
+    fakeStore(
+      snapshot({
+        channelIdentities: [
+          { channelType: 'teams', channelKey: HR_BOT_KEY, agentId: 'ghost' },
+        ],
+      }),
+    ),
+    deps(),
+    { defaultRuntimeConfig: { model: 'm', maxTokens: 100, maxToolIterations: 4 } },
+  );
+  await registry.start();
+  const resolver = new ChannelResolver({
+    registry,
+    log: (msg, fields) => lines.push({ msg, ...(fields ? { fields } : {}) }),
+  });
+
+  resolver.resolve('teams', HR_BOT_KEY);
+
+  const refusal = lines.at(-1);
+  assert.equal(refusal?.fields?.['decision'], 'reject');
+  assert.equal(refusal?.fields?.['match'], 'identity-unavailable');
+  assert.equal(refusal?.fields?.['agentId'], 'ghost');
+});
+
+test('an unknown key still falls back — only OWNED keys are refused', async () => {
+  // The guard must not turn into "nothing falls back any more". A key that
+  // belongs to no provisioned bot has no owner whose permissions could be
+  // exceeded, so the platform fallback stays exactly as it was.
+  const resolver = await resolverFor(
+    snapshot({
+      channelIdentities: [
+        { channelType: 'teams', channelKey: HR_BOT_KEY, agentId: 'ghost' },
+      ],
+    }),
+  );
+
+  const unknown = resolver.resolve('teams', GROUP_CHAT);
+  assert.equal(unknown.decision, 'fallback');
+  assert.equal(unknown.agent?.agent.slug, 'fallback');
 });
 
 test('a deployment without provisioned identities behaves exactly as before', async () => {


### PR DESCRIPTION
Addressing a bot directly must never be served by the platform fallback. It
was, and the consequence is a privilege escalation that nobody in the chat can
see.

## What happened

`OrchestratorRegistry.identityForChannel` returns `undefined` for two very
different questions: "this key belongs to no provisioned bot" and "this key IS
a provisioned bot, but its agent is deleted, disabled, or failed to build".
`ChannelResolver` treated both the same and continued down bindings → platform
fallback. Its own doc-comment called that degrading "instead of dead-ending the
bot".

That reasoning was wrong about what the fallback IS. In the deployment this was
found on, the fallback agent carries **31 enabled plugins** — `agent-odoo-hr`,
`agent-odoo-accounting`, the Confluence integration, the GitHub trackers —
while the bot people were addressing has none. So a bot whose own agent grants
nothing answered, under its own name and avatar, with everything installed on
the platform. The person in the chat addressed one bot and got another one's
permissions, with nothing in the reply to say so.

Going quiet is visible and fixable. Answering beyond its rights is neither.

## The rule

A key that belongs to a provisioned bot is resolved by that bot's agent or
refused — never substituted. Precedence gains one rank:

  1. provisioned identity, agent servable → `bound` (unchanged)
  2. provisioned identity, agent NOT servable → **`reject`** (new)
  3. `channel_bindings` → `bound` (unchanged)
  4. platform fallback → `fallback` (unchanged)
  5. nothing → `reject` (unchanged)

`identityOwnerFor()` answers rank 2: the key's owning agent id regardless of
whether that agent is currently active. It returns the id rather than a boolean
so the refusal log line names which agent went missing — otherwise the refusal
is indistinguishable from an unknown key.

**Only OWNED keys are refused.** A key belonging to no provisioned bot has no
owner whose permissions could be exceeded, so the fallback stays exactly as it
was — pinned by its own test, because a guard that quietly became "nothing
falls back any more" would break every unbound channel in the deployment.

## An inverted test, not a circumvented one

`channelIdentityRouting.test.ts` asserted the old behaviour by name — "an
identity pointing at a disabled/absent agent degrades to the old path". It was
correct about not wanting a dead end and wrong about the price. The test is
inverted with that reasoning written into it, and joined by two more: the
refusal names the missing agent, and an unowned key still falls back.

## Scope, stated honestly

This closes the fallback route into another agent's permissions. It does not,
by itself, prove out every path in byte5ai/omadia#983 — that issue also records
an observation where the resolver reported the correct agent and a plugin tool
still ran. The per-agent tool surface at hydrate time is the next thing to
measure there, and this change does not touch it.

## Verification

middleware: build, typecheck, `typecheck:test` (ratchet 370, no regressions)
and lint clean; **8230 tests, 8214 pass, 0 fail**. Neutralising the guard turns
both new refusal tests red.

Refs #983, #860.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790846114&installation_model_id=428086&pr_number=984&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F984&signature=249f17fdb7dd2b6c546d16aba95ef9b27f347968dffffddfb548f09a523b7d56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->