### PR TITLE
chore: log each agent's effective tool surface by name and owner

### DIFF
--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -2694,10 +2694,28 @@ async function main(): Promise<void> {
 
       let attached = 0;
       for (const entry of registryForHydrate.list()) {
-        for (const t of scopeDomainToolsToPlugins(
+        // WHAT THIS AGENT ACTUALLY ENDED UP WITH, by name and by owner.
+        //
+        // The count alone was not enough to answer the question that matters
+        // — "why can this agent reach that connector?" — because it cannot
+        // distinguish a tool that was granted from one that passed the filter
+        // for lack of an owner id (`agentId === undefined` is waved through by
+        // design, as a core helper). An agent with no grants reaching a
+        // plugin's tool is indistinguishable from correct behaviour in a
+        // number.
+        const scoped = scopeDomainToolsToPlugins(
           currentDomainTools(),
           entry.plugins,
-        )) {
+        );
+        console.log(
+          `[middleware] registry: tool surface for "${entry.agent.slug}": ` +
+            (scoped.length === 0
+              ? '(none)'
+              : scoped
+                  .map((t) => `${t.name}←${t.agentId ?? 'UNOWNED'}`)
+                  .join(', ')),
+        );
+        for (const t of scoped) {
           if (!entry.built.orchestrator.hasDomainTool(t.name)) {
             entry.built.orchestrator.registerDomainTool(t);
             attached += 1;
@@ -2744,8 +2762,14 @@ async function main(): Promise<void> {
           }
         }
         const subTools = hydrateSubAgentTools(slug, built);
+        // Same by-name surface as the initial hydrate above — a rebuild is
+        // exactly when a tool can appear that the operator did not grant, so
+        // the rebuild path must be as readable as the boot path.
         console.log(
-          `[middleware] registry: orchestrator for "${slug}" hydrated with ${String(tools.length)} domain-tool(s) + ${String(subTools)} sub-agent tool(s) (per-Agent plugin-scoped)`,
+          `[middleware] registry: orchestrator for "${slug}" hydrated with ${String(tools.length)} domain-tool(s) + ${String(subTools)} sub-agent tool(s) (per-Agent plugin-scoped): ` +
+            (tools.length === 0
+              ? '(none)'
+              : tools.map((t) => `${t.name}←${t.agentId ?? 'UNOWNED'}`).join(', ')),
         );
       });
 


### PR DESCRIPTION
Diagnostic only. No behaviour change, and deliberately so — see below.

## The question the count could not answer

An agent with **no plugin grants at all** (0 rows in `agent_plugins`, 0
sub-agents, 0 tool grants — confirmed against the live database) invoked
`query_odoo_hr` and answered a user with real HR data. The turn provably ran as
that agent: `scope=messias::teams-…  agent=messias`, with the tool call
between two of its own context assemblies.

Both guards that should have stopped it wave through one shape of tool: one
whose `agentId` — the id of the owning agent-plugin — is `undefined`.
`scopeDomainToolsToPlugins` documents that as "a core helper available to
everyone", and the dispatch gate added in #984 follows the same rule. If
`query_odoo_hr` reaches an agent without that id, both are working exactly as
written and the tool still runs.

I cannot tell from outside whether that is what happened, because nothing logs
which tools an agent ended up with or who owns them. The existing line reports
a COUNT, and a count cannot distinguish a granted tool from one that passed for
lack of an owner.

## What this adds

Both hydrate paths — boot and rebuild — now log the surface by name and owner:

    registry: tool surface for "messias": query_odoo_hr←@omadia/agent-odoo-hr, …
    registry: tool surface for "messias": query_odoo_hr←UNOWNED

Those two lines call for opposite fixes. One says the scope filter is being
bypassed somewhere; the other says the tool is unattributable and the
permissive branch is the hole. One turn against the live deployment
distinguishes them.

## Why not just tighten the rule now

Because the tightening depends on which line appears, and guessing wrong here
is expensive in both directions: refusing unattributable domain tools would
close the hole if they are the cause — and silently disable genuine core
helpers for every registry-built agent if they are not. The doc comment claims
`memory` and `ask_user_choice` are exactly such helpers.

The measurement is one deploy and settles it. Twice today I concluded ahead of
the evidence on this system and was wrong both times; this is the correction to
that, not caution for its own sake.

## Verification

middleware: build, typecheck and lint clean; 8234 tests, 8218 pass, 0 fail
(unchanged — this adds no behaviour to test).

Refs #983.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790852230&installation_model_id=428086&pr_number=985&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F985&signature=17e0cdbb0835cbba60f07ee7082a821cc9a1a5ecde434b318a70e81992759efd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->