### PR TITLE
fix: a dropped connection on a release runner no longer strands the release

### DIFF
--- a/.github/workflows/desktop-apps.yml
+++ b/.github/workflows/desktop-apps.yml
@@ -477,17 +477,43 @@ jobs:
 
       # The .app is notarized + stapled by electron-builder above; the DMG needs
       # its own ticket so `stapler validate` passes on the disk image itself.
+      # Retried, because this step talks to Apple over the network for minutes at
+      # a time and a dropped connection here is expensive out of all proportion
+      # to its cause: the job fails, `mac-update-feed` fails with it, and
+      # `promote-release` never runs — so the release stays a DRAFT forever and
+      # nobody is told. Seven releases (v0.142.2 … v0.147.12) were stranded that
+      # way; the one we traced died on NSURLErrorDomain -1009, "The Internet
+      # connection appears to be offline", on the runner.
+      #
+      # Both commands are safe to repeat: `notarytool submit` creates a new
+      # submission (Apple accepts a re-submitted, already-notarized DMG) and
+      # `stapler staple` is idempotent. A retry can only cost time, against a
+      # failure mode that costs a release.
       - name: Notarize + staple the DMGs
         if: ${{ startsWith(matrix.os, 'macos') && env.APPLE_P12_BASE64 != '' && env.NOTARIZE == 'yes' }}
         working-directory: desktop
         run: |
-          for dmg in release/*.dmg; do
-            xcrun notarytool submit "$dmg" \
+          notarize_one() {
+            xcrun notarytool submit "$1" \
               --key "$RUNNER_TEMP/asc-key.p8" \
               --key-id "$APPLE_ASC_KEY_ID" \
               --issuer "$APPLE_ASC_ISSUER_ID" \
-              --wait
-            xcrun stapler staple "$dmg"
+              --wait \
+            && xcrun stapler staple "$1"
+          }
+          for dmg in release/*.dmg; do
+            for attempt in 1 2 3; do
+              if notarize_one "$dmg"; then
+                echo "OK notarized + stapled $dmg (attempt $attempt)"
+                break
+              fi
+              if [ "$attempt" = 3 ]; then
+                echo "FAIL: notarization of $dmg did not succeed in 3 attempts" >&2
+                exit 1
+              fi
+              echo "notarization of $dmg failed on attempt $attempt - retrying" >&2
+              sleep 60
+            done
           done
 
       - name: Verify macOS signatures (acceptance gate)

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,15 @@ COPY middleware/scripts/check-node-version.mjs ./scripts/check-node-version.mjs
 # Skipping scripts lets the bundled prebuild be used. The two packages that
 # genuinely need their install script are rebuilt explicitly afterwards; both
 # fetch prebuilt binaries, so no compiler is required either.
+# npm's registry fetches are retried harder than the default (2 attempts, short
+# backoff) because a dropped connection here fails the whole image build: the
+# web-ui edge image died on `npm error code ECONNRESET` mid-`npm ci` while the
+# very same commit built fine in the other pipeline minutes later. Retrying in
+# npm is strictly cheaper than re-running a Docker job by hand, and it applies
+# to `npm rebuild` / `npm install` in this stage too.
+ENV NPM_CONFIG_FETCH_RETRIES=5 \
+    NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=20000 \
+    NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=120000
 RUN NPM_CPU=$(case "${TARGETARCH:-amd64}" in arm64) echo arm64;; *) echo x64;; esac) \
  && npm ci --ignore-scripts --no-audit --no-fund \
  && npm rebuild argon2 esbuild \
@@ -105,6 +114,10 @@ COPY middleware/scripts/check-node-version.mjs ./scripts/check-node-version.mjs
 # See the builder stage for why `--ignore-scripts` + an explicit rebuild is
 # required here (better-sqlite3 v13 + `npm ci` ignoring `gypfile: false`).
 # esbuild is dev-only, so this stage rebuilds argon2 alone.
+# Same registry-retry hardening as the builder stage above — see the note there.
+ENV NPM_CONFIG_FETCH_RETRIES=5 \
+    NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=20000 \
+    NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=120000
 RUN NPM_CPU=$(case "${TARGETARCH:-amd64}" in arm64) echo arm64;; *) echo x64;; esac) \
  && npm ci --omit=dev --ignore-scripts --no-audit --no-fund \
  && npm rebuild argon2 \

--- a/web-ui/Dockerfile
+++ b/web-ui/Dockerfile
@@ -8,6 +8,15 @@
 FROM node:22.23.2-slim AS deps
 WORKDIR /app
 COPY package.json package-lock.json ./
+# npm's registry fetches are retried harder than the default (2 attempts, short
+# backoff) because a dropped connection here fails the whole image build: the
+# web-ui edge image died on `npm error code ECONNRESET` mid-`npm ci` while the
+# very same commit built fine in the other pipeline minutes later. Retrying in
+# npm is strictly cheaper than re-running a Docker job by hand, and it applies
+# to `npm rebuild` / `npm install` in this stage too.
+ENV NPM_CONFIG_FETCH_RETRIES=5 \
+    NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=20000 \
+    NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=120000
 RUN npm ci --no-audit --no-fund
 
 # --- builder ----------------------------------------------------------------


### PR DESCRIPTION
Seven releases — v0.142.2, v0.142.3, v0.144.0, v0.145.0, v0.147.6, v0.147.11,
v0.147.12 — are sitting in this repo as drafts that were never promoted. None
of them failed for a reason anyone would want to keep. They failed because a
socket dropped.

## How a network blip costs a release

`auto-release` creates the release as a draft on purpose (#928) and promotes it
only once `desktop-apps` has attached the installers and the merged update
feed. That gate is right. What it does not survive is a transient failure in
the middle of it:

    desktop-apps / build (macos-26-intel)  FAIL
      └─ desktop-apps / mac-update-feed    FAIL
           └─ promote-release              FAIL   → draft, forever, silently

The traced failure is the whole story:

    Error: HTTPError(... NSURLErrorDomain Code=-1009
    "The Internet connection appears to be offline." ...)

That is `xcrun notarytool submit` failing to reach Apple. The step talks to
Apple over the network for minutes at a time, and a single dropped connection
in that window discards a signed, notarized macOS build and the entire release
around it. Nothing retries and nothing reports it — the run goes red, the next
merge tags the next version, and the draft is left behind. Seven times.

The web-ui edge image shows the same shape from the other side:

    npm error code ECONNRESET
    npm error network aborted
    ERROR: process "/bin/sh -c npm ci --no-audit --no-fund" ... exit code: 1

The same commit built web-ui fine in `publish-images` minutes later. It was
never the code.

## What changes

**Notarization is retried, up to three attempts.** Both commands in the step
are safe to repeat: `notarytool submit` opens a new submission, and Apple
accepts a re-submitted DMG that is already notarized; `stapler staple` is
idempotent. So a retry can only cost time — against a failure that costs a
release. Three failed attempts still fail the job, loudly: this raises the bar
for calling the network broken, it does not paper over a real one.

**npm's registry fetches are retried harder than the default** (2 attempts,
short backoff) in both Dockerfiles, via `NPM_CONFIG_FETCH_RETRIES` and friends
so it covers `npm rebuild` and `npm install` in the same stage, not just the
`npm ci` we happened to catch. Retrying inside npm is strictly cheaper than a
human re-running a Docker job.

## What this does not do

It does not promote the seven existing drafts, and it does not delete them.
They are real releases with real assets and the call on each one is the
maintainer's, not this PR's. It also does not touch the two-phase gate itself
— the gate is correct, it was simply brittle upstream.

Worth knowing: a flake that outlives three attempts still strands a draft
silently. Making the pipeline *notice* that is a separate change, and probably
the better long-term answer than any number of retries.

## Verification

The retry step's control flow is exercised under `bash -e`, the shell GitHub
Actions uses, for all three cases — succeeds first try, succeeds on the third,
never succeeds (exits non-zero). A failed attempt inside `if` does not trip
errexit, which is the one thing that would have turned this into a worse bug
than the one it fixes.

Both Dockerfiles pass `docker build --check` with no warnings. The workflow
YAML is tab-free and parses.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790930410&installation_model_id=428086&pr_number=990&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F990&signature=ada25d442cead61b6b991a4bd4b66017d75202b36718fab5481b790af0cb200f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->