### PR TITLE
fix: a plugin granted to a running agent works now, not after the next restart

### DIFF
--- a/middleware/packages/harness-orchestrator/src/registry/applyDiff.ts
+++ b/middleware/packages/harness-orchestrator/src/registry/applyDiff.ts
@@ -39,11 +39,23 @@ import type {
  *  - `remove`  — Agent disappeared (row deleted OR status flipped to
  *                disabled). Drop the existing `BuiltOrchestrator`.
  *  - `rebuild` — Agent kept its slug but a runtime-relevant field changed
- *                (privacy_profile, runtime config). Tear down + rebuild.
- *  - `update`  — Agent kept its slug AND its runtime config; only the
- *                plugin / binding lists changed. Refresh registry metadata
- *                without touching the `Orchestrator` instance — sessions
- *                in-flight on the old plugin set keep working (US6).
+ *                (privacy_profile, runtime config, PLUGIN GRANTS). Tear down
+ *                + rebuild.
+ *  - `update`  — Agent kept its slug, its runtime config AND its plugin
+ *                grants; only the channel bindings changed. Refresh registry
+ *                metadata without touching the `Orchestrator` instance.
+ *
+ * Why plugin grants rebuild rather than update: the granted plugin set is
+ * baked into the `Orchestrator` at build time twice over — once as the
+ * `grantedPluginIds` the dispatch gate checks, and once as the domain tools
+ * the kernel hydrates through `onAgentBuilt`, which only an `add`/`rebuild`
+ * fires. An `update` refreshed the registry's metadata and left both stale,
+ * so the operator's grant took effect on the NEXT PROCESS START and not
+ * before. The original design read `update` as the cheap path that let
+ * in-flight sessions finish on the old plugin set (US6); with an enforcing
+ * dispatch gate that same sentence describes a revocation that does not
+ * revoke. Capability changes are rare and operator-driven — correctness
+ * beats the saved rebuild.
  *
  * The function does NOT touch the registry itself; it returns a typed plan
  * the caller (OrchestratorRegistry) executes. This keeps `applyDiff` pure
@@ -111,9 +123,17 @@ export function diffSnapshots(
     if (!isEnabled) continue;
 
     // Both old and new are enabled. Decide rebuild vs metadata-only update.
+    const oldPlugins = oldPluginsByAgent.get(oldAgent!.id) ?? [];
+    const newPlugins = newPluginsByAgent.get(newAgent.id) ?? [];
+
     const reasons = [
       ...runtimeChangeReasons(oldAgent!, newAgent),
       ...graphChangeReasons(oldAgent!.id, newAgent.id, oldSnap, newSnap),
+      // The enabled plugin set IS this agent's authorisation. It reaches the
+      // running orchestrator only through a build, so a grant change that
+      // produced a metadata-only `update` was persisted, reported as saved
+      // and never armed — in both directions.
+      ...(equalPlugins(oldPlugins, newPlugins) ? [] : ['plugin_grants']),
     ];
     if (reasons.length > 0) {
       actions.push({
@@ -124,15 +144,10 @@ export function diffSnapshots(
       continue;
     }
 
-    const oldPlugins = oldPluginsByAgent.get(oldAgent!.id) ?? [];
-    const newPlugins = newPluginsByAgent.get(newAgent.id) ?? [];
     const oldBindings = oldBindingsByAgent.get(oldAgent!.id) ?? [];
     const newBindings = newBindingsByAgent.get(newAgent.id) ?? [];
 
-    if (
-      !equalPlugins(oldPlugins, newPlugins) ||
-      !equalBindings(oldBindings, newBindings)
-    ) {
+    if (!equalBindings(oldBindings, newBindings)) {
       actions.push({ kind: 'update', agent: newAgent });
     }
   }

--- a/middleware/test/agentToolGrantEnforcement.test.ts
+++ b/middleware/test/agentToolGrantEnforcement.test.ts
@@ -7,8 +7,13 @@ import type { EntityRefBus, KnowledgeGraph, MemoryStore } from '@omadia/plugin-a
 
 import type { OrchestratorDeps } from '../packages/harness-orchestrator/src/buildOrchestrator.js';
 import type { NativeToolRegistry } from '../packages/harness-orchestrator/src/nativeToolRegistry.js';
-import type { AgentRow } from '../packages/harness-orchestrator/src/registry/configStore.js';
+import type {
+  AgentRow,
+  ConfigSnapshot,
+  ConfigStore,
+} from '../packages/harness-orchestrator/src/registry/configStore.js';
 import { buildForAgent } from '../packages/harness-orchestrator/src/registry/applyDiff.js';
+import { OrchestratorRegistry } from '../packages/harness-orchestrator/src/registry/index.js';
 
 /**
  * AN AGENT MAY ONLY RUN WHAT IT WAS GRANTED — enforced where the tool is
@@ -149,5 +154,132 @@ test('an empty grant list is "nothing", not "everything"', async () => {
   granted.orchestrator.registerDomainTool(hrTool(ran));
 
   assert.match(await dispatch(granted, 'query_odoo_hr'), /not available/);
+  assert.equal(ran.value, false);
+});
+
+
+/**
+ * THE GRANT HAS TO ARM THE LIVE AGENT, NOT THE NEXT ONE.
+ *
+ * Everything above tests a freshly built Orchestrator, which is the easy case
+ * — the grant was known before the object existed. Production hits the other
+ * case: the operator ticks a plugin on a running agent, the row lands, the UI
+ * says saved, and the question is whether the agent that is already serving
+ * turns can now use it.
+ *
+ * It could not. A grant change produced a metadata-only `update`, so the
+ * running Orchestrator kept both the tool surface and the `grantedPluginIds`
+ * it was born with. The capability appeared on the next process start, which
+ * read from the outside as "assigned plugins only work after a restart".
+ *
+ * This test drives the real registry through the real reload and then asks the
+ * only question that matters: does the tool RUN. Reproducing the boot wiring
+ * (hydrate on `onAgentBuilt`, scoped to the agent's plugins) is the point —
+ * that seam is where the stale surface used to survive.
+ */
+class FakeStore implements Pick<ConfigStore, 'loadSnapshot'> {
+  constructor(private snap: ConfigSnapshot) {}
+  set(snap: ConfigSnapshot): void {
+    this.snap = snap;
+  }
+  loadSnapshot(): Promise<ConfigSnapshot> {
+    return Promise.resolve(this.snap);
+  }
+}
+
+test('a plugin granted to a RUNNING agent works without a restart', async () => {
+  const agent = agentRow('clippy');
+  const empty: ConfigSnapshot = {
+    agents: [agent],
+    agentPlugins: [],
+    channelBindings: [],
+    platformSettings: { fallbackAgentId: null, updatedAt: new Date(0) },
+  };
+  const store = new FakeStore(empty);
+  const registry = new OrchestratorRegistry(store as unknown as ConfigStore, deps(), {
+    defaultRuntimeConfig: RUNTIME,
+  });
+
+  // Stand in for the kernel's boot wiring: every built Orchestrator gets the
+  // tools its plugin grants allow, and nothing else.
+  const ran = { value: false };
+  const hydrate = (slug: string, built: ReturnType<typeof buildForAgent>): void => {
+    const entry = registry.get(slug);
+    const enabled = new Set(
+      (entry?.plugins ?? []).filter((p) => p.enabled).map((p) => p.pluginId),
+    );
+    if (enabled.has(HR_PLUGIN)) built.orchestrator.registerDomainTool(hrTool(ran));
+  };
+  registry.setOnAgentBuilt(hydrate);
+  await registry.start();
+  for (const entry of registry.list()) hydrate(entry.agent.slug, entry.built);
+
+  // Before the grant: refused, and the handler is never reached.
+  const before = registry.get('clippy')!.built;
+  before.orchestrator.registerDomainTool(hrTool(ran));
+  assert.match(await dispatch(before, 'query_odoo_hr'), /not available to this agent/);
+  assert.equal(ran.value, false);
+
+  // The operator grants the plugin; the route reloads the registry.
+  store.set({
+    ...empty,
+    agentPlugins: [
+      {
+        agentId: agent.id,
+        pluginId: HR_PLUGIN,
+        config: {},
+        enabled: true,
+        createdAt: new Date(0),
+      },
+    ],
+  });
+  await registry.reload();
+
+  const after = registry.get('clippy')!.built;
+  assert.equal(await dispatch(after, 'query_odoo_hr'), 'REAL HR DATA');
+  assert.equal(ran.value, true, 'the granted handler actually ran');
+});
+
+test('a plugin revoked from a RUNNING agent stops working immediately', async () => {
+  // The direction that is a security bug rather than an inconvenience: an
+  // operator who withdraws a capability must not have to restart the process
+  // to make the withdrawal true.
+  const agent = agentRow('clippy');
+  const granted: ConfigSnapshot = {
+    agents: [agent],
+    agentPlugins: [
+      {
+        agentId: agent.id,
+        pluginId: HR_PLUGIN,
+        config: {},
+        enabled: true,
+        createdAt: new Date(0),
+      },
+    ],
+    channelBindings: [],
+    platformSettings: { fallbackAgentId: null, updatedAt: new Date(0) },
+  };
+  const store = new FakeStore(granted);
+  const registry = new OrchestratorRegistry(store as unknown as ConfigStore, deps(), {
+    defaultRuntimeConfig: RUNTIME,
+  });
+  await registry.start();
+
+  const ran = { value: false };
+  registry.get('clippy')!.built.orchestrator.registerDomainTool(hrTool(ran));
+  assert.equal(
+    await dispatch(registry.get('clippy')!.built, 'query_odoo_hr'),
+    'REAL HR DATA',
+  );
+
+  store.set({ ...granted, agentPlugins: [] });
+  await registry.reload();
+
+  // The rebuilt Orchestrator has no tool AND no grant. Re-register the tool to
+  // prove the gate — not merely the missing registration — is what refuses.
+  ran.value = false;
+  const after = registry.get('clippy')!.built;
+  after.orchestrator.registerDomainTool(hrTool(ran));
+  assert.match(await dispatch(after, 'query_odoo_hr'), /not available to this agent/);
   assert.equal(ran.value, false);
 });

--- a/middleware/test/orchestratorRegistryHotReload.test.ts
+++ b/middleware/test/orchestratorRegistryHotReload.test.ts
@@ -102,7 +102,7 @@ const baseSnapshot: ConfigSnapshot = {
 
 test('SC-001/SC-002: removing one Agent does NOT touch the other Agent\'s Orchestrator', async () => {
   const store = new MutableFakeStore(baseSnapshot);
-  const registry = new OrchestratorRegistry(store as ConfigStore, deps(), {
+  const registry = new OrchestratorRegistry(store as unknown as ConfigStore, deps(), {
     defaultRuntimeConfig: { model: 'm', maxTokens: 100, maxToolIterations: 4 },
   });
   await registry.start();
@@ -135,7 +135,7 @@ test('SC-001/SC-002: adding a new Agent leaves existing Agents instances untouch
     ...baseSnapshot,
     agents: [agent('public', '00000000-0000-0000-0000-000000000001')],
   });
-  const registry = new OrchestratorRegistry(store as ConfigStore, deps(), {
+  const registry = new OrchestratorRegistry(store as unknown as ConfigStore, deps(), {
     defaultRuntimeConfig: { model: 'm', maxTokens: 100, maxToolIterations: 4 },
   });
   await registry.start();
@@ -157,7 +157,7 @@ test('SC-001/SC-002: adding a new Agent leaves existing Agents instances untouch
 
 test('T020: privacy_profile flip emits a rebuild action and replaces the Orchestrator', async () => {
   const store = new MutableFakeStore(baseSnapshot);
-  const registry = new OrchestratorRegistry(store as ConfigStore, deps(), {
+  const registry = new OrchestratorRegistry(store as unknown as ConfigStore, deps(), {
     defaultRuntimeConfig: { model: 'm', maxTokens: 100, maxToolIterations: 4 },
   });
   await registry.start();
@@ -181,9 +181,29 @@ test('T020: privacy_profile flip emits a rebuild action and replaces the Orchest
   assert.notEqual(registry.get('public')!.built.orchestrator, publicBefore);
 });
 
-test('T020: plugin list change emits an update action without rebuilding the Orchestrator', async () => {
+const SEO_PLUGIN = '@omadia/agent-seo-analyst';
+
+function pluginRow(agentId: string, pluginId: string, enabled = true) {
+  return { agentId, pluginId, config: {}, enabled, createdAt: new Date(0) };
+}
+
+/**
+ * A grant reaches the running Agent only through a BUILD.
+ *
+ * The granted plugin set is baked into the `Orchestrator` twice: as the
+ * `grantedPluginIds` its dispatch gate checks, and as the domain tools the
+ * kernel hydrates from `onAgentBuilt` — which only `add`/`rebuild` fire. So a
+ * metadata-only `update` left the operator's change persisted, reported as
+ * saved, and inert until the next process start.
+ *
+ * These two tests pin both directions, because only one of them is merely
+ * annoying. Granting late means a capability arrives after a restart nobody
+ * asked for; revoking late means a capability the operator took away is still
+ * live — the same privilege escalation as #984, just on a timer.
+ */
+test('granting a plugin rebuilds the Orchestrator (the grant must not wait for a restart)', async () => {
   const store = new MutableFakeStore(baseSnapshot);
-  const registry = new OrchestratorRegistry(store as ConfigStore, deps(), {
+  const registry = new OrchestratorRegistry(store as unknown as ConfigStore, deps(), {
     defaultRuntimeConfig: { model: 'm', maxTokens: 100, maxToolIterations: 4 },
   });
   await registry.start();
@@ -192,12 +212,96 @@ test('T020: plugin list change emits an update action without rebuilding the Orc
 
   store.set({
     ...baseSnapshot,
+    agentPlugins: [pluginRow('00000000-0000-0000-0000-000000000001', SEO_PLUGIN)],
+  });
+  const plan = await registry.reload();
+
+  assert.equal(plan.actions.length, 1);
+  const action = plan.actions[0]!;
+  assert.equal(action.kind, 'rebuild');
+  assert.match(
+    action.kind === 'rebuild' ? action.reason : '',
+    /plugin_grants/,
+    'the reason names the grant change, so the log says why the agent restarted',
+  );
+  assert.notEqual(
+    registry.get('public')!.built.orchestrator,
+    publicBefore,
+    'a fresh Orchestrator is what carries the new grant + tool surface',
+  );
+  assert.deepEqual(
+    registry.get('public')!.plugins.map((p) => p.pluginId),
+    [SEO_PLUGIN],
+    'plugin list is refreshed on the ActiveAgent metadata',
+  );
+});
+
+test('revoking a plugin rebuilds too — a withdrawn capability must stop working now', async () => {
+  const granted: ConfigSnapshot = {
+    ...baseSnapshot,
+    agentPlugins: [pluginRow('00000000-0000-0000-0000-000000000001', SEO_PLUGIN)],
+  };
+  const store = new MutableFakeStore(granted);
+  const registry = new OrchestratorRegistry(store as unknown as ConfigStore, deps(), {
+    defaultRuntimeConfig: { model: 'm', maxTokens: 100, maxToolIterations: 4 },
+  });
+  await registry.start();
+
+  const publicBefore = registry.get('public')!.built.orchestrator;
+
+  store.set(baseSnapshot);
+  const plan = await registry.reload();
+
+  assert.equal(plan.actions.length, 1);
+  assert.equal(plan.actions[0]!.kind, 'rebuild');
+  assert.notEqual(registry.get('public')!.built.orchestrator, publicBefore);
+  assert.deepEqual(registry.get('public')!.plugins, []);
+});
+
+test('disabling a granted plugin counts as a revocation, not a metadata edit', async () => {
+  // `enabled: false` is the UI's toggle. The diff groups on the ENABLED rows,
+  // so a flip has to read as a set change and not as "same row, new column".
+  const granted: ConfigSnapshot = {
+    ...baseSnapshot,
+    agentPlugins: [pluginRow('00000000-0000-0000-0000-000000000001', SEO_PLUGIN)],
+  };
+  const store = new MutableFakeStore(granted);
+  const registry = new OrchestratorRegistry(store as unknown as ConfigStore, deps(), {
+    defaultRuntimeConfig: { model: 'm', maxTokens: 100, maxToolIterations: 4 },
+  });
+  await registry.start();
+
+  store.set({
+    ...baseSnapshot,
     agentPlugins: [
+      pluginRow('00000000-0000-0000-0000-000000000001', SEO_PLUGIN, false),
+    ],
+  });
+  const plan = await registry.reload();
+
+  assert.equal(plan.actions.length, 1);
+  assert.equal(plan.actions[0]!.kind, 'rebuild');
+});
+
+test('T020: a binding-only change still emits a cheap update, not a rebuild', async () => {
+  // The `update` path keeps its reason to exist: channel bindings decide WHERE
+  // an agent is reachable, never WHAT it may do, so routing changes must not
+  // cost every live session its Orchestrator.
+  const store = new MutableFakeStore(baseSnapshot);
+  const registry = new OrchestratorRegistry(store as unknown as ConfigStore, deps(), {
+    defaultRuntimeConfig: { model: 'm', maxTokens: 100, maxToolIterations: 4 },
+  });
+  await registry.start();
+
+  const publicBefore = registry.get('public')!.built.orchestrator;
+
+  store.set({
+    ...baseSnapshot,
+    channelBindings: [
       {
         agentId: '00000000-0000-0000-0000-000000000001',
-        pluginId: '@omadia/agent-seo-analyst',
-        config: {},
-        enabled: true,
+        channelType: 'teams',
+        channelKey: '19:abc@thread.skype',
         createdAt: new Date(0),
       },
     ],
@@ -211,16 +315,11 @@ test('T020: plugin list change emits an update action without rebuilding the Orc
     publicBefore,
     'update should NOT replace the Orchestrator instance',
   );
-  assert.deepEqual(
-    registry.get('public')!.plugins.map((p) => p.pluginId),
-    ['@omadia/agent-seo-analyst'],
-    'plugin list is refreshed on the ActiveAgent metadata',
-  );
 });
 
 test('T020: an idempotent reload (no DB change) emits zero actions', async () => {
   const store = new MutableFakeStore(baseSnapshot);
-  const registry = new OrchestratorRegistry(store as ConfigStore, deps(), {
+  const registry = new OrchestratorRegistry(store as unknown as ConfigStore, deps(), {
     defaultRuntimeConfig: { model: 'm', maxTokens: 100, maxToolIterations: 4 },
   });
   await registry.start();
@@ -258,7 +357,7 @@ test('T022: a throw inside one Agent\'s rebuild does NOT abort the rest of the d
   // SECOND agent — but during start() both build sequentially. We expect the
   // first to throw + be skipped, the second to come up.
   const registry = new OrchestratorRegistry(
-    store as ConfigStore,
+    store as unknown as ConfigStore,
     flakyDeps,
     {
       defaultRuntimeConfig: { model: 'm', maxTokens: 100, maxToolIterations: 4 },


### PR DESCRIPTION
Assigning a plugin in the operator UI persisted the row, reported success, and
changed nothing about the agent that was already serving turns. The capability
appeared on the next process start. From the outside that reads as "the agent
ignores its plugins", which is how it was reported.

## Why a saved grant was inert

The granted plugin set reaches a running Agent only through a BUILD. It is
baked into the `Orchestrator` twice over:

  * as `grantedPluginIds`, the set the dispatch gate checks (#984), and
  * as the domain tools the kernel hydrates from `onAgentBuilt` — a callback
    only the `add` and `rebuild` diff actions fire.

`diffSnapshots` classified a plugin change as `{ kind: 'update' }`. That action
replaces the registry's metadata and deliberately leaves `built` alone, so
both copies stayed exactly as the process had started with. `registry.reload()`
was being called all along — `PUT /:slug/plugins` has always awaited it. The
reload was never the missing piece; the diff decided there was nothing to
rebuild.

## The direction that is not merely annoying

A late grant is an inconvenience. A late REVOCATION is the same privilege
escalation #984 closed, on a timer: the operator unticks a plugin, the UI
confirms, and the agent keeps the tool — and keeps passing the dispatch gate,
because the gate is holding the grant set from boot — until someone restarts
the middleware.

The original design said this out loud and meant well by it: `update` was the
cheap path that let sessions in flight finish on the old plugin set (US6).
With an enforcing dispatch gate that same sentence describes a revocation that
does not revoke.

## The fix

A change to the enabled plugin set is a rebuild reason, alongside
`privacy_profile`, `model_routing` and `context_memory` — all the other fields
that decide what a turn may do. `update` keeps its purpose and its cheap path
for channel bindings, which decide WHERE an agent is reachable and never WHAT
it may do, so routing changes still cost no live sessions.

One line of classification. Both directions correct, and no new mutation API
on the Orchestrator: the rebuild already re-reads grants and re-hydrates the
tool surface from the live source.

## Verification

typecheck, build and the full suite clean — 8245 tests, 8229 pass, 0 fail,
16 skipped. The test-typecheck ratchet improves to 364 against a baseline of
370 (the new tests widened the pre-existing fake-store casts through `unknown`
rather than adding to the debt).

Five tests, RED against this commit's parent (5 fail / 11 pass) and green with
it:

  * granting rebuilds, and the reason names `plugin_grants` so the log says why
  * revoking rebuilds
  * `enabled: false` is a revocation, not a metadata edit
  * a binding-only change still emits the cheap `update`
  * end-to-end through the real registry and the real reload: a plugin granted
    to a RUNNING agent dispatches, and a revoked one is refused — with the tool
    deliberately re-registered afterwards, so it is the gate that refuses and
    not merely a missing registration

`T020: plugin list change emits an update action without rebuilding the
Orchestrator` encoded precisely this bug as the expected behaviour, so it is
inverted rather than supplemented.

Refs byte5ai/omadia#983, byte5ai/omadia#860.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/989"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790913792&installation_model_id=428086&pr_number=989&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F989&signature=467ff090401c28527aa9369d59fae883edd11fce8442c90ffc5f33136247cb10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->