### PR TITLE
fix: work started by a message to a bot runs as that bot's agent, or not at all

### DIFF
--- a/middleware/src/conductor/realStepEffects.ts
+++ b/middleware/src/conductor/realStepEffects.ts
@@ -99,6 +99,26 @@ export class RealStepEffects implements StepEffects {
     const registry = this.deps.getRegistry();
     if (!registry) throw new Error('orchestrator registry is unavailable (no graphPool / registry not built)');
 
+    // WORK STARTED BY A MESSAGE TO A BOT RUNS AS THAT BOT'S AGENT. FULL STOP.
+    //
+    // A person addresses one bot in a group chat. If a workflow triggered by
+    // that message runs as a DIFFERENT agent, the answer carries that agent's
+    // permissions while wearing the addressed bot's name — and nobody in the
+    // chat can see the substitution. Observed in production: a message to an
+    // agent with no plugin grants at all produced live HR data, because the
+    // workflow behind it was configured to run as the platform fallback, which
+    // is granted every installed plugin.
+    //
+    // This is deliberately NOT a warning and NOT a capability intersection.
+    // Both leave the outcome depending on how somebody configured a graph, and
+    // the rule has to hold regardless of configuration: the addressed bot's
+    // agent runs, or nothing runs.
+    //
+    // Scoped to CHANNEL triggers. A manual, scheduled or webhook run has no
+    // addressed bot, no impersonation risk, and keeps behaving exactly as
+    // before — which is why the rule keys on the trigger, not on the step.
+    assertChannelOriginAllows(step, context, meta, registry, this.deps.log);
+
     const entry = registry.get(slug);
     if (!entry) {
       throw new Error(`Agent '${slug}' is not active in the orchestrator registry`);
@@ -167,5 +187,84 @@ export function extractFencedJson(text: string, maxBytes = 16_384): JsonValue | 
     return JSON.parse(last) as JsonValue;
   } catch {
     return undefined;
+  }
+}
+
+/**
+ * Channel events whose payload identifies the bot a person addressed.
+ *
+ * A prefix list rather than a wildcard: a channel that does NOT carry an
+ * addressed bot must not be silently treated as if it did, because the rule
+ * below would then refuse every run it starts. Adding a channel here is a
+ * deliberate statement that its events name their bot.
+ */
+const CHANNEL_EVENT_PREFIXES: readonly string[] = ['teams.'];
+
+/** The addressed bot's routing key, as the channel put it in the payload. */
+function addressedBotKey(context: JsonObject): string | undefined {
+  const raw = context['botId'];
+  return typeof raw === 'string' && raw.trim() !== '' ? raw.trim() : undefined;
+}
+
+/**
+ * Refuse an agent step whose run began with a message to a DIFFERENT bot.
+ *
+ * Three outcomes, and the middle one is the point:
+ *
+ *  - not a channel trigger → allowed, unchanged (manual, schedule, webhook).
+ *  - channel trigger, bot unknown → REFUSED. A channel run whose origin cannot
+ *    be established is exactly the case that must not be guessed: the plugin
+ *    builds that omit the bot id are the ones that produced the impersonation,
+ *    so treating "unknown" as "fine" would keep the hole open for precisely
+ *    the deployments that have it.
+ *  - channel trigger, bot known → the step must BE that bot's agent.
+ */
+function assertChannelOriginAllows(
+  step: Step,
+  context: JsonObject,
+  meta: StepMeta,
+  registry: OrchestratorRegistry,
+  log?: (msg: string) => void,
+): void {
+  const eventId = meta.triggerEventId;
+  const isChannelTrigger =
+    (meta.triggerKind === 'event' || meta.triggerKind === 'webhook') &&
+    eventId !== undefined &&
+    CHANNEL_EVENT_PREFIXES.some((p) => eventId.startsWith(p));
+  if (!isChannelTrigger) return;
+
+  const botKey = addressedBotKey(context);
+  if (botKey === undefined) {
+    log?.(
+      `[conductor] agent step '${step.id}' refused — run started by '${String(eventId)}' ` +
+        `but the payload names no addressed bot, so its permissions cannot be established`,
+    );
+    throw new Error(
+      `agent step '${step.id}' cannot run: the channel event '${String(eventId)}' does not identify ` +
+        `the bot it was addressed to, so the step's permissions cannot be bound to it`,
+    );
+  }
+
+  const owner = registry.identityForChannel('teams', botKey);
+  if (!owner) {
+    log?.(
+      `[conductor] agent step '${step.id}' refused — addressed bot '${botKey}' resolves to no active agent`,
+    );
+    throw new Error(
+      `agent step '${step.id}' cannot run: the addressed bot '${botKey}' resolves to no active Agent`,
+    );
+  }
+
+  if (owner.agent.slug !== step.agentId) {
+    log?.(
+      `[conductor] agent step '${step.id}' refused — addressed bot '${botKey}' belongs to Agent ` +
+        `'${owner.agent.slug}' but the step is configured to run as '${String(step.agentId)}'`,
+    );
+    throw new Error(
+      `agent step '${step.id}' cannot run as '${String(step.agentId)}': the message was addressed to ` +
+        `Agent '${owner.agent.slug}'. Work started by a message to a bot runs with that bot's ` +
+        `permissions only — configure this step for '${owner.agent.slug}', or trigger the workflow ` +
+        `another way.`,
+    );
   }
 }

--- a/middleware/src/conductor/runExecutor.ts
+++ b/middleware/src/conductor/runExecutor.ts
@@ -151,6 +151,33 @@ export class ConductorRunExecutor {
   }
 
   /**
+   * The run's trigger, in the shape effects consume.
+   *
+   * Tolerant on purpose: a run that cannot be read back yields an EMPTY meta,
+   * which effects treat as "not channel-triggered" — the same answer a manual
+   * run gives. That is the safe direction here because the origin rule refuses
+   * on a channel trigger it cannot attribute; an unreadable run must not be
+   * turned into a channel trigger by accident.
+   */
+  private async triggerMetaFor(
+    runId: string,
+  ): Promise<{ triggerKind?: TriggerKind; triggerEventId?: string }> {
+    const run = await this.runStore.get(runId);
+    if (!run) return {};
+    const source = run.triggerSource;
+    const eventId =
+      typeof source === 'object' && source !== null && !Array.isArray(source)
+        ? (source as Record<string, unknown>)['eventId']
+        : undefined;
+    return {
+      ...(run.triggerKind ? { triggerKind: run.triggerKind } : {}),
+      ...(typeof eventId === 'string' && eventId !== ''
+        ? { triggerEventId: eventId }
+        : {}),
+    };
+  }
+
+  /**
    * Drive a run forward from `startStepId`. Human steps open an await and park. Every step/park
    * write is fenced on `lease` (the driver's claimed_by token): if a resume worker has taken the
    * run over (because this drive stalled past staleMs), the next write throws RunLeaseLostError and
@@ -166,6 +193,15 @@ export class ConductorRunExecutor {
     let context: JsonObject = { ...startContext };
     let currentStepId: string | null = startStepId;
     let seq = (await this.runStore.stepsForRun(runId)).length;
+    // How this run began, read ONCE here rather than threaded through the five
+    // `driveFrom` callers — three of them are resume paths that already hold
+    // the run, and a sixth parameter on a private method is a worse seam than
+    // one read per drive (an agent step costs an LLM turn; this costs a row).
+    //
+    // Effects need it to tell a run started by a message to a bot from one a
+    // human or a schedule started: only the first has an addressed identity
+    // whose permissions the work must stay inside.
+    const triggerMeta = await this.triggerMetaFor(runId);
 
     try {
       while (currentStepId && seq < MAX_STEPS) {
@@ -264,8 +300,8 @@ export class ConductorRunExecutor {
         let exec;
         try {
           exec = step.kind === 'agent'
-            ? await this.effects.runAgentStep(step, context, { runId })
-            : await this.effects.runActionStep(step, context, { runId });
+            ? await this.effects.runAgentStep(step, context, { runId, ...triggerMeta })
+            : await this.effects.runActionStep(step, context, { runId, ...triggerMeta });
         } catch (err) {
           this.log(`[conductor] run ${runId} step '${stepId}' threw: ${err instanceof Error ? err.message : String(err)}`);
           await this.runStore.recordStepAndAdvance({

--- a/middleware/src/conductor/stepEffects.ts
+++ b/middleware/src/conductor/stepEffects.ts
@@ -1,4 +1,9 @@
-import type { JsonObject, JsonValue, Step } from '@omadia/conductor-core';
+import type {
+  JsonObject,
+  JsonValue,
+  Step,
+  TriggerKind,
+} from '@omadia/conductor-core';
 
 export interface StepExecution {
   /** the step's result, fed to the engine as `stepResult` for guard/postcondition evaluation. */
@@ -10,6 +15,21 @@ export interface StepExecution {
 /** Per-call context the executor passes to effects (for session bucketing / tracing). */
 export interface StepMeta {
   runId: string;
+  /**
+   * How this run was started. Present so an effect can tell a run that a HUMAN
+   * or a schedule began from one a CHANNEL began — the two carry different
+   * authority, and only the second one has an addressed bot whose permissions
+   * the work must stay inside.
+   *
+   * Optional so every existing caller (preview, tests, the resume worker's
+   * older shape) keeps compiling and keeps its current behaviour: absent means
+   * "not channel-triggered", which is what those callers are.
+   */
+  triggerKind?: TriggerKind;
+  /** The domain event that started the run (`teams.message.posted`, …), when
+   *  it was an event/webhook trigger. Names WHICH channel, so the origin rule
+   *  applies only to channels that actually carry an addressed bot. */
+  triggerEventId?: string;
 }
 
 /**

--- a/middleware/test/conductorChannelOrigin.test.ts
+++ b/middleware/test/conductorChannelOrigin.test.ts
@@ -1,0 +1,160 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import type { JsonObject, Step } from '@omadia/conductor-core';
+import type { OrchestratorRegistry } from '@omadia/orchestrator';
+
+import { RealStepEffects } from '../src/conductor/realStepEffects.js';
+
+/**
+ * WORK STARTED BY A MESSAGE TO A BOT RUNS AS THAT BOT'S AGENT.
+ *
+ * The failure this pins was live and invisible. A person addressed one bot in a
+ * group chat; a workflow subscribed to `teams.message.posted` ran its agent
+ * step as the platform FALLBACK agent — which is granted every installed
+ * plugin — and answered with data the addressed bot's own agent had no grant
+ * for. Nothing in the chat distinguished the two: the reply carried the
+ * addressed bot's name and avatar.
+ *
+ * The rule is deliberately not a warning and not a capability intersection.
+ * Both leave the outcome depending on how somebody configured a graph. Here the
+ * addressed bot's agent runs, or nothing runs.
+ */
+
+const CHAT_BOT_KEY = '28:19ad2729-f7d3-4099-9d2a-7da1230c9533';
+
+function registryWith(
+  botKey: string,
+  ownerSlug: string,
+  ran: { slugs: string[] },
+): OrchestratorRegistry {
+  const entryFor = (slug: string) => ({
+    agent: { slug, id: `id-${slug}` },
+    built: {
+      bundle: {
+        agent: {
+          chat: async () => {
+            ran.slugs.push(slug);
+            return { text: `answered by ${slug}` };
+          },
+        },
+      },
+    },
+  });
+  return {
+    identityForChannel: (channelType: string, key: string) =>
+      channelType === 'teams' && key === botKey ? entryFor(ownerSlug) : undefined,
+    get: (slug: string) => entryFor(slug),
+  } as unknown as OrchestratorRegistry;
+}
+
+function agentStep(agentId: string): Step {
+  return { id: 'agent-4', kind: 'agent', agentId, prompt: 'do it' } as unknown as Step;
+}
+
+const TEAMS_EVENT = {
+  runId: 'run-1',
+  triggerKind: 'event' as const,
+  triggerEventId: 'teams.message.posted',
+};
+
+describe('conductor — a channel-triggered step runs as the addressed bot', () => {
+  it('refuses a step configured for a DIFFERENT agent than the bot addressed', async () => {
+    // The production shape: the message went to `messias`, the workflow says
+    // `fallback`, and `fallback` holds every plugin in the deployment.
+    const ran = { slugs: [] as string[] };
+    const effects = new RealStepEffects({
+      getRegistry: () => registryWith(CHAT_BOT_KEY, 'messias', ran),
+    });
+
+    const context: JsonObject = { botId: CHAT_BOT_KEY, text: 'Urlaub?' };
+    await assert.rejects(
+      effects.runAgentStep(agentStep('fallback'), context, TEAMS_EVENT),
+      /addressed to Agent 'messias'/,
+    );
+    // The turn must never have started — a refusal after the fact is not a
+    // refusal, the tool calls have already happened.
+    assert.deepEqual(ran.slugs, []);
+  });
+
+  it('runs when the step IS the addressed bot’s agent', async () => {
+    // The other half. Without it the guard could refuse everything and the
+    // test above would still pass.
+    const ran = { slugs: [] as string[] };
+    const effects = new RealStepEffects({
+      getRegistry: () => registryWith(CHAT_BOT_KEY, 'messias', ran),
+    });
+
+    const exec = await effects.runAgentStep(
+      agentStep('messias'),
+      { botId: CHAT_BOT_KEY },
+      TEAMS_EVENT,
+    );
+    assert.deepEqual(ran.slugs, ['messias']);
+    assert.deepEqual(exec.actor, { kind: 'agent', agentSlug: 'messias' });
+  });
+
+  it('refuses a channel-triggered run whose payload names no bot', async () => {
+    // FAIL-CLOSED, and this is the case that matters most in practice: the
+    // plugin builds that omit the bot id are exactly the ones that produced
+    // the impersonation. Treating "unknown origin" as "fine" would keep the
+    // hole open for precisely the deployments that have it.
+    const ran = { slugs: [] as string[] };
+    const effects = new RealStepEffects({
+      getRegistry: () => registryWith(CHAT_BOT_KEY, 'messias', ran),
+    });
+
+    await assert.rejects(
+      effects.runAgentStep(agentStep('fallback'), { text: 'hi' }, TEAMS_EVENT),
+      /does not identify the bot/,
+    );
+    assert.deepEqual(ran.slugs, []);
+  });
+
+  it('refuses when the addressed bot resolves to no active agent', async () => {
+    const ran = { slugs: [] as string[] };
+    const effects = new RealStepEffects({
+      getRegistry: () => registryWith('28:someone-else', 'messias', ran),
+    });
+
+    await assert.rejects(
+      effects.runAgentStep(
+        agentStep('fallback'),
+        { botId: CHAT_BOT_KEY },
+        TEAMS_EVENT,
+      ),
+      /resolves to no active Agent/,
+    );
+    assert.deepEqual(ran.slugs, []);
+  });
+
+  it('leaves manual and scheduled runs exactly as they were', async () => {
+    // The rule keys on the TRIGGER, not on the step. A run with no addressed
+    // bot has no impersonation risk, and a workflow that legitimately uses a
+    // specialist agent must keep working — otherwise this guard would break
+    // every non-channel workflow in the deployment.
+    const ran = { slugs: [] as string[] };
+    const effects = new RealStepEffects({
+      getRegistry: () => registryWith(CHAT_BOT_KEY, 'messias', ran),
+    });
+
+    await effects.runAgentStep(agentStep('fallback'), {}, { runId: 'run-2' });
+    assert.deepEqual(ran.slugs, ['fallback']);
+  });
+
+  it('does not police a non-channel event trigger', async () => {
+    // An operator emit or an inbound webhook carries no addressed bot either.
+    // Only event ids from a channel that DOES name its bot are policed.
+    const ran = { slugs: [] as string[] };
+    const effects = new RealStepEffects({
+      getRegistry: () => registryWith(CHAT_BOT_KEY, 'messias', ran),
+    });
+
+    await effects.runAgentStep(agentStep('fallback'), {}, {
+      runId: 'run-3',
+      triggerKind: 'event',
+      triggerEventId: 'crm.deal.won',
+    });
+    assert.deepEqual(ran.slugs, ['fallback']);
+  });
+});


### PR DESCRIPTION
A person addresses one bot in a group chat. A workflow subscribed to
`teams.message.posted` then ran its agent step as the **platform fallback
agent** — which is granted every installed plugin — and answered with data the
addressed bot's own agent has no grant for. The reply carried the addressed
bot's name and avatar. Nothing in the chat distinguished the two.

Measured, not inferred. The addressed agent holds **zero** rows in
`agent_plugins`, zero sub-agents and zero tool grants, and its hydrated tool
surface logs as `(none)`. The Odoo calls in the same seconds belong to a
conductor run whose step is configured as `fallback`:

    [conductor] event 'teams.message.posted' started run … on 'test-teams'
    [conductor] agent step 'agent-4' → Agent 'fallback'
    [domain:odoo.hr] query_odoo_hr → ok

## The rule

An agent step whose run was started by a channel event may only run as the
agent that owns the addressed bot. Three outcomes:

  * **not a channel trigger** → unchanged. Manual, scheduled and non-channel
    event/webhook runs have no addressed bot and no impersonation risk, and a
    workflow that legitimately delegates to a specialist keeps working. The
    rule keys on the TRIGGER, not on the step.
  * **channel trigger, bot not identified** → refused. This is the case that
    matters most in practice: the plugin builds that omit the bot id are
    exactly the ones that produced the impersonation, so treating "unknown
    origin" as "fine" would keep the hole open for precisely the deployments
    that have it.
  * **channel trigger, bot known** → the step must BE that bot's agent.

Deliberately **not** a warning and **not** a capability intersection. Both
leave the outcome depending on how somebody configured a graph, and the
requirement is that it hold regardless of configuration. The addressed bot's
agent runs, or nothing runs.

The refusal names the agent the step should be configured for, so an operator
reading it can fix the workflow without going digging.

## Plumbing

`StepMeta` gains the run's `triggerKind` and `triggerEventId`, both optional so
every existing caller compiles and keeps its behaviour. The executor resolves
them once per drive from the run row rather than threading two parameters
through five `driveFrom` call sites — three of those are resume paths that
already hold the run, and an agent step costs an LLM turn while this costs one
row read. An unreadable run yields an empty meta, i.e. "not channel-triggered",
which is the safe direction: nothing may be turned INTO a channel trigger by
accident.

## What this does not do

It does not make the workflow work again — it stops it. `teams.message.posted`
currently carries `{ conversationId, activityId, userId, userName, text,
mentioned, tenantId }` and no bot identity at all, so every channel-triggered
agent step now refuses. That is the correct state until the channel plugin
carries the addressed bot; the alternative is leaving the escalation in place
because the data needed to prevent it is missing.

Adding `botId` to the Teams event is the follow-up, in
`byte5ai/omadia-channel-teams`.

## Verification

middleware: build, typecheck, `typecheck:test` (ratchet 370, no regressions)
and lint clean; **8240 tests, 8224 pass, 0 fail**. Neutralising the guard turns
3 of its 6 tests red — the three refusals; the three that stay green are the
"must still run" cases, which is what stops the guard from being "refuse
everything".

Refs #983, #860.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/986"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790858940&installation_model_id=428086&pr_number=986&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F986&signature=bcacce064a29b7d62a60f0f6ab28a7d5a510fa7c5dc4b415d6bde3e7c976653b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->