### PR TITLE
fix: answer marketplace search from the cached catalog when only the registry's search is broken

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,29 @@ changelog.
 
 ## [Unreleased]
 
+### Fixed — MCP marketplace search now answers from the cached catalog when only the registry's search is broken
+
+2026-09-01 — Follow-up to the entry below, found by watching the deployed fix
+against the live registry. Failing fast was correct but not sufficient:
+`registry.modelcontextprotocol.io` serves `/v0/servers` in under a second (66
+servers) while `?search=` hangs to the full timeout. So browse worked, search
+showed an error card, and the operator still got no results — the reported
+symptom, just faster and better explained.
+
+`search()` now falls back to substring-filtering the browse page it already
+holds in cache whenever the server-side search fails at the transport level.
+That costs no network, and it is the difference between an error card and
+actual hits. When nothing is cached it still fails fast as before.
+
+Because a filter over one page is *not* the registry's ranking of its whole
+catalog, `search()` now returns a `scope` (`registry` | `cached-page`) that the
+route forwards and the UI renders as a `nur geladene Seite` badge beside the
+result count. Without it, "1 Treffer" would read as "the registry has one", and
+an operator would conclude a server is missing when it merely sits past the
+cached page. The `timeout` failure card also stopped claiming the host is
+"offline or blocked" — that is wrong when browsing works — and now points at
+clearing the search box to list the catalog instead.
+
 ### Fixed — MCP marketplace search hung instead of failing, and told you nothing
 
 2026-09-01 — The Marketplace tab's search sat in "Katalog durchsuchen…"

--- a/middleware/src/routes/agentBuilder.ts
+++ b/middleware/src/routes/agentBuilder.ts
@@ -2197,8 +2197,15 @@ export function createAgentBuilderRouter(
       // so Retry and Refresh in the UI actually hit the registry instead of
       // being answered from either cache.
       if (req.query['refresh'] === '1') mcpRegistryClient.invalidate(registry.id);
-      const entries = await mcpRegistryClient.search(await toRegistryConfig(registry), q);
-      res.json({ entries });
+      const { entries, scope } = await mcpRegistryClient.search(
+        await toRegistryConfig(registry),
+        q,
+      );
+      // `scope` travels to the UI: a 'cached-page' result is a substring filter
+      // over the browse page, not the registry's own ranking of the whole
+      // catalog, and the operator has to be told so before concluding that a
+      // server they expected simply is not there.
+      res.json({ entries, scope });
     } catch (err) {
       if (err instanceof McpRegistryError) {
         res.status(502).json({ error: 'mcp_registry_unreachable', code: err.code, message: err.message });

--- a/middleware/src/services/mcpRegistryClient.ts
+++ b/middleware/src/services/mcpRegistryClient.ts
@@ -100,6 +100,19 @@ export class McpRegistryError extends Error {
  *  exactly the case the local-filter fallback exists to rescue. */
 const UNREACHABLE_CODES = new Set(['timeout', 'transport_failed', 'blocked_host']);
 
+/** Substring match over name and description, the fallback ranking whenever a
+ *  registry's own search is unavailable or ignored. */
+function localFilter(
+  entries: readonly McpCatalogEntry[],
+  needle: string,
+): readonly McpCatalogEntry[] {
+  return entries.filter(
+    (e) =>
+      e.name.toLowerCase().includes(needle) ||
+      (e.description ?? '').toLowerCase().includes(needle),
+  );
+}
+
 /** An aborted fetch is our own deadline firing, not a network error — it gets
  *  its own code so the operator is told "too slow", not "unreachable". */
 function isAbort(err: unknown): boolean {
@@ -510,17 +523,34 @@ export class McpRegistryClient {
    */
   private readonly unreachableUntil = new Map<string, number>();
 
-  private throwIfRecentlyUnreachable(registryId: string): void {
+  /** The error a suppressed re-dial would raise, or `null` when the host may
+   *  be tried again. Returning it rather than throwing lets callers that hold
+   *  a usable cached catalog answer from it instead of failing. */
+  private recentlyUnreachable(registryId: string): McpRegistryError | null {
     const until = this.unreachableUntil.get(registryId);
-    if (until === undefined) return;
+    if (until === undefined) return null;
     if (Date.now() >= until) {
       this.unreachableUntil.delete(registryId);
-      return;
+      return null;
     }
-    throw new McpRegistryError(
+    return new McpRegistryError(
       'transport_failed',
       'registry did not answer on the previous attempt; not retried yet',
     );
+  }
+
+  /** The cached catalog for a registry if it is still inside the success TTL,
+   *  else `null`. Deliberately bypasses the unreachable gate — reading a cache
+   *  we already hold touches no network. */
+  private freshlyCached(registryId: string): readonly McpCatalogEntry[] | null {
+    const slot = this.cache.get(registryId);
+    if (!slot || Date.now() - slot.fetchedAtMs >= CACHE_TTL_MS) return null;
+    return slot.entries;
+  }
+
+  private throwIfRecentlyUnreachable(registryId: string): void {
+    const suppressed = this.recentlyUnreachable(registryId);
+    if (suppressed) throw suppressed;
   }
 
   private noteUnreachable(registryId: string, err: unknown): void {
@@ -550,43 +580,73 @@ export class McpRegistryClient {
   /**
    * Search the registry. A non-empty query is passed to the registry's
    * SERVER-SIDE search (Smithery `?q=`, official/generic `?search=`) so the
-   * whole catalog is reachable, not just the first browsed page. The result is
-   * additionally substring-filtered locally as a safety net (a registry that
-   * ignores the param still returns something sensible). An empty query serves
-   * the cached full-first-page browse.
+   * whole catalog is reachable, not just the first browsed page. An empty
+   * query serves the cached full-first-page browse.
    *
    * Failure handling matters for latency, not just correctness: a registry
    * whose host black-holes packets (registry.modelcontextprotocol.io did
-   * exactly that) costs one full timeout per attempt. Retrying the *same dead
-   * host* through the local-filter fallback doubled that into a ~60s spinner
-   * with no feedback. So a transport-level failure is rethrown immediately and
-   * only a protocol-level one (the registry answered, but not usefully — it
-   * may simply ignore the search param) falls through to the local filter.
+   * exactly that) costs one full timeout per attempt, and retrying the same
+   * dead host doubled that into a ~60s spinner.
+   *
+   * `scope` tells the caller what it actually got, because the two are not
+   * interchangeable and the operator must not mistake one for the other:
+   *   'registry' — the registry's own search ranked the whole catalog.
+   *   'cached-page' — its search was unavailable, so this is a substring
+   *                   filter over the browse page we already held. Correct as
+   *                   far as it goes, but only covers that page.
    */
-  async search(registry: McpRegistryConfig, q: string): Promise<readonly McpCatalogEntry[]> {
+  async search(
+    registry: McpRegistryConfig,
+    q: string,
+  ): Promise<{ entries: readonly McpCatalogEntry[]; scope: 'registry' | 'cached-page' }> {
     const needle = q.trim().toLowerCase();
-    if (needle === '') return this.catalog(registry);
+    if (needle === '') return { entries: await this.catalog(registry), scope: 'registry' };
     // official (?search=) and smithery (?q=) honor the query server-side — trust
     // their relevance ranking and return as-is.
     if (registry.kind === 'official' || registry.kind === 'smithery') {
-      this.throwIfRecentlyUnreachable(registry.id);
+      // Already known unreachable: serve a cached browse page if we have one
+      // rather than reporting nothing, and only fail when we have nothing.
+      const suppressed = this.recentlyUnreachable(registry.id);
+      if (suppressed) {
+        const cached = this.freshlyCached(registry.id);
+        if (cached) return { entries: localFilter(cached, needle), scope: 'cached-page' };
+        throw suppressed;
+      }
       try {
-        return await this.fetchCatalog(registry, q.trim());
+        return { entries: await this.fetchCatalog(registry, q.trim()), scope: 'registry' };
       } catch (err) {
         if (err instanceof McpRegistryError && UNREACHABLE_CODES.has(err.code)) {
           this.noteUnreachable(registry.id, err);
+          // The endpoint that failed is the SEARCH endpoint, which is not
+          // necessarily the whole host: registry.modelcontextprotocol.io
+          // serves /v0/servers in under a second while ?search= hangs to the
+          // full timeout. When the browse page is already cached, filtering it
+          // costs no network and gives the operator real results instead of an
+          // error card — strictly better than surfacing the failure.
+          const cached = this.freshlyCached(registry.id);
+          if (cached) {
+            this.log(
+              `[mcpRegistry] "${registry.name}": server-side search failed (${err.code}); ` +
+                `filtering the cached browse page instead`,
+            );
+            return { entries: localFilter(cached, needle), scope: 'cached-page' };
+          }
           throw err;
         }
         /* the registry answered but not usefully — fall through to local filter */
+        return {
+          entries: localFilter(await this.catalog(registry), needle),
+          // Reached only because the server-side search failed. Whatever comes
+          // back is a filter over one page, so it carries the same caveat as
+          // the cached-page path — labelling it 'registry' would overstate it.
+          scope: 'cached-page',
+        };
       }
     }
-    // A generic registry may ignore the param, so substring-filter its page.
-    const entries = await this.catalog(registry);
-    return entries.filter(
-      (e) =>
-        e.name.toLowerCase().includes(needle) ||
-        (e.description ?? '').toLowerCase().includes(needle),
-    );
+    // A `generic` registry is expected to be a plain document rather than a
+    // search API, so filtering what it serves IS the whole registry, not a
+    // degraded substitute for something better.
+    return { entries: localFilter(await this.catalog(registry), needle), scope: 'registry' };
   }
 
   /** Resolve one entry by its catalog id — the from-registry import path.

--- a/middleware/test/mcpRegistryClient.test.ts
+++ b/middleware/test/mcpRegistryClient.test.ts
@@ -69,8 +69,9 @@ describe('McpRegistryClient', () => {
   it('searches name and description case-insensitively', async () => {
     const client = new McpRegistryClient({ fetchImpl: fetchOk(OFFICIAL_DOC), log: () => {} });
     const hits = await client.search(REGISTRY, 'BILLING');
-    assert.equal(hits.length, 1);
-    assert.equal(hits[0]?.id, 'io.github.acme/billing');
+    assert.equal(hits.entries.length, 1);
+    assert.equal(hits.entries[0]?.id, 'io.github.acme/billing');
+    assert.equal(hits.scope, 'registry');
   });
 
   it('resolve throws catalog_entry_not_found for unknown ids', async () => {
@@ -436,6 +437,80 @@ describe('McpRegistryClient', () => {
       client.invalidate(official.id);
       await assert.rejects(client.search(official, 'strava'));
       assert.equal(calls.n, 2);
+    });
+  });
+
+  // Live finding after deploying the fast-fail: registry.modelcontextprotocol.io
+  // serves /v0/servers in under a second (66 servers) while ?search= hangs to
+  // the full timeout. Failing fast was right, but reporting an error while
+  // holding a perfectly good browse page in cache was not — the operator asked
+  // for hits and we had hits.
+  describe('falls back to the cached browse page when only search is broken', () => {
+    /** Browse answers; the search URL never does. */
+    function browseOkSearchDead(counter: { search: number }): typeof fetch {
+      return (async (input: unknown) => {
+        if (String(input).includes('search=')) {
+          counter.search += 1;
+          throw new TypeError('fetch failed');
+        }
+        return new Response(JSON.stringify(OFFICIAL_DOC), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }) as unknown as typeof fetch;
+    }
+
+    it('filters the cached catalog instead of surfacing the search failure', async () => {
+      const calls = { search: 0 };
+      const client = new McpRegistryClient({
+        fetchImpl: browseOkSearchDead(calls),
+        log: () => {},
+      });
+      const official = { ...REGISTRY, id: 'search-dead', kind: 'official' as const };
+
+      // The UI's auto-load browses first, which fills the cache.
+      const browsed = await client.search(official, '');
+      assert.equal(browsed.scope, 'registry');
+      assert.equal(browsed.entries.length, 3);
+
+      const hits = await client.search(official, 'billing');
+      assert.equal(calls.search, 1, 'the server-side search is still attempted once');
+      assert.equal(hits.scope, 'cached-page', 'provenance is reported, not hidden');
+      assert.equal(hits.entries.length, 1);
+      assert.equal(hits.entries[0]?.id, 'io.github.acme/billing');
+    });
+
+    it('keeps serving the cached page while the host stays suppressed', async () => {
+      const calls = { search: 0 };
+      const client = new McpRegistryClient({
+        fetchImpl: browseOkSearchDead(calls),
+        log: () => {},
+      });
+      const official = { ...REGISTRY, id: 'search-dead-2', kind: 'official' as const };
+      await client.search(official, '');
+
+      await client.search(official, 'billing');
+      const again = await client.search(official, 'notes');
+      // The negative cache suppresses the re-dial, and the cached page still
+      // answers — so a second query is instant AND useful.
+      assert.equal(calls.search, 1);
+      assert.equal(again.scope, 'cached-page');
+      assert.equal(again.entries[0]?.id, 'io.github.acme/local-notes');
+    });
+
+    it('still fails when there is no cached page to fall back to', async () => {
+      const calls = { n: 0 };
+      const dead: typeof fetch = (async () => {
+        calls.n += 1;
+        throw new TypeError('fetch failed');
+      }) as unknown as typeof fetch;
+      const client = new McpRegistryClient({ fetchImpl: dead, log: () => {} });
+      const official = { ...REGISTRY, id: 'nothing-cached', kind: 'official' as const };
+      await assert.rejects(
+        client.search(official, 'billing'),
+        (err: unknown) => err instanceof McpRegistryError && err.code === 'transport_failed',
+      );
+      assert.equal(calls.n, 1);
     });
   });
 });

--- a/web-ui/app/_lib/agentBuilder.ts
+++ b/web-ui/app/_lib/agentBuilder.ts
@@ -966,6 +966,11 @@ export interface McpRegistryInfo {
   hasToken: boolean;
 }
 
+/** Where a search result actually came from. `cached-page` means the registry's
+ *  own search was unavailable and the middleware substring-filtered the browse
+ *  page it already held — correct, but limited to that page. */
+export type McpCatalogScope = 'registry' | 'cached-page';
+
 export interface McpCatalogEntry {
   id: string;
   name: string;
@@ -1011,7 +1016,7 @@ export async function searchMcpCatalog(
   registryId: string,
   q: string,
   opts?: { refresh?: boolean; signal?: AbortSignal },
-): Promise<{ entries: McpCatalogEntry[] }> {
+): Promise<{ entries: McpCatalogEntry[]; scope?: McpCatalogScope }> {
   const params = new URLSearchParams();
   if (q) params.set('q', q);
   if (opts?.refresh === true) params.set('refresh', '1');

--- a/web-ui/app/admin/mcp/page.tsx
+++ b/web-ui/app/admin/mcp/page.tsx
@@ -45,6 +45,7 @@ import {
   type McpConfigField,
   type McpCallLogEntry,
   type McpCatalogEntry,
+  type McpCatalogScope,
   type McpGrantMatrixRow,
   type McpOrchestrator,
   type McpPluginCandidate,
@@ -1081,6 +1082,9 @@ function MarketplacePane(): React.ReactElement {
   /** The query the currently displayed `entries` were fetched for — so the
    *  result header never claims a count for a query the user has since edited. */
   const [appliedQuery, setAppliedQuery] = useState('');
+  /** Provenance of the displayed hits — a 'cached-page' result is a substring
+   *  filter over the browse page, not the registry's ranking of its catalog. */
+  const [scope, setScope] = useState<McpCatalogScope>('registry');
   const [loading, setLoading] = useState(false);
   const [failure, setFailure] = useState<CatalogFailure | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -1123,14 +1127,13 @@ function MarketplacePane(): React.ReactElement {
       setFailure(null);
       setConnected(null);
       try {
-        const found = (
-          await searchMcpCatalog(registryId, q, {
-            ...(opts?.refresh === true ? { refresh: true } : {}),
-            ...(opts?.signal ? { signal: opts.signal } : {}),
-          })
-        ).entries;
+        const found = await searchMcpCatalog(registryId, q, {
+          ...(opts?.refresh === true ? { refresh: true } : {}),
+          ...(opts?.signal ? { signal: opts.signal } : {}),
+        });
         if (seq.current !== mine) return;
-        setEntries(found);
+        setEntries(found.entries);
+        setScope(found.scope ?? 'registry');
         setAppliedQuery(q);
       } catch (err) {
         // An abort is this component superseding its own request, not a
@@ -1363,7 +1366,9 @@ function MarketplacePane(): React.ReactElement {
           <div className="text-xs text-[color:var(--fg-muted)]">
             {failure.kind === 'generic'
               ? failure.detail
-              : t('marketplace.errorUnreachableHint')}
+              : failure.kind === 'timeout'
+                ? t('marketplace.errorTimeoutHint')
+                : t('marketplace.errorUnreachableHint')}
           </div>
           <div>
             <Button
@@ -1418,6 +1423,18 @@ function MarketplacePane(): React.ReactElement {
               >
                 {t('marketplace.refresh')}
               </Button>
+              {/* Say so when these hits are a filter over the browse page
+                  rather than the registry's own search: otherwise "1 Treffer"
+                  reads as "the registry has one", and the operator concludes a
+                  server is missing when it is merely past the cached page. */}
+              {scope === 'cached-page' && appliedQuery !== '' ? (
+                <span
+                  title={t('marketplace.scopeCachedPageWhy')}
+                  className="whitespace-nowrap rounded border border-[color:var(--warning)]/50 px-1.5 py-0.5 text-[10px] text-[color:var(--warning)]"
+                >
+                  {t('marketplace.scopeCachedPage')}
+                </span>
+              ) : null}
             </span>
             <span className="sm:text-right">{t('marketplace.hintShort')}</span>
           </div>

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -4237,7 +4237,10 @@
       "errorUnreachableHint": "Der Registry-Host ist offline oder aus dieser Installation heraus blockiert. Wähle oben eine andere Registry oder versuche es gleich noch einmal.",
       "removeRegistryBody": "Registry „{name}“ entfernen? Bereits importierte Server bleiben bestehen.",
       "unlicensedShort": "ohne Lizenz",
-      "refresh": "Aktualisieren"
+      "refresh": "Aktualisieren",
+      "scopeCachedPage": "nur geladene Seite",
+      "scopeCachedPageWhy": "Die Suche dieser Registry hat nicht geantwortet. Diese Treffer sind deshalb ein Textabgleich über die bereits geladene Katalogseite — Server weiter hinten im Katalog sind nicht erfasst. Mit „Aktualisieren“ die Registry-Suche erneut versuchen.",
+      "errorTimeoutHint": "Die Registry hat die Verbindung angenommen, aber nicht rechtzeitig zu Ende geantwortet. Ihre Katalogliste funktioniert womöglich trotzdem — Suchfeld leeren, um den Katalog zu listen, oder erneut versuchen."
     },
     "grants": {
       "grantHeading": "Tools einem Orchestrator zuweisen",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -4237,7 +4237,10 @@
       "errorUnreachableHint": "The registry host is down or blocked from this installation. Pick another registry above, or try again in a moment.",
       "removeRegistryBody": "Remove the registry \"{name}\"? Servers already imported from it stay.",
       "unlicensedShort": "unlicensed",
-      "refresh": "Refresh"
+      "refresh": "Refresh",
+      "scopeCachedPage": "cached page only",
+      "scopeCachedPageWhy": "This registry’s own search did not answer, so these hits are a text match over the catalog page already loaded — servers further into the catalog are not covered. Use Refresh to try the registry’s search again.",
+      "errorTimeoutHint": "The registry accepted the connection but did not finish answering in time. Its browse listing may still work — clear the search box to list the catalog, or try again."
     },
     "grants": {
       "grantHeading": "Grant tools to an orchestrator",


### PR DESCRIPTION
Follow-up to #987, found by watching that fix run against the live registry after deploy.

## What the deploy revealed

#987 turned a ~60-second silent hang into a fast, labelled failure. Correct — but not sufficient, because the host is not down in the way it looked:

| Endpoint | Live behaviour |
|---|---|
| `GET /v0/servers?limit=100` (browse) | ✅ 66 servers, under a second |
| `GET /v0/servers?search=strava` | ❌ hangs to the full 15s timeout |

So browse worked, search showed the error card, and the operator still got **no results** — the originally reported symptom, just faster and better explained. Meanwhile the middleware was holding a perfectly good 66-entry catalog in cache.

## Change

`search()` now falls back to substring-filtering the cached browse page whenever the server-side search fails at the transport level. It costs no network — we already have the entries — and it is the difference between an error card and actual hits. With nothing cached it still fails fast, exactly as #987 made it.

**Provenance is reported, not hidden.** A filter over one page is not the registry's ranking of its whole catalog, so `search()` returns a `scope` (`registry` | `cached-page`), the route forwards it, and the UI renders a `nur geladene Seite` badge beside the result count (with the full explanation on hover). Without it, "1 Treffer" reads as "the registry has one", and an operator concludes a server is missing when it merely sits past the cached page. The same reasoning corrects the label on the existing fall-through path for a registry that answers but ignores the search param — that is a one-page filter too.

The `timeout` failure card also stopped claiming the host is "offline or blocked" — demonstrably wrong when browsing works — and now points at clearing the search box to list the catalog.

## Verification

- middleware: `npm run build` ✓, `tsc --noEmit` ✓, **28/28** `mcpRegistryClient` tests ✓ (3 new: filters the cached catalog rather than surfacing the failure; keeps serving it while the host stays suppressed; still fails when nothing is cached), `typecheck:test` ratchet 370/370 ✓, eslint clean.
- web-ui: `typecheck` ✓, `lint` exit 0 ✓, `i18n:check` 4393 keys ✓, `npm test` 1140/1140 ✓.
- Real Chrome against a stub emitting the new field: browse (`scope=registry`) shows **no** badge; the filtered search (`scope=cached-page`) renders `4 Treffer für „strava" in smithery` **+ `nur geladene Seite`**. Confirmed the badge does not appear on the browse listing, where it would be wrong.

### Test plan

- [ ] With `official` selected, search returns hits from the loaded catalog instead of an error card
- [ ] Those hits carry the `nur geladene Seite` badge; a working registry's search does not
- [ ] Clearing the search box still lists the full browse page
- [ ] A registry that is genuinely unreachable (no cached page) still fails fast with the error card

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790875250&installation_model_id=428086&pr_number=988&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F988&signature=e4723dcf0b4d21a6bbbb010178e930c1ccfccea485adadb06097cee8003234a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->