### PR TITLE
fix: MCP marketplace search failed slowly and silently instead of fast and legibly

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,50 @@ changelog.
 
 ## [Unreleased]
 
+### Fixed — MCP marketplace search hung instead of failing, and told you nothing
+
+2026-09-01 — The Marketplace tab's search sat in "Katalog durchsuchen…"
+indefinitely and produced neither results nor an error. The trigger was
+external: `registry.modelcontextprotocol.io` — the registry seeded as `official`
+in migration `0010` — is black-holing packets (DNS resolves to 34.61.200.254,
+TCP times out). What made it read as a broken feature rather than a dead host
+was our own code spending **four** 15-second timeouts on it per search:
+`fetchCatalog` probed two candidate URLs, and when the server-side search threw,
+`search()` fell through to a local-filter fallback that re-ran the whole thing
+against the same dead host. Roughly 60 seconds of spinner, then a bare error
+string.
+
+Three changes in `middleware/src/services/mcpRegistryClient.ts`:
+
+- **Transport failures short-circuit.** `search()` rethrows a transport-level
+  error instead of retrying the same unreachable host through the local-filter
+  fallback. The distinction is load-bearing, so the classification was tightened
+  at the same time: only the `fetchImpl` call itself yields `transport_failed` /
+  `timeout`; status, body-read and `JSON.parse` failures stay on `http_error` /
+  `bad_catalog_shape` and still take the fallback — a registry answering 200
+  with HTML is answering, and may simply be ignoring the search param.
+- **The bare base-URL candidate is dropped for `kind = 'official'`.** Migration
+  `0013` assigns that kind to exactly `registry.modelcontextprotocol.io`, whose
+  base URL is a landing page, never a catalog. Operator-added registries default
+  to `generic` and keep the candidate.
+- **A 60-second negative cache.** Successes were cached, failures were not, so
+  each caller paid the full timeout. That was survivable while browsing sat
+  behind an explicit button; it is not now that the UI loads the catalog on its
+  own. `GET /mcp-registries/:id/catalog?refresh=1` drops both caches, so the
+  UI's Retry and Refresh still reach the host.
+
+The pane itself (`web-ui/app/admin/mcp/page.tsx`) was reworked in the same pass:
+the catalog loads on registry select instead of waiting for a button, search
+runs debounced as you type with in-flight requests aborted, registries are pills
+rather than a select, and failures render a typed card naming the registry and
+what to do about it. Results moved to a card grid with a result count and an
+explicit Refresh; registry removal moved out of the search row into a folded
+management panel behind a confirm dialog.
+
+**Note for operators:** this makes the outage legible and fast — it does not
+bring the official registry back. Use `smithery` (seeded, keyless to browse)
+until `registry.modelcontextprotocol.io` answers again.
+
 ### Fixed — omadia beta test round 3: the desktop shell (OM-50 to OM-69, #938)
 
 2026-08-28 — Silvio Lange (TE Printline GmbH) reached the application for the

--- a/middleware/src/routes/agentBuilder.ts
+++ b/middleware/src/routes/agentBuilder.ts
@@ -2192,6 +2192,11 @@ export function createAgentBuilderRouter(
         return;
       }
       const q = typeof req.query['q'] === 'string' ? req.query['q'] : '';
+      // `refresh=1` is the operator explicitly asking to re-dial: it drops both
+      // the 5-minute success cache and the short "recently unreachable" note,
+      // so Retry and Refresh in the UI actually hit the registry instead of
+      // being answered from either cache.
+      if (req.query['refresh'] === '1') mcpRegistryClient.invalidate(registry.id);
       const entries = await mcpRegistryClient.search(await toRegistryConfig(registry), q);
       res.json({ entries });
     } catch (err) {

--- a/middleware/src/services/mcpRegistryClient.ts
+++ b/middleware/src/services/mcpRegistryClient.ts
@@ -75,6 +75,10 @@ function packageEnvSchema(pkg: unknown): McpConfigField[] {
 const DEFAULT_TIMEOUT_MS = 15_000;
 const MAX_CATALOG_BYTES = 5 * 1024 * 1024;
 const CACHE_TTL_MS = 5 * 60 * 1000;
+/** How long a host that refused to answer is skipped instead of re-dialled.
+ *  Short on purpose: long enough to stop an auto-loading UI from stacking
+ *  timeouts, short enough that a registry coming back is noticed quickly. */
+const UNREACHABLE_TTL_MS = 60 * 1000;
 
 export class McpRegistryError extends Error {
   constructor(
@@ -84,6 +88,22 @@ export class McpRegistryError extends Error {
     super(message);
     this.name = 'McpRegistryError';
   }
+}
+
+/** Transport-level failures: the registry host never produced an HTTP answer.
+ *  Retrying the same host inside one operator action only multiplies the wait,
+ *  so these short-circuit instead of falling through to a second round-trip.
+ *
+ *  Deliberately excludes `fetch_failed` and every protocol-level code
+ *  (`http_error`, `bad_catalog_shape`): those mean the registry answered, and
+ *  an answering registry may simply be ignoring the search param — which is
+ *  exactly the case the local-filter fallback exists to rescue. */
+const UNREACHABLE_CODES = new Set(['timeout', 'transport_failed', 'blocked_host']);
+
+/** An aborted fetch is our own deadline firing, not a network error — it gets
+ *  its own code so the operator is told "too slow", not "unreachable". */
+function isAbort(err: unknown): boolean {
+  return err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError');
 }
 
 interface CacheSlot {
@@ -477,13 +497,52 @@ export class McpRegistryClient {
     this.log = deps?.log ?? ((m) => console.log(m));
   }
 
+  /**
+   * Short-lived memory of "this host just refused to answer".
+   *
+   * Successes were already cached; failures were not, so a black-holing
+   * registry charged the full timeout to every single caller. That was
+   * tolerable while browsing was behind an explicit button and is not now
+   * that the UI loads the catalog on its own — without this, re-entering the
+   * Marketplace tab or clicking between registry pills stacks 15s requests.
+   * The window is deliberately much shorter than the success TTL so a
+   * recovering registry is picked up quickly, and `invalidate()` clears it.
+   */
+  private readonly unreachableUntil = new Map<string, number>();
+
+  private throwIfRecentlyUnreachable(registryId: string): void {
+    const until = this.unreachableUntil.get(registryId);
+    if (until === undefined) return;
+    if (Date.now() >= until) {
+      this.unreachableUntil.delete(registryId);
+      return;
+    }
+    throw new McpRegistryError(
+      'transport_failed',
+      'registry did not answer on the previous attempt; not retried yet',
+    );
+  }
+
+  private noteUnreachable(registryId: string, err: unknown): void {
+    if (err instanceof McpRegistryError && UNREACHABLE_CODES.has(err.code)) {
+      this.unreachableUntil.set(registryId, Date.now() + UNREACHABLE_TTL_MS);
+    }
+  }
+
   /** Fetch (or serve from the 5-minute cache) a registry's full catalog. */
   async catalog(registry: McpRegistryConfig): Promise<readonly McpCatalogEntry[]> {
     const cached = this.cache.get(registry.id);
     if (cached && Date.now() - cached.fetchedAtMs < CACHE_TTL_MS) {
       return cached.entries;
     }
-    const entries = await this.fetchCatalog(registry);
+    this.throwIfRecentlyUnreachable(registry.id);
+    let entries: readonly McpCatalogEntry[];
+    try {
+      entries = await this.fetchCatalog(registry);
+    } catch (err) {
+      this.noteUnreachable(registry.id, err);
+      throw err;
+    }
     this.cache.set(registry.id, { fetchedAtMs: Date.now(), entries });
     return entries;
   }
@@ -495,6 +554,14 @@ export class McpRegistryClient {
    * additionally substring-filtered locally as a safety net (a registry that
    * ignores the param still returns something sensible). An empty query serves
    * the cached full-first-page browse.
+   *
+   * Failure handling matters for latency, not just correctness: a registry
+   * whose host black-holes packets (registry.modelcontextprotocol.io did
+   * exactly that) costs one full timeout per attempt. Retrying the *same dead
+   * host* through the local-filter fallback doubled that into a ~60s spinner
+   * with no feedback. So a transport-level failure is rethrown immediately and
+   * only a protocol-level one (the registry answered, but not usefully — it
+   * may simply ignore the search param) falls through to the local filter.
    */
   async search(registry: McpRegistryConfig, q: string): Promise<readonly McpCatalogEntry[]> {
     const needle = q.trim().toLowerCase();
@@ -502,10 +569,15 @@ export class McpRegistryClient {
     // official (?search=) and smithery (?q=) honor the query server-side — trust
     // their relevance ranking and return as-is.
     if (registry.kind === 'official' || registry.kind === 'smithery') {
+      this.throwIfRecentlyUnreachable(registry.id);
       try {
         return await this.fetchCatalog(registry, q.trim());
-      } catch {
-        /* fall through to the local-filter fallback below */
+      } catch (err) {
+        if (err instanceof McpRegistryError && UNREACHABLE_CODES.has(err.code)) {
+          this.noteUnreachable(registry.id, err);
+          throw err;
+        }
+        /* the registry answered but not usefully — fall through to local filter */
       }
     }
     // A generic registry may ignore the param, so substring-filter its page.
@@ -616,8 +688,16 @@ export class McpRegistryClient {
 
   /** Test seam / operator action: drop the cache for one or all registries. */
   invalidate(registryId?: string): void {
-    if (registryId) this.cache.delete(registryId);
-    else this.cache.clear();
+    if (registryId) {
+      this.cache.delete(registryId);
+      // Also forget the "recently unreachable" note, so an operator who
+      // explicitly asks to retry actually reaches the host instead of being
+      // served the suppressed-retry error for the rest of the window.
+      this.unreachableUntil.delete(registryId);
+    } else {
+      this.cache.clear();
+      this.unreachableUntil.clear();
+    }
   }
 
   private async fetchCatalog(
@@ -640,7 +720,14 @@ export class McpRegistryClient {
           ]
         : [
             `${base}/v0/servers?limit=100${q ? `&search=${encodeURIComponent(q)}` : ''}`,
-            base,
+            // The bare base URL is a `generic` affordance (a plain
+            // { servers: [...] } document). `official` is not operator-set —
+            // migration 0013 assigns it to exactly
+            // registry.modelcontextprotocol.io, whose base URL is a landing
+            // page, never a catalog. Probing it there only buys a second full
+            // timeout when the host is down, and no operator-added registry
+            // can reach this branch (those default to `generic`).
+            ...(registry.kind === 'official' ? [] : [base]),
           ];
     const normalize = registry.kind === 'smithery' ? normalizeSmitheryEntry : normalizeEntry;
     let lastError: McpRegistryError | null = null;
@@ -672,10 +759,13 @@ export class McpRegistryClient {
         );
         return entries;
       } catch (err) {
+        // fetchJson already classified transport vs. protocol; anything else
+        // reaching here (a parse/shape failure) is the registry answering
+        // badly, which is explicitly NOT a transport code.
         lastError =
           err instanceof McpRegistryError
             ? err
-            : new McpRegistryError('fetch_failed', String(err));
+            : new McpRegistryError('bad_catalog_shape', String(err));
       }
     }
     throw lastError ?? new McpRegistryError('fetch_failed', 'no catalog endpoint reachable');
@@ -686,18 +776,34 @@ export class McpRegistryClient {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), this.timeoutMs);
     try {
-      const res = await this.fetchImpl(url, {
-        headers: {
-          accept: 'application/json',
-          ...(registry.authKind === 'bearer' && registry.token
-            ? { authorization: `Bearer ${registry.token}` }
-            : {}),
-        },
-        signal: controller.signal,
-        // A redirect could bounce the (token-carrying) request to a host the
-        // operator never configured — refuse instead of following (codex fold).
-        redirect: 'error',
-      });
+      // Only the call itself is classified as transport-level. Everything
+      // after it (status, body read, JSON parse) means the registry DID
+      // answer, and those failures must stay on non-transport codes — the
+      // fast-fail in search() keys off transport codes, and mislabelling a
+      // 200-with-HTML as unreachable would both skip the local-filter
+      // fallback and tell the operator their host is down when it is not.
+      let res: Response;
+      try {
+        res = await this.fetchImpl(url, {
+          headers: {
+            accept: 'application/json',
+            ...(registry.authKind === 'bearer' && registry.token
+              ? { authorization: `Bearer ${registry.token}` }
+              : {}),
+          },
+          signal: controller.signal,
+          // A redirect could bounce the (token-carrying) request to a host the
+          // operator never configured — refuse instead of following (codex fold).
+          redirect: 'error',
+        });
+      } catch (err) {
+        throw isAbort(err)
+          ? new McpRegistryError(
+              'timeout',
+              `${url} did not answer within ${String(this.timeoutMs)}ms`,
+            )
+          : new McpRegistryError('transport_failed', `${url} could not be reached: ${String(err)}`);
+      }
       if (!res.ok) {
         throw new McpRegistryError('http_error', `${url} answered ${String(res.status)}`);
       }

--- a/middleware/test/mcpRegistryClient.test.ts
+++ b/middleware/test/mcpRegistryClient.test.ts
@@ -338,4 +338,104 @@ describe('McpRegistryClient', () => {
       assert.equal(entry?.transportDeprecated, false);
     });
   });
+
+  // ── dead-host search latency ────────────────────────────────────────────
+  // registry.modelcontextprotocol.io started black-holing packets, and the
+  // marketplace search reacted by spending FOUR full timeouts on it: two
+  // candidate URLs for the server-side search, then two more for the
+  // local-filter fallback. At the 15s default that is a ~60s spinner with no
+  // feedback, which reads as "search is broken" rather than "registry is down".
+  describe('unreachable registry fails fast', () => {
+    /** A host that never answers: every attempt rejects at the transport level. */
+    function deadHost(counter: { n: number }): typeof fetch {
+      return (async () => {
+        counter.n += 1;
+        throw new TypeError('fetch failed');
+      }) as unknown as typeof fetch;
+    }
+
+    it('does not retry a dead official registry through the local-filter fallback', async () => {
+      const calls = { n: 0 };
+      const client = new McpRegistryClient({ fetchImpl: deadHost(calls), log: () => {} });
+      const official = { ...REGISTRY, id: 'dead-official', kind: 'official' as const };
+      await assert.rejects(
+        client.search(official, 'strava'),
+        (err: unknown) => err instanceof McpRegistryError && err.code === 'transport_failed',
+      );
+      // One attempt: the /v0/servers search URL. The bare base URL is not a
+      // catalog endpoint for a typed `official` registry, and the local-filter
+      // fallback must not re-run against the same dead host.
+      assert.equal(calls.n, 1);
+    });
+
+    it('keeps the base-URL candidate for a generic registry', async () => {
+      const calls = { n: 0 };
+      const client = new McpRegistryClient({ fetchImpl: deadHost(calls), log: () => {} });
+      await assert.rejects(client.catalog({ ...REGISTRY, id: 'dead-generic' }));
+      // /v0/servers then the plain document at the base URL — the `generic`
+      // shape genuinely lives at one of the two, so both are still probed.
+      assert.equal(calls.n, 2);
+    });
+
+    it('reports an expired deadline as `timeout`, not a transport failure', async () => {
+      const stalls: typeof fetch = (async (_input: unknown, init?: { signal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            const err = new Error('aborted');
+            err.name = 'AbortError';
+            reject(err);
+          });
+        })) as unknown as typeof fetch;
+      const client = new McpRegistryClient({ fetchImpl: stalls, log: () => {}, timeoutMs: 20 });
+      const official = { ...REGISTRY, id: 'slow-official', kind: 'official' as const };
+      await assert.rejects(
+        client.search(official, 'strava'),
+        (err: unknown) => err instanceof McpRegistryError && err.code === 'timeout',
+      );
+    });
+
+    // The fast-fail must key off TRANSPORT failure only. A registry that
+    // answers 200 with a non-JSON body is answering — the local-filter
+    // fallback is exactly the rescue path for it, and labelling it
+    // "unreachable" would both skip that path and misinform the operator.
+    it('still falls back to the local filter when the registry answers badly', async () => {
+      let calls = 0;
+      const answersHtml: typeof fetch = (async () => {
+        calls += 1;
+        return new Response('<!doctype html><html>nope</html>', {
+          status: 200,
+          headers: { 'content-type': 'text/html' },
+        });
+      }) as unknown as typeof fetch;
+      const client = new McpRegistryClient({ fetchImpl: answersHtml, log: () => {} });
+      const official = { ...REGISTRY, id: 'html-official', kind: 'official' as const };
+      await assert.rejects(
+        client.search(official, 'strava'),
+        (err: unknown) => err instanceof McpRegistryError && err.code === 'bad_catalog_shape',
+      );
+      // Two attempts: the server-side search, then the local-filter fallback's
+      // catalog() — NOT short-circuited after the first, because the host
+      // answered.
+      assert.equal(calls, 2);
+    });
+
+    it('does not re-dial a host that just refused, until an explicit refresh', async () => {
+      const calls = { n: 0 };
+      const client = new McpRegistryClient({ fetchImpl: deadHost(calls), log: () => {} });
+      const official = { ...REGISTRY, id: 'sticky-dead', kind: 'official' as const };
+
+      await assert.rejects(client.search(official, 'strava'));
+      assert.equal(calls.n, 1);
+
+      // An auto-loading UI re-entering the tab must not pay the timeout again.
+      await assert.rejects(client.search(official, 'strava'));
+      await assert.rejects(client.catalog(official));
+      assert.equal(calls.n, 1);
+
+      // The operator explicitly asking to retry does reach the host again.
+      client.invalidate(official.id);
+      await assert.rejects(client.search(official, 'strava'));
+      assert.equal(calls.n, 2);
+    });
+  });
 });

--- a/web-ui/app/_lib/agentBuilder.ts
+++ b/web-ui/app/_lib/agentBuilder.ts
@@ -1000,15 +1000,25 @@ export async function deleteMcpRegistry(id: string): Promise<void> {
   await callJson(`/v1/operator/mcp-registries/${encodeURIComponent(id)}`, { method: 'DELETE' });
 }
 
+/**
+ * @param opts.refresh Operator explicitly asked to re-dial — drops the
+ *   server-side success cache AND the short "recently unreachable" note.
+ * @param opts.signal Abort a superseded request (search-as-you-type, or the
+ *   operator switching registries) instead of leaving it in flight against a
+ *   registry that can take the full timeout to fail.
+ */
 export async function searchMcpCatalog(
   registryId: string,
   q: string,
+  opts?: { refresh?: boolean; signal?: AbortSignal },
 ): Promise<{ entries: McpCatalogEntry[] }> {
   const params = new URLSearchParams();
   if (q) params.set('q', q);
+  if (opts?.refresh === true) params.set('refresh', '1');
   const qs = params.toString();
   return callJson(
     `/v1/operator/mcp-registries/${encodeURIComponent(registryId)}/catalog${qs ? `?${qs}` : ''}`,
+    opts?.signal ? { signal: opts.signal } : {},
   );
 }
 

--- a/web-ui/app/admin/mcp/page.tsx
+++ b/web-ui/app/admin/mcp/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useTranslations } from 'next-intl';
 
@@ -1038,24 +1038,70 @@ function ToolTestForm({
 
 // ── Marketplace (issue #455) ─────────────────────────────────────────────────
 
+/** Search-as-you-type debounce. Long enough that typing a word costs one
+ *  registry round-trip instead of six, short enough that the list feels live. */
+const CATALOG_SEARCH_DEBOUNCE_MS = 400;
+
+/** How many placeholder cards the loading grid shows. Purely cosmetic — it just
+ *  has to look like "a list is coming", not predict the real result count. */
+const CATALOG_SKELETON_ROWS = 6;
+
+/**
+ * Classify a catalog failure into the three things an operator can actually do
+ * something about. `code` comes from the route's JSON body (`McpRegistryError`
+ * codes), so this stays a lookup rather than message-sniffing.
+ *
+ * The distinction is not cosmetic: "the host never answered" (the official
+ * registry black-holing packets) needs a different reaction — pick another
+ * registry — than "the registry answered with something unparseable".
+ */
+type CatalogErrorKind = 'timeout' | 'unreachable' | 'generic';
+
+function catalogErrorKind(err: unknown): CatalogErrorKind {
+  if (!(err instanceof ApiError)) return 'generic';
+  if (err.code === 'timeout') return 'timeout';
+  // Only genuinely transport-level codes claim "unreachable". `http_error` /
+  // `bad_catalog_shape` mean the registry answered badly, which is a different
+  // problem with a different remedy.
+  if (err.code === 'transport_failed' || err.code === 'blocked_host') return 'unreachable';
+  return 'generic';
+}
+
+interface CatalogFailure {
+  kind: CatalogErrorKind;
+  detail: string;
+}
+
 function MarketplacePane(): React.ReactElement {
   const t = useTranslations('adminMcp');
   const [registries, setRegistries] = useState<McpRegistryInfo[] | null>(null);
   const [selected, setSelected] = useState<string | null>(null);
   const [entries, setEntries] = useState<McpCatalogEntry[] | null>(null);
   const [query, setQuery] = useState('');
+  /** The query the currently displayed `entries` were fetched for — so the
+   *  result header never claims a count for a query the user has since edited. */
+  const [appliedQuery, setAppliedQuery] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [failure, setFailure] = useState<CatalogFailure | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [connected, setConnected] = useState<string | null>(null);
+  const [manageOpen, setManageOpen] = useState(false);
+  const [confirmRemove, setConfirmRemove] = useState<McpRegistryInfo | null>(null);
   const [regName, setRegName] = useState('');
   const [regUrl, setRegUrl] = useState('');
   const [regToken, setRegToken] = useState('');
+
+  /** Monotonic request id. Debounced typing plus a slow registry means an older
+   *  response can land after a newer one; without this the list would flicker
+   *  back to stale results. Only the newest sequence is allowed to render. */
+  const seq = useRef(0);
 
   const refreshRegistries = useCallback(async () => {
     try {
       const list = (await listMcpRegistries()).registries;
       setRegistries(list);
-      setSelected((prev) => prev ?? list[0]?.id ?? null);
+      setSelected((prev) => (prev && list.some((r) => r.id === prev) ? prev : (list[0]?.id ?? null)));
       setError(null);
     } catch (err) {
       setError(errText(err));
@@ -1066,20 +1112,66 @@ function MarketplacePane(): React.ReactElement {
     void refreshRegistries();
   }, [refreshRegistries]);
 
-  async function browse(): Promise<void> {
+  const runSearch = useCallback(
+    async (
+      registryId: string,
+      q: string,
+      opts?: { refresh?: boolean; signal?: AbortSignal },
+    ): Promise<void> => {
+      const mine = ++seq.current;
+      setLoading(true);
+      setFailure(null);
+      setConnected(null);
+      try {
+        const found = (
+          await searchMcpCatalog(registryId, q, {
+            ...(opts?.refresh === true ? { refresh: true } : {}),
+            ...(opts?.signal ? { signal: opts.signal } : {}),
+          })
+        ).entries;
+        if (seq.current !== mine) return;
+        setEntries(found);
+        setAppliedQuery(q);
+      } catch (err) {
+        // An abort is this component superseding its own request, not a
+        // registry problem — it must not paint the failure card.
+        if (opts?.signal?.aborted === true || seq.current !== mine) return;
+        setEntries(null);
+        setFailure({ kind: catalogErrorKind(err), detail: errText(err) });
+      } finally {
+        if (seq.current === mine) setLoading(false);
+      }
+    },
+    [],
+  );
+
+  /**
+   * The catalog loads itself: selecting a registry browses it immediately and
+   * typing re-queries after a pause. The old pane sat empty until the operator
+   * found the "Browse catalog" button, which made an already-slow registry look
+   * broken rather than slow.
+   *
+   * The cleanup aborts an in-flight request as well as cancelling a pending
+   * debounce: against a registry that takes the full server-side timeout to
+   * fail, dropping only the response would leave every superseded keystroke
+   * and pill click running to completion.
+   */
+  useEffect(() => {
     if (!selected) return;
-    setBusy('browse');
-    setError(null);
-    setConnected(null);
-    try {
-      setEntries((await searchMcpCatalog(selected, query)).entries);
-    } catch (err) {
-      setError(errText(err));
-      setEntries(null);
-    } finally {
-      setBusy(null);
-    }
-  }
+    const registryId = selected;
+    const q = query.trim();
+    const controller = new AbortController();
+    const timer = setTimeout(
+      () => {
+        void runSearch(registryId, q, { signal: controller.signal });
+      },
+      q === '' ? 0 : CATALOG_SEARCH_DEBOUNCE_MS,
+    );
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [selected, query, runSearch]);
 
   async function connect(entry: McpCatalogEntry): Promise<void> {
     if (!selected) return;
@@ -1095,115 +1187,152 @@ function MarketplacePane(): React.ReactElement {
     }
   }
 
+  const activeRegistry = (registries ?? []).find((r) => r.id === selected) ?? null;
+  const registryLabel = activeRegistry?.name ?? '';
+  const canRemove = !!activeRegistry && (registries ?? []).length > 1;
+
   return (
-    <div className="flex flex-col gap-3">
-      <div className="flex flex-wrap items-end gap-2 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4">
-        <label className="flex flex-col gap-1 text-xs">
-          {t('marketplace.registry')}
-          <select
-            value={selected ?? ''}
-            onChange={(e) => {
-              setSelected(e.target.value || null);
-              setEntries(null);
-            }}
-            className="rounded-md border border-[color:var(--border)] bg-transparent px-3 py-2 text-sm outline-none focus:border-[color:var(--accent)]"
-          >
-            {(registries ?? []).map((r) => (
-              <option key={r.id} value={r.id}>
-                {r.name}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label className="flex grow flex-col gap-1 text-xs">
-          {t('marketplace.search')}
-          <input
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') void browse();
-            }}
-            className="rounded-md border border-[color:var(--border)] bg-transparent px-3 py-2 text-sm outline-none focus:border-[color:var(--accent)]"
-          />
-        </label>
-        <Button size="sm" busy={busy === 'browse'} onClick={() => void browse()}>
-          {t('marketplace.browse')}
-        </Button>
-        {selected && registries && registries.length > 1 ? (
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={() =>
-              void deleteMcpRegistry(selected).then(() => {
-                setSelected(null);
-                setEntries(null);
-                return refreshRegistries();
-              })
-            }
-          >
-            {t('marketplace.removeRegistry')}
-          </Button>
-        ) : null}
+    <div className="flex flex-col gap-4">
+      {/* Search is the primary action, so it gets the full width and the top
+          slot — the registry picker below it is the qualifier, not the verb. */}
+      <div className="relative">
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm text-[color:var(--fg-muted)]"
+        >
+          ⌕
+        </span>
+        <input
+          type="search"
+          value={query}
+          aria-label={t('marketplace.search')}
+          placeholder={t('marketplace.searchPlaceholder')}
+          onChange={(e) => setQuery(e.target.value)}
+          className="w-full rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 py-2.5 pl-9 pr-24 text-sm outline-none transition-colors focus:border-[color:var(--accent)]"
+        />
+        <div className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center gap-1">
+          {query !== '' ? (
+            <Button size="sm" variant="ghost" onClick={() => setQuery('')}>
+              {t('marketplace.clearSearch')}
+            </Button>
+          ) : null}
+          {loading ? (
+            <span className="pr-1 text-xs text-[color:var(--fg-muted)]">
+              {t('marketplace.searching')}
+            </span>
+          ) : null}
+        </div>
       </div>
 
-      <details className="rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4">
-        <summary className="cursor-pointer text-xs text-[color:var(--fg-muted)]">
-          {t('marketplace.addRegistry')}
-        </summary>
-        <div className="mt-2 flex flex-wrap items-end gap-2">
-          <label className="flex flex-col gap-1 text-xs">
-            {t('marketplace.registryName')}
-            <input
-              value={regName}
-              onChange={(e) => setRegName(e.target.value)}
-              className="rounded-md border border-[color:var(--border)] bg-transparent px-3 py-2 text-sm outline-none focus:border-[color:var(--accent)]"
-            />
-          </label>
-          <label className="flex grow flex-col gap-1 text-xs">
-            {t('marketplace.registryUrl')}
-            <input
-              value={regUrl}
-              onChange={(e) => setRegUrl(e.target.value)}
-              placeholder="https://…"
-              className="rounded-md border border-[color:var(--border)] bg-transparent px-3 py-2 text-sm outline-none focus:border-[color:var(--accent)]"
-            />
-          </label>
-          <label className="flex flex-col gap-1 text-xs">
-            {t('marketplace.registryToken')}
-            <input
-              type="password"
-              value={regToken}
-              onChange={(e) => setRegToken(e.target.value)}
-              className="rounded-md border border-[color:var(--border)] bg-transparent px-3 py-2 text-sm outline-none focus:border-[color:var(--accent)]"
-            />
-          </label>
-          <Button
-            size="sm"
-            busy={busy === 'addRegistry'}
-            onClick={() => {
-              setBusy('addRegistry');
-              setError(null);
-              void addMcpRegistry({
-                name: regName.trim(),
-                url: regUrl.trim(),
-                ...(regToken.trim() !== ''
-                  ? { authKind: 'bearer' as const, token: regToken.trim() }
-                  : {}),
-              })
-                .then(() => {
-                  setRegName('');
-                  setRegUrl('');
-                  setRegToken('');
-                  return refreshRegistries();
+      {/* Registries as pills: with two or three sources the whole choice is
+          visible at once, and switching is one click instead of open-select-pick. */}
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs text-[color:var(--fg-muted)]">{t('marketplace.registry')}</span>
+        {(registries ?? []).map((r) => {
+          const active = r.id === selected;
+          return (
+            <Button
+              key={r.id}
+              size="sm"
+              pill
+              variant={active ? 'primary' : 'ghost'}
+              aria-pressed={active}
+              onClick={() => {
+                setSelected(r.id);
+                setEntries(null);
+                setConnected(null);
+                // Without this the previous registry's error card survives the
+                // debounce window and is re-labelled with the NEW registry's
+                // name — an accusation against a host never contacted.
+                setFailure(null);
+              }}
+            >
+              {r.name}
+            </Button>
+          );
+        })}
+        <span className="grow" />
+        <Button size="sm" variant="ghost" onClick={() => setManageOpen((v) => !v)}>
+          {t('marketplace.manageRegistries')}
+        </Button>
+      </div>
+
+      {/* Registry management is administration, not discovery — it stays folded
+          away so it cannot be mistaken for part of the search flow, and the
+          destructive action lives in here rather than beside the search box. */}
+      {manageOpen ? (
+        <div className="flex flex-col gap-3 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4">
+          <div className="text-xs text-[color:var(--fg-muted)]">{t('marketplace.addRegistry')}</div>
+          <div className="flex flex-wrap items-end gap-2">
+            <label className="flex flex-col gap-1 text-xs">
+              {t('marketplace.registryName')}
+              <input
+                value={regName}
+                onChange={(e) => setRegName(e.target.value)}
+                className="rounded-md border border-[color:var(--border)] bg-transparent px-3 py-2 text-sm outline-none focus:border-[color:var(--accent)]"
+              />
+            </label>
+            <label className="flex grow flex-col gap-1 text-xs">
+              {t('marketplace.registryUrl')}
+              <input
+                value={regUrl}
+                onChange={(e) => setRegUrl(e.target.value)}
+                placeholder="https://…"
+                className="rounded-md border border-[color:var(--border)] bg-transparent px-3 py-2 text-sm outline-none focus:border-[color:var(--accent)]"
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-xs">
+              {t('marketplace.registryToken')}
+              <input
+                type="password"
+                value={regToken}
+                onChange={(e) => setRegToken(e.target.value)}
+                className="rounded-md border border-[color:var(--border)] bg-transparent px-3 py-2 text-sm outline-none focus:border-[color:var(--accent)]"
+              />
+            </label>
+            <Button
+              size="sm"
+              busy={busy === 'addRegistry'}
+              disabled={regName.trim() === '' || regUrl.trim() === ''}
+              onClick={() => {
+                setBusy('addRegistry');
+                setError(null);
+                void addMcpRegistry({
+                  name: regName.trim(),
+                  url: regUrl.trim(),
+                  ...(regToken.trim() !== ''
+                    ? { authKind: 'bearer' as const, token: regToken.trim() }
+                    : {}),
                 })
-                .catch((err: unknown) => setError(errText(err)))
-                .finally(() => setBusy(null));
-            }}
-          >
-            {t('marketplace.addRegistryConfirm')}
-          </Button>
+                  .then(() => {
+                    setRegName('');
+                    setRegUrl('');
+                    setRegToken('');
+                    return refreshRegistries();
+                  })
+                  .catch((err: unknown) => setError(errText(err)))
+                  .finally(() => setBusy(null));
+              }}
+            >
+              {t('marketplace.addRegistryConfirm')}
+            </Button>
+          </div>
+          {canRemove && activeRegistry ? (
+            <div className="flex items-center justify-between gap-3 border-t border-[color:var(--border)] pt-3">
+              <span className="text-xs text-[color:var(--fg-muted)]">
+                {t('marketplace.removeRegistryBody', { name: activeRegistry.name })}
+              </span>
+              <Button
+                size="sm"
+                variant="danger"
+                onClick={() => setConfirmRemove(activeRegistry)}
+              >
+                {t('marketplace.removeRegistry')}
+              </Button>
+            </div>
+          ) : null}
         </div>
-      </details>
+      ) : null}
 
       {error ? <div className="text-sm text-[color:var(--danger)]">{error}</div> : null}
       {connected ? (
@@ -1212,68 +1341,192 @@ function MarketplacePane(): React.ReactElement {
         </div>
       ) : null}
 
-      {entries ? (
-        entries.length === 0 ? (
-          <div className="text-sm text-[color:var(--fg-muted)]">{t('marketplace.noResults')}</div>
-        ) : (
-          <div className="flex flex-col gap-2">
+      {/* ── Result region ─────────────────────────────────────────────────── */}
+      {loading && entries === null ? (
+        <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3" aria-busy="true">
+          {Array.from({ length: CATALOG_SKELETON_ROWS }, (_, i) => (
+            <div
+              key={i}
+              className="h-28 animate-pulse rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/30"
+            />
+          ))}
+        </div>
+      ) : failure ? (
+        <div className="flex flex-col gap-2 rounded-lg border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 p-4">
+          <div className="text-sm text-[color:var(--danger)]">
+            {failure.kind === 'timeout'
+              ? t('marketplace.errorTimeout', { name: registryLabel })
+              : failure.kind === 'unreachable'
+                ? t('marketplace.errorUnreachable', { name: registryLabel })
+                : t('marketplace.errorGeneric', { name: registryLabel })}
+          </div>
+          <div className="text-xs text-[color:var(--fg-muted)]">
+            {failure.kind === 'generic'
+              ? failure.detail
+              : t('marketplace.errorUnreachableHint')}
+          </div>
+          <div>
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={() => {
+                if (selected) void runSearch(selected, query.trim(), { refresh: true });
+              }}
+            >
+              {t('marketplace.retry')}
+            </Button>
+          </div>
+        </div>
+      ) : entries === null ? (
+        <div className="text-sm text-[color:var(--fg-muted)]">{t('marketplace.hint')}</div>
+      ) : entries.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-[color:var(--border)] p-6 text-center">
+          <div className="text-sm text-[color:var(--fg-muted)]">
+            {appliedQuery === ''
+              ? t('marketplace.noResults')
+              : t('marketplace.noResultsFor', { query: appliedQuery })}
+          </div>
+          <div className="mt-1 text-xs text-[color:var(--fg-muted)]">
+            {t('marketplace.noResultsHint')}
+          </div>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {/* Two independently long strings on one line overlapped the grid
+              below once either wrapped, so they stack until there is room. */}
+          <div className="flex flex-col gap-1 text-xs text-[color:var(--fg-muted)] sm:flex-row sm:items-baseline sm:justify-between sm:gap-4">
+            <span className="flex shrink-0 items-center gap-1">
+              {appliedQuery === ''
+                ? t('marketplace.resultCount', { count: entries.length, name: registryLabel })
+                : t('marketplace.resultCountFor', {
+                    count: entries.length,
+                    query: appliedQuery,
+                    name: registryLabel,
+                  })}
+              {/* Neither `selected` nor `query` changes on a re-run, so the
+                  auto-load effect will not refire — and the server holds a
+                  5-minute catalog cache. Without this there is no way to see
+                  a server published upstream a minute ago. */}
+              <Button
+                size="sm"
+                variant="ghost"
+                busy={loading}
+                busyLabel={t('marketplace.searching')}
+                onClick={() => {
+                  if (selected) void runSearch(selected, appliedQuery, { refresh: true });
+                }}
+              >
+                {t('marketplace.refresh')}
+              </Button>
+            </span>
+            <span className="sm:text-right">{t('marketplace.hintShort')}</span>
+          </div>
+          <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
             {entries.map((entry) => (
               <div
                 key={entry.id}
-                className="flex items-start justify-between gap-3 rounded-md border border-[color:var(--border)] px-3 py-2"
+                className="flex flex-col gap-2 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/30 p-3 transition-colors hover:border-[color:var(--border-strong)]"
               >
                 <div className="min-w-0">
-                  <div className="text-sm">
+                  <div className="truncate text-sm font-medium" title={entry.name}>
                     {entry.name}
-                    {entry.version ? (
-                      <span className="text-xs text-[color:var(--fg-muted)]"> · v{entry.version}</span>
-                    ) : null}
                   </div>
-                  {entry.description ? (
-                    <div className="text-xs text-[color:var(--fg-muted)]">{entry.description}</div>
+                  {entry.version ? (
+                    <div className="text-[10px] text-[color:var(--fg-muted)]">v{entry.version}</div>
                   ) : null}
-                  <div className="mt-1 flex flex-wrap gap-2 text-[10px]">
-                    {entry.license ? (
-                      <span className="text-[color:var(--fg-muted)]">{entry.license}</span>
-                    ) : (
-                      <span className="text-[color:var(--warning)]">{t('marketplace.unlicensed')}</span>
-                    )}
-                    {entry.author ? (
-                      <span className="text-[color:var(--fg-muted)]">@{entry.author}</span>
-                    ) : null}
-                    {entry.transport ? (
-                      <span className="text-[color:var(--fg-muted)]">{entry.transport}</span>
-                    ) : (
-                      <span className="text-[color:var(--fg-muted)]">{t('marketplace.browseOnly')}</span>
-                    )}
-                    {entry.transport === 'http' || entry.transport === 'sse' ? (
-                      <span className="text-[color:var(--warning)]">{t('marketplace.authHintRemote')}</span>
-                    ) : entry.transport === 'stdio' ? (
-                      <span className="text-[color:var(--fg-muted)]">{t('marketplace.authHintLocal')}</span>
-                    ) : null}
-                  </div>
                 </div>
-                <span
-                  className="shrink-0"
-                  title={!entry.transport ? t('marketplace.browseOnlyHint') : undefined}
-                >
-                  <Button
-                    size="sm"
-                    variant="secondary"
-                    busy={busy === `connect:${entry.id}`}
-                    disabled={!entry.transport}
-                    onClick={() => void connect(entry)}
+                {entry.description ? (
+                  <p className="line-clamp-3 text-xs text-[color:var(--fg-muted)]">
+                    {entry.description}
+                  </p>
+                ) : null}
+                {/* Badges must never wrap inside their own border — a long
+                    label breaking mid-pill spilled the text past the outline. */}
+                <div className="mt-auto flex flex-wrap items-center gap-1.5 text-[10px]">
+                  <span className="whitespace-nowrap rounded border border-[color:var(--border)] px-1.5 py-0.5 text-[color:var(--fg-muted)]">
+                    {entry.transport ?? t('marketplace.browseOnly')}
+                  </span>
+                  {entry.license ? (
+                    <span className="whitespace-nowrap rounded border border-[color:var(--border)] px-1.5 py-0.5 text-[color:var(--fg-muted)]">
+                      {entry.license}
+                    </span>
+                  ) : (
+                    <span
+                      title={t('marketplace.unlicensed')}
+                      className="whitespace-nowrap rounded border border-[color:var(--warning)]/50 px-1.5 py-0.5 text-[color:var(--warning)]"
+                    >
+                      {t('marketplace.unlicensedShort')}
+                    </span>
+                  )}
+                  {entry.author ? (
+                    <span className="truncate text-[color:var(--fg-muted)]">@{entry.author}</span>
+                  ) : null}
+                </div>
+                <div className="flex items-center justify-between gap-2">
+                  {(() => {
+                    const authHint =
+                      entry.transport === 'http' || entry.transport === 'sse'
+                        ? t('marketplace.authHintRemote')
+                        : entry.transport === 'stdio'
+                          ? t('marketplace.authHintLocal')
+                          : '';
+                    // Truncated rather than wrapped so it cannot push past the
+                    // card edge; the full sentence stays available on hover.
+                    return (
+                      <span
+                        title={authHint === '' ? undefined : authHint}
+                        className="min-w-0 truncate text-[10px] text-[color:var(--fg-muted)]"
+                      >
+                        {authHint}
+                      </span>
+                    );
+                  })()}
+                  <span
+                    className="shrink-0"
+                    title={!entry.transport ? t('marketplace.browseOnlyHint') : undefined}
                   >
-                    {t('marketplace.connect')}
-                  </Button>
-                </span>
+                    <Button
+                      size="sm"
+                      variant="secondary"
+                      busy={busy === `connect:${entry.id}`}
+                      disabled={!entry.transport}
+                      onClick={() => void connect(entry)}
+                    >
+                      {t('marketplace.connect')}
+                    </Button>
+                  </span>
+                </div>
               </div>
             ))}
           </div>
-        )
-      ) : (
-        <div className="text-sm text-[color:var(--fg-muted)]">{t('marketplace.hint')}</div>
+        </div>
       )}
+
+      <ConfirmDialog
+        open={confirmRemove !== null}
+        title={t('marketplace.removeRegistry')}
+        body={
+          confirmRemove
+            ? t('marketplace.removeRegistryBody', { name: confirmRemove.name })
+            : undefined
+        }
+        confirmLabel={t('marketplace.removeRegistry')}
+        cancelLabel={t('cancel')}
+        tone="danger"
+        onCancel={() => setConfirmRemove(null)}
+        onConfirm={() => {
+          const target = confirmRemove;
+          setConfirmRemove(null);
+          if (!target) return;
+          void deleteMcpRegistry(target.id)
+            .then(() => {
+              setSelected(null);
+              setEntries(null);
+              return refreshRegistries();
+            })
+            .catch((err: unknown) => setError(errText(err)));
+        }}
+      />
     </div>
   );
 }

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -4206,7 +4206,6 @@
     "marketplace": {
       "registry": "Registry",
       "search": "Suche",
-      "browse": "Katalog durchsuchen",
       "hint": "Registry wählen und Katalog durchsuchen. Verbundene Server starten deaktiviert: erst Discover ausführen, Verdicts prüfen, dann aktivieren.",
       "noResults": "Keine passenden Katalog-Einträge.",
       "connect": "Verbinden",
@@ -4221,7 +4220,24 @@
       "removeRegistry": "Registry entfernen",
       "registryName": "Name",
       "registryUrl": "URL",
-      "registryToken": "Bearer-Token (optional)"
+      "registryToken": "Bearer-Token (optional)",
+      "searchPlaceholder": "Katalog durchsuchen — z. B. postgres, github, slack",
+      "clearSearch": "Leeren",
+      "searching": "Suche läuft…",
+      "manageRegistries": "Registries verwalten",
+      "retry": "Erneut versuchen",
+      "resultCount": "{count, plural, one {# Server} other {# Server}} in {name}",
+      "resultCountFor": "{count, plural, one {# Treffer} other {# Treffer}} für „{query}“ in {name}",
+      "hintShort": "Importe starten deaktiviert — erst Discover ausführen.",
+      "noResultsFor": "Kein Katalog-Eintrag passt zu „{query}“.",
+      "noResultsHint": "Kürzeren Begriff probieren oder oben eine andere Registry wählen.",
+      "errorTimeout": "Die Registry „{name}“ hat nicht rechtzeitig geantwortet.",
+      "errorUnreachable": "Die Registry „{name}“ ist nicht erreichbar.",
+      "errorGeneric": "Der Katalog von „{name}“ konnte nicht gelesen werden.",
+      "errorUnreachableHint": "Der Registry-Host ist offline oder aus dieser Installation heraus blockiert. Wähle oben eine andere Registry oder versuche es gleich noch einmal.",
+      "removeRegistryBody": "Registry „{name}“ entfernen? Bereits importierte Server bleiben bestehen.",
+      "unlicensedShort": "ohne Lizenz",
+      "refresh": "Aktualisieren"
     },
     "grants": {
       "grantHeading": "Tools einem Orchestrator zuweisen",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -4206,7 +4206,6 @@
     "marketplace": {
       "registry": "Registry",
       "search": "Search",
-      "browse": "Browse catalog",
       "hint": "Pick a registry and browse its catalog. Connected servers arrive disabled: run Discover, review the verdicts, then enable.",
       "noResults": "No catalog entries match.",
       "connect": "Connect",
@@ -4221,7 +4220,24 @@
       "removeRegistry": "Remove registry",
       "registryName": "Name",
       "registryUrl": "URL",
-      "registryToken": "Bearer token (optional)"
+      "registryToken": "Bearer token (optional)",
+      "searchPlaceholder": "Search the catalog — e.g. postgres, github, slack",
+      "clearSearch": "Clear",
+      "searching": "Searching…",
+      "manageRegistries": "Manage registries",
+      "retry": "Try again",
+      "resultCount": "{count, plural, one {# server} other {# servers}} in {name}",
+      "resultCountFor": "{count, plural, one {# match} other {# matches}} for \"{query}\" in {name}",
+      "hintShort": "Imports arrive disabled — run Discover first.",
+      "noResultsFor": "Nothing in this catalog matches \"{query}\".",
+      "noResultsHint": "Try a shorter term, or switch to another registry above.",
+      "errorTimeout": "The registry \"{name}\" did not answer in time.",
+      "errorUnreachable": "The registry \"{name}\" could not be reached.",
+      "errorGeneric": "The catalog of \"{name}\" could not be read.",
+      "errorUnreachableHint": "The registry host is down or blocked from this installation. Pick another registry above, or try again in a moment.",
+      "removeRegistryBody": "Remove the registry \"{name}\"? Servers already imported from it stay.",
+      "unlicensedShort": "unlicensed",
+      "refresh": "Refresh"
     },
     "grants": {
       "grantHeading": "Grant tools to an orchestrator",


### PR DESCRIPTION
## What was reported

The Marketplace tab's search sat in „Katalog durchsuchen…“ and produced neither results nor an error.

## What was actually wrong

Two things, and only one of them is ours.

**External:** `registry.modelcontextprotocol.io` — the registry seeded as `official` in migration `0010` — is currently black-holing packets. DNS resolves (34.61.200.254), TCP times out. Verified from this machine; `registry.smithery.ai` answers normally.

**Ours:** we turned that outage into an apparently broken feature by spending **four** 15-second timeouts on it per search. `fetchCatalog` probed two candidate URLs, and when the server-side search threw, `search()` fell through to a local-filter fallback that re-ran the whole thing against the same dead host. Roughly 60 seconds of spinner behind a busy button, then a bare error string.

## middleware

- **Transport failures short-circuit.** `search()` rethrows instead of retrying an unreachable host through the local-filter fallback. The distinction is load-bearing, so the error classification was tightened in the same change: only the `fetchImpl` call itself yields `transport_failed` / `timeout`. Status, body-read and `JSON.parse` failures stay on `http_error` / `bad_catalog_shape` and **still take the fallback** — a registry answering 200 with HTML *is* answering, and may simply be ignoring the search param. (Caught in review: an earlier revision of this PR had `fetch_failed` as a catch-all in the short-circuit set, which would have killed the fallback for answering registries and told operators their host was down when it was not.)
- **The bare base-URL candidate is dropped for `kind = 'official'`.** Migration `0013` assigns that kind to exactly `registry.modelcontextprotocol.io`, whose base URL is a landing page, never a catalog. `kind` is not operator-settable; operator-added registries default to `generic` and keep the candidate.
- **A 60-second negative cache.** Successes were cached, failures were not, so each caller paid the full timeout. Tolerable while browsing sat behind an explicit button; not tolerable now that the UI loads the catalog on its own. `GET /mcp-registries/:id/catalog?refresh=1` drops both caches, so Retry and Refresh still reach the host.

## web-ui

The missing feedback was half the bug, so the pane was reworked in the same pass:

- The catalog **loads on registry select** instead of waiting for a button; search runs **debounced as you type** (400 ms) with superseded requests **aborted**, not merely discarded.
- Failures render a **typed error card** naming the registry and what to do about it, plus Retry.
- Results carry a **count** and an explicit **Refresh** — nothing else re-runs a query whose registry and text did not change, and the server holds a 5-minute catalog cache.
- Registries are **pills** instead of a select; results are a **card grid**; registry removal moved out of the search row into a **folded management panel behind a confirm dialog**.

## Verification

- middleware: `npm run build` ✓, `tsc --noEmit` ✓, 25/25 `mcpRegistryClient` tests ✓ (5 new), `typecheck:test` ratchet 370/370 no regressions ✓, eslint clean on changed files.
- web-ui: `typecheck` ✓, `lint` exit 0 ✓, `i18n:check` 4390 keys ✓, `npm test` 1140/1140 ✓.
- Real Chrome (Interceptor) against a stubbed middleware: auto-load on tab open, unreachable card with the correct copy, registry switch shows **no** stale error during the debounce window, live search `strava` → 4 hits, and Refresh confirmed sending `?q=strava&refresh=1` to the backend. Typing six characters produced exactly **one** request.

**Not visually re-verified:** three layout defects (header row overlapping the grid, badges wrapping out of their border, auth hint crossing the card edge) were found in screenshots and fixed, but Interceptor's screenshot channel died afterwards. Those fixes are confirmed structurally via the DOM, not by a fresh capture. Worth a look before merge.

## Note for operators

This makes the outage **legible and fast** — it does not bring the official registry back. Use `smithery` (seeded, keyless to browse) until `registry.modelcontextprotocol.io` answers again.

## Scope

Both the bug fix and the redesign were explicitly requested together. If you would rather have the middleware change independently revertible, say so and I will split it.

### Test plan

- [ ] Marketplace tab opens and browses the selected registry without a button press
- [ ] With `official` selected, the failure card appears in seconds, not a minute
- [ ] Switching registries mid-search never labels the old error with the new registry's name
- [ ] Retry / Refresh actually re-dial (check for `refresh=1` in the request)
- [ ] Card grid holds up at narrow widths — badges and the auth hint must not cross the card border

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790871138&installation_model_id=428086&pr_number=987&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F987&signature=4f5a737e2b629910bbc147a0b0ce773af87e0f140ac8e4175ba9a68b3eb62302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->