### PR TITLE
fix: close the subscription-CLI process boundary (OM-81, OM-82, OM-83)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,51 @@ changelog.
 
 ## [Unreleased]
 
+### Fixed — The subscription-CLI agent can no longer run shell commands on the user's machine
+
+2026-09-03 — Beta test round 4, OM-81 (#991). On the subscription path the
+agent loop runs inside the external `claude` CLI, and a tester asked the omadia
+chat to run `whoami && hostname`. The CLI did, with the user's OS rights, no
+confirmation, and none of omadia's gates (plugin grants, audience floor, privacy
+guard, `sandbox_execute_enabled`) involved. omadia had registered no shell tool;
+the call came from the CLI's own built-in `Bash`. `--allowedTools mcp__omadia__*`
+only pre-approves omadia's loopback tools, it never removed the built-ins.
+
+The spawn argv now closes the boundary four ways: `--tools ""` removes the
+CLI's built-in tool set (MCP tools stay), `--disallowedTools` carries a named,
+test-asserted deny list (`CLI_BUILTIN_TOOL_DENYLIST`) as a fallback for a CLI
+that ignores `--tools`, `--permission-mode dontAsk` denies anything not
+pre-approved instead of prompting a UI nobody sees, and `--setting-sources ""`
+keeps the operator's personal allow rules out of the session. Any tool call in
+the trace whose name is not `mcp__omadia__*` is marked `foreign`, so a CLI-native
+call can never read like an omadia call.
+
+### Fixed — On the subscription path the agent introduces itself as omadia, not as Claude Code
+
+2026-09-03 — OM-83 (#992). omadia's instructions were passed to the CLI with
+`--append-system-prompt`, so Claude Code's own prompt stayed the primary
+identity. The model told a user sitting in the omadia chat that it was "running
+in a CLI session in the middleware repo", advised them to "ask the same thing in
+an omadia chat", and offered to schedule the task in a different system. The
+prompt is now replaced via `--system-prompt`: the agent's persona comes first,
+followed by a fixed runtime note naming omadia and the only toolset the model
+actually has (the `mcp__omadia__*` MCP tools). A neutral default applies when no
+persona is configured, so the CLI's self-description never leaks through.
+
+### Fixed — omadia's own tools keep the user context when called through the loopback MCP server
+
+2026-09-03 — OM-82 (#993). Asked from the omadia chat to create a routine, the
+CLI-backed agent got `Error: cannot create routine outside a channel turn (no
+user context)` although the request came from a channel. On the subscription
+path a tool call reaches the middleware as an HTTP request from the external
+`claude` process, in a fresh async context, so every per-turn
+`AsyncLocalStorage` (`routineTurnContext`, `privacyHandle`, `toolIdempotency`,
+…) was undefined inside `dispatch()`. The loopback server now snapshots the
+async context it is constructed in (inside the turn) and runs every
+`tools/call` within it, so context-bound tools see the same tenant and user the
+in-process path sees. The `manage_routine` error for a genuinely missing
+context now reads as a runtime wiring fault instead of blaming the caller.
+
 ### Fixed — dashboard and readiness banner read one runtime truth (#999, #1000, #1001, #1002, #1003)
 
 2026-09-03 — omadia beta test round 4 (TE Printline, OM-72/74/75/78/84). The

--- a/docs/middleware-agent-handoff.md
+++ b/docs/middleware-agent-handoff.md
@@ -154,7 +154,12 @@ Forced-`tool_choice`) und `executeDirectLine()` (`#token`-Kandidatenauflösung,
 degradiert auf die bestehende "Specialist … is no longer available."-Notiz
 statt den internen Dispatch-Fehler zu zeigen). Die parallele
 `ToolDispatchService` (Subscription-CLI-Bridge) trägt dieselbe Gate-Logik
-unabhängig nach, da sie ohne Orchestrator-Instanz läuft.
+unabhängig nach, da sie ohne Orchestrator-Instanz läuft. Auf dieser Bridge gibt
+es zusätzlich ein Gate auf der Spawn-Seite: `CliChatAgent` startet die CLI mit
+`--tools ""`, `--disallowedTools`, `--permission-mode dontAsk`,
+`--setting-sources ""` und `--system-prompt`, damit die eingebauten CLI-Tools
+(Bash, Edit, Write, …) und die `~/.claude`-Hooks des Host-Users nie erreichbar
+sind (#991/#992; Details in `docs/security-architecture.md` § 3a).
 
 Zwei unabhängige Readiness-Signale werden UND-verknüpft (jedes kann
 Verfügbarkeit allein verweigern) — bewusst zwei getrennte Caches statt einem

--- a/docs/security-architecture.md
+++ b/docs/security-architecture.md
@@ -55,6 +55,57 @@ tool (`createGraphLookupTool(scope)`), not the raw graph client. The scope:
 - Survives prompt-injection attempts that ask the sub-agent to "use a
   different user id" — the tool simply does not accept an override.
 
+## 3a. Subscription-CLI process boundary (#991, #992, #993)
+
+On the subscription path (`claude-cli` provider, Shape 3) the agent loop does
+not run in the middleware. `CliChatAgent` spawns the official `claude` CLI as a
+child process and hands it omadia's tools over a per-turn loopback MCP server
+(`mcp__omadia__*`). Everything omadia enforces in-process — plugin grants,
+audience floor, privacy guard, `sandbox_execute_enabled` — sits in front of
+*omadia's* tools. The CLI's own built-in tools (Bash, Edit, Write, Read,
+WebFetch, WebSearch, Agent, …) sit behind them, run with the user's OS rights,
+and are one prompt injection away from any mail, document or web page the agent
+reads. Beta test round 4 demonstrated exactly that: the agent ran
+`whoami && hostname` on the tester's Mac on request, with no gate involved.
+
+`--allowedTools mcp__omadia__*` alone was insufficient because it is a
+**pre-approval** list, not a restriction: it only says which tools may run
+without prompting. It never removed the built-ins, and `--strict-mcp-config`
+limits MCP servers only.
+
+The gate is the spawn argv in
+`middleware/packages/harness-orchestrator/src/cliChatAgent.ts`, asserted by
+`test/cliBridge/cliChatAgent.test.ts`:
+
+| Flag | What it closes |
+|---|---|
+| `--tools ""` | Removes the CLI's built-in tool set; only MCP tools remain. Primary lever. |
+| `--disallowedTools <CLI_BUILTIN_TOOL_DENYLIST>` | Names every built-in explicitly; the fallback for a CLI that ignores `--tools`. The list is an exported constant so the test asserts the contract, not the intent. |
+| `--permission-mode dontAsk` | Anything not pre-approved is denied outright. There is no human at a permission prompt in an omadia chat. |
+| `--setting-sources ""` | Loads no user/project/local `settings.json`. Otherwise the host user's `~/.claude` settings apply, including `hooks` (shell commands that run on every tool call) and personal allow rules. Credentials are unaffected: the CLI reads them from `CLAUDE_CONFIG_DIR`, not from settings. |
+| `--strict-mcp-config --mcp-config <0600 file>` | Only omadia's loopback server; no MCP servers from the user's own config. |
+| `--allowedTools mcp__omadia__*` | Pre-approves omadia's tools so the turn does not stall on a prompt. |
+| `--system-prompt <omadia prompt>` | Replaces the CLI's default prompt. With `--append-system-prompt` the model kept Claude Code's identity, treated the CLI toolbox as its own and told users in the omadia chat to "go to omadia" (#992). `composeCliSystemPrompt()` always states the runtime and the only toolset the model has. |
+
+Two further pieces make the boundary observable and keep omadia's own tools
+working across it:
+
+- **Foreign tool marking.** `StreamJsonParser` sets `foreign: true` on every
+  `tool_use` event whose name is not `mcp__omadia__*`. The built-ins are
+  removed at spawn time; if one ever surfaces anyway it can never read like an
+  omadia tool in the trace.
+- **Turn context across the process hop (#993).** A tool call on this path
+  arrives as an HTTP request from the external process, in a fresh async
+  context, so `AsyncLocalStorage` values the channel set around `chat()`
+  (today `routineTurnContext`) were undefined inside `dispatch()` and
+  `manage_routine` reported "no user context" to a user who was in a channel.
+  `LoopbackMcpServer` takes `AsyncLocalStorage.snapshot()` when it is
+  constructed — inside the turn, in `CliChatAgent.runLifecycle` — and runs
+  every `tools/call` inside that snapshot. The snapshot carries whatever stores
+  are active at construction, so a future store needs no change here; a
+  `CliChatAgent`-level test guards against hoisting server creation out of the
+  turn.
+
 ## 4. Plugin install surface
 
 Plugins are installed as signed ZIPs uploaded through the operator UI, not
@@ -582,6 +633,9 @@ Before merging a PR that touches credentials, prompts, or proxy routes:
 - [ ] Any new proxy route validates the response shape before returning it
       to the agent (defends against prompt injection from upstream).
 - [ ] Any new sub-agent tool is scope-locked at construction time.
+- [ ] A change to the `CliChatAgent` spawn argv keeps the deny gate
+      (`--tools ""`, `--disallowedTools`, `--permission-mode dontAsk`,
+      `--setting-sources ""`, `--system-prompt`) and its test (§3a).
 - [ ] No new entry in `auth/publicPaths.ts` unless the route authenticates
       itself, and then only the narrowest regex covering that one route (§10).
 - [ ] No operator surface is mounted inside a `DEV_ENDPOINTS_ENABLED` block —

--- a/middleware/packages/harness-channel-sdk/src/chatAgent.ts
+++ b/middleware/packages/harness-channel-sdk/src/chatAgent.ts
@@ -683,6 +683,14 @@ export type ChatStreamEvent =
       input: unknown;
       /** Set by the chat route when `name` resolves to an installed agent. */
       agent?: AgentMeta;
+      /**
+       * OM-81 — set by the subscription-CLI agent when the call did NOT go
+       * through omadia's loopback MCP server (`mcp__omadia__*`), i.e. it was
+       * one of the CLI's own built-in tools. Those are removed from the CLI
+       * at spawn time; the flag exists so a call that slips through can never
+       * look like an omadia tool in the trace.
+       */
+      foreign?: true;
     }
   | { type: 'tool_result'; id: string; output: string; durationMs: number; isError?: boolean }
   /**

--- a/middleware/packages/harness-orchestrator/src/cliChatAgent.ts
+++ b/middleware/packages/harness-orchestrator/src/cliChatAgent.ts
@@ -59,6 +59,100 @@ export const CLI_ENV_SCRUB_KEYS: readonly string[] = [
   'AWS_DEFAULT_REGION',
 ];
 
+/**
+ * OM-81 (#991) — the CLI's built-in tool set, denied by name at spawn time.
+ *
+ * `--allowedTools mcp__omadia__*` only pre-approves omadia's loopback tools; it
+ * never restricted the CLI's own Bash/Edit/Write/Read/WebFetch. A beta tester
+ * asked the omadia chat to run `whoami && hostname` and the CLI did, with the
+ * user's OS permissions and none of omadia's gates (plugin grants, audience
+ * floor, privacy guard, `sandbox_execute_enabled`) involved. `--tools ""`
+ * removes the built-in set; this list is the belt to that braces for a CLI
+ * that ignores `--tools`, and the contract a test can assert against.
+ */
+export const CLI_BUILTIN_TOOL_DENYLIST: readonly string[] = [
+  'Agent',
+  'Task',
+  'Bash',
+  'BashOutput',
+  'KillShell',
+  'PowerShell',
+  'REPL',
+  'Edit',
+  'MultiEdit',
+  'Write',
+  'Read',
+  'Glob',
+  'Grep',
+  'LS',
+  'NotebookEdit',
+  'NotebookRead',
+  'WebFetch',
+  'WebSearch',
+  'Skill',
+  'SlashCommand',
+  'ToolSearch',
+  'Workflow',
+  'TodoWrite',
+  'TaskCreate',
+  'TaskGet',
+  'TaskList',
+  'TaskUpdate',
+  'TaskOutput',
+  'TaskStop',
+  'ScheduleWakeup',
+  'CronCreate',
+  'CronDelete',
+  'CronList',
+  'ListAgents',
+  'SendMessage',
+  'PushNotification',
+  'RemoteTrigger',
+  'ReportFindings',
+  'EnterPlanMode',
+  'ExitPlanMode',
+  'EnterWorktree',
+  'ExitWorktree',
+  'LSP',
+  'Monitor',
+  'Artifact',
+  'AskUserQuestion',
+  'ListMcpResourcesTool',
+  'ReadMcpResourceTool',
+  'ReadMcpResourceDirTool',
+];
+
+/** Prefix of every tool omadia serves to the CLI over the loopback MCP server. */
+export const OMADIA_MCP_TOOL_PREFIX = 'mcp__omadia__';
+
+/**
+ * OM-83 (#992) — the runtime context every CLI-backed turn carries in its
+ * system prompt. Appended AFTER the caller's persona so identity stays with
+ * omadia's text; it exists because `--system-prompt` drops the CLI's default
+ * prompt entirely (intended: the CLI's self-description made the model believe
+ * it was "Claude Code in the middleware repo" and route users out of omadia),
+ * so the model has to be told here what runtime it is in and which tools it has.
+ */
+const CLI_RUNTIME_CONTEXT = [
+  'You are running inside omadia, an enterprise agent platform, as the assistant of an omadia chat channel.',
+  'You are not Claude Code and you are not in a terminal, repository or IDE; the person you talk to is already inside omadia.',
+  `Your only tools are the omadia tools served over MCP (names starting with ${OMADIA_MCP_TOOL_PREFIX}).`,
+  'You have no shell, file, web or scheduling tools of your own; never claim to run commands or to act in another system.',
+].join(' ');
+
+const DEFAULT_CLI_SYSTEM_PROMPT = 'You are a helpful, precise assistant.';
+
+/**
+ * Compose the `--system-prompt` value: the caller's persona (or a neutral
+ * default when none is configured) followed by the omadia runtime context.
+ */
+export function composeCliSystemPrompt(persona: string | undefined): string {
+  const base = typeof persona === 'string' && persona.trim().length > 0
+    ? persona.trimEnd()
+    : DEFAULT_CLI_SYSTEM_PROMPT;
+  return `${base}\n\n${CLI_RUNTIME_CONTEXT}`;
+}
+
 type JsonRecord = Record<string, unknown>;
 
 export interface CliUsage {
@@ -292,6 +386,10 @@ export class StreamJsonParser {
         id,
         name,
         input: block.input,
+        // OM-81 — a call that did not come through omadia's loopback server is
+        // one of the CLI's own tools. They are removed at spawn time; if one
+        // still shows up it must never read like an omadia tool in the trace.
+        ...(name.startsWith(OMADIA_MCP_TOOL_PREFIX) ? {} : { foreign: true as const }),
       });
     }
 
@@ -603,15 +701,44 @@ export class CliChatAgent implements ChatAgent {
         '--strict-mcp-config',
         '--mcp-config',
         configPath,
+        // OM-81 (#991) — the permission boundary. `--allowedTools` is only a
+        // pre-approval of omadia's loopback tools; on its own it left the
+        // CLI's Bash/Edit/Write/Read/WebFetch reachable with the user's OS
+        // rights and none of omadia's gates in the way. Four flags close it:
+        //   --tools ""            remove the built-in tool set (MCP tools stay)
+        //   --disallowedTools ... deny the built-ins by name as well, for a CLI
+        //                         that ignores `--tools`
+        //   --permission-mode dontAsk  deny anything not pre-approved instead of
+        //                         prompting a UI nobody is watching
+        //   --setting-sources ""  load no user/project/local settings.json.
+        //                         Without it the CLI picks up the host user's
+        //                         ~/.claude settings, including `hooks`, which
+        //                         run shell commands on the machine whenever a
+        //                         tool fires, and personal allow rules. `--tools`
+        //                         closes the built-ins; this closes the side
+        //                         channel. Credentials are unaffected: they are
+        //                         read from CLAUDE_CONFIG_DIR, not from settings,
+        //                         and the MCP server still comes from
+        //                         --mcp-config under --strict-mcp-config.
+        '--tools',
+        '',
+        '--disallowedTools',
+        ...CLI_BUILTIN_TOOL_DENYLIST,
+        '--permission-mode',
+        'dontAsk',
+        '--setting-sources',
+        '',
         '--allowedTools',
-        'mcp__omadia__*',
+        `${OMADIA_MCP_TOOL_PREFIX}*`,
         '--model',
         this.deps.model ?? DEFAULT_MODEL,
+        // OM-83 (#992) — replace, do not append. With `--append-system-prompt`
+        // the CLI's own identity stayed primary and the model told users it
+        // was "Claude Code in the middleware repo", sending them out of the
+        // omadia chat they were already in.
+        '--system-prompt',
+        composeCliSystemPrompt(this.deps.systemPrompt),
       ];
-
-      if (typeof this.deps.systemPrompt === 'string' && this.deps.systemPrompt.length > 0) {
-        argv.push('--append-system-prompt', this.deps.systemPrompt);
-      }
 
       child = (this.deps.spawnFn ?? nodeSpawn)(
         this.deps.cliBinary ?? DEFAULT_CLI_BINARY,

--- a/middleware/packages/harness-orchestrator/src/loopbackMcpServer.ts
+++ b/middleware/packages/harness-orchestrator/src/loopbackMcpServer.ts
@@ -7,6 +7,7 @@
  * the dispatch service and the MCP SDK this package already depends on.
  */
 
+import { AsyncLocalStorage } from 'node:async_hooks';
 import {
   createServer,
   type IncomingMessage,
@@ -61,6 +62,27 @@ export class LoopbackMcpServer {
   private started = false;
   /** #562 — the long-lived serving entry; see `nodeHandler()`. */
   private handler?: ReturnType<typeof toNodeHandler>;
+
+  /**
+   * OM-82 (#993) — the async context this server was CONSTRUCTED in.
+   *
+   * On the subscription path a tool call arrives as an HTTP request from the
+   * external `claude` process, so the `tools/call` handler runs in a fresh
+   * async root with none of the AsyncLocalStorage values the caller had set
+   * around `chat()`. That is why `manage_routine` answered "no user context"
+   * to a user who was in a channel. The server is constructed inside the turn
+   * (see `cliChatAgent.runLifecycle`), so we snapshot the context here and run
+   * every dispatch inside it.
+   *
+   * The snapshot restores whatever stores are active at construction time: on
+   * the CLI path today that is `routineTurnContext` (entered by the channel
+   * adapter around `chat()`); the orchestrator's own `turnContext` is NOT set
+   * on this path, because the CLI owns the loop. Any store a caller enters in
+   * the future is carried automatically. `AsyncLocalStorage.snapshot()` needs
+   * Node >= 20; this package requires >= 20.
+   */
+  private readonly runInTurnContext: <T>(fn: () => T) => T =
+    AsyncLocalStorage.snapshot();
 
   constructor(private readonly deps: LoopbackMcpServerDeps) {
     if (!deps.bearer) {
@@ -175,7 +197,12 @@ export class LoopbackMcpServer {
 
     mcp.server.setRequestHandler('tools/call', async (request) => {
       const { name, arguments: args } = request.params;
-      const result = await this.deps.dispatch.dispatch(name, args ?? {});
+      // OM-82 — run the dispatch inside the turn's captured async context so
+      // context-bound tools (`manage_routine`, privacy handle, idempotency)
+      // see the same (tenant, user) the in-process path would.
+      const result = await this.runInTurnContext(() =>
+        this.deps.dispatch.dispatch(name, args ?? {}),
+      );
       return {
         content: [{ type: 'text' as const, text: result.content }],
         ...(result.isError ? { isError: true } : {}),

--- a/middleware/src/plugins/routines/manageRoutineTool.ts
+++ b/middleware/src/plugins/routines/manageRoutineTool.ts
@@ -14,6 +14,17 @@ import {
 
 export const MANAGE_ROUTINE_TOOL_NAME = 'manage_routine';
 
+/**
+ * OM-82 (#993) — shown when the per-turn user context is missing. The old text
+ * ("outside a channel turn") blamed the caller, but a subscription-CLI user is
+ * IN a channel; the context was dropped crossing the loopback process boundary.
+ * Phrase it as a runtime/configuration fault, not user error.
+ */
+export const ROUTINE_NO_CONTEXT_ERROR =
+  'Error: routines are unavailable in this session because the user context ' +
+  'did not reach the routines tool (a runtime wiring issue, not something you ' +
+  'did wrong). Please report this to your omadia operator.';
+
 const ActionSchema = z.enum(['create', 'list', 'pause', 'resume', 'delete']);
 const ListFilterSchema = z.enum(['all', 'active', 'paused']);
 
@@ -187,7 +198,7 @@ export class ManageRoutineTool {
     }
     const ctx = this.resolveContext();
     if (!ctx) {
-      return 'Error: cannot create routine outside a channel turn (no user context).';
+      return ROUTINE_NO_CONTEXT_ERROR;
     }
 
     // Cold-start 1:1 outreach: when the caller names another person via
@@ -230,7 +241,7 @@ export class ManageRoutineTool {
   private async handleList(args: ManageRoutineInput): Promise<string> {
     const ctx = this.resolveContext();
     if (!ctx) {
-      return 'Error: cannot list routines outside a channel turn (no user context).';
+      return ROUTINE_NO_CONTEXT_ERROR;
     }
     const rows = await this.runner.listRoutines(ctx.tenant, ctx.userId);
     const filter: RoutineListFilter = args.filter ?? 'all';

--- a/middleware/test/cliBridge/cliChatAgent.test.ts
+++ b/middleware/test/cliBridge/cliChatAgent.test.ts
@@ -138,7 +138,7 @@ describe('CliChatAgent CLI process boundary (OM-81, OM-83)', () => {
     const agent = new CliChatAgent({
       dispatch: {
         listDispatchableToolSpecs: () => [],
-      } as CliChatAgentDeps['dispatch'],
+      } as unknown as CliChatAgentDeps['dispatch'],
       createLoopbackServer: () =>
         ({
           start: async () => ({
@@ -243,7 +243,7 @@ describe('CliChatAgent turn context reaches the loopback server (OM-82)', () => 
     const agent = new CliChatAgent({
       dispatch: {
         listDispatchableToolSpecs: () => [],
-      } as CliChatAgentDeps['dispatch'],
+      } as unknown as CliChatAgentDeps['dispatch'],
       // The factory runs where `LoopbackMcpServer` takes its snapshot. If server
       // creation were hoisted out of the turn (e.g. into the constructor), this
       // would read `undefined` and the snapshot would carry no user context.

--- a/middleware/test/cliBridge/cliChatAgent.test.ts
+++ b/middleware/test/cliBridge/cliChatAgent.test.ts
@@ -1,10 +1,13 @@
 import { describe, it } from 'node:test';
 import { strict as assert } from 'node:assert';
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { PassThrough } from 'node:stream';
 
 import {
+  CLI_BUILTIN_TOOL_DENYLIST,
   CliChatAgent,
   StreamJsonParser,
+  composeCliSystemPrompt,
 } from '../../packages/harness-orchestrator/src/cliChatAgent.js';
 import type { CliChatAgentDeps } from '../../packages/harness-orchestrator/src/cliChatAgent.js';
 
@@ -113,5 +116,192 @@ describe('StreamJsonParser (M2 stream-json mapping)', () => {
       agent.chat({ userMessage: 'hello from test' }),
       /terminal result line/,
     );
+  });
+});
+
+/**
+ * OM-81 / OM-83 (#991, #992) — the CLI process boundary.
+ *
+ * `--allowedTools mcp__omadia__*` is a pre-approval, not a restriction: the
+ * CLI's own Bash/Edit/Write/Read/WebFetch stayed reachable and the agent ran
+ * `whoami && hostname` on the tester's machine without any omadia gate. These
+ * tests pin the argv that closes that hole and the system-prompt flag that
+ * makes the model identify as omadia instead of Claude Code.
+ */
+describe('CliChatAgent CLI process boundary (OM-81, OM-83)', () => {
+  /** Spawn a fake child that exits cleanly with a terminal result, capturing argv. */
+  function makeAgent(opts: { readonly systemPrompt?: string } = {}): {
+    readonly agent: CliChatAgent;
+    readonly argv: () => readonly string[];
+  } {
+    let captured: readonly string[] = [];
+    const agent = new CliChatAgent({
+      dispatch: {
+        listDispatchableToolSpecs: () => [],
+      } as CliChatAgentDeps['dispatch'],
+      createLoopbackServer: () =>
+        ({
+          start: async () => ({
+            url: 'http://127.0.0.1:1/mcp',
+            port: 1,
+            bearer: 'bearer',
+          }),
+          stop: async () => {},
+        }) as never,
+      ...(opts.systemPrompt !== undefined ? { systemPrompt: opts.systemPrompt } : {}),
+      spawnFn: ((_bin: string, argv: readonly string[]) => {
+        captured = argv;
+        const stdout = new PassThrough();
+        const stderr = new PassThrough();
+        const stdin = new PassThrough();
+        const child = Object.assign(new PassThrough(), {
+          stdin,
+          stdout,
+          stderr,
+          exitCode: null as number | null,
+          signalCode: null as NodeJS.Signals | null,
+          kill: () => true,
+        });
+        stdin.on('finish', () => {
+          stdout.end(
+            JSON.stringify({ type: 'result', is_error: false, result: 'ok', num_turns: 1 }) + '\n',
+          );
+          child.exitCode = 0;
+          child.emit('close', 0, null);
+        });
+        return child;
+      }) as unknown as CliChatAgentDeps['spawnFn'],
+    });
+    return { agent, argv: () => captured };
+  }
+
+  function valueAfter(argv: readonly string[], flag: string): string | undefined {
+    const idx = argv.indexOf(flag);
+    return idx === -1 ? undefined : argv[idx + 1];
+  }
+
+  it('removes the CLI built-in tool set and denies anything not pre-approved', async () => {
+    const { agent, argv } = makeAgent();
+    await agent.chat({ userMessage: 'run whoami' });
+    const a = argv();
+
+    // `--tools ""` removes every built-in tool; only MCP tools remain.
+    assert.equal(valueAfter(a, '--tools'), '');
+    // Belt and braces: an explicit deny list for the built-ins, so an older
+    // CLI that ignores `--tools ""` still refuses them.
+    const denyIdx = a.indexOf('--disallowedTools');
+    assert.notEqual(denyIdx, -1, 'argv must carry --disallowedTools');
+    const denied = new Set(a.slice(denyIdx + 1, denyIdx + 1 + CLI_BUILTIN_TOOL_DENYLIST.length));
+    for (const tool of ['Bash', 'Edit', 'Write', 'Read', 'WebFetch', 'WebSearch', 'Agent']) {
+      assert.ok(CLI_BUILTIN_TOOL_DENYLIST.includes(tool), `denylist names ${tool}`);
+      assert.ok(denied.has(tool), `argv denies ${tool}`);
+    }
+    // Anything not pre-approved is denied instead of prompting a UI nobody sees.
+    assert.equal(valueAfter(a, '--permission-mode'), 'dontAsk');
+    // No user/project/local settings.json: the host user's `hooks` and
+    // personal allow rules must not reach a session omadia spawns.
+    assert.equal(valueAfter(a, '--setting-sources'), '');
+    // The omadia loopback tools stay pre-approved.
+    assert.equal(valueAfter(a, '--allowedTools'), 'mcp__omadia__*');
+  });
+
+  it('replaces the CLI system prompt instead of appending to it', async () => {
+    const { agent, argv } = makeAgent({ systemPrompt: 'You are Hedwig, the HR assistant.' });
+    await agent.chat({ userMessage: 'hi' });
+    const a = argv();
+
+    assert.equal(a.includes('--append-system-prompt'), false);
+    const prompt = valueAfter(a, '--system-prompt');
+    assert.ok(prompt, 'argv must carry --system-prompt');
+    assert.match(prompt, /Hedwig, the HR assistant/);
+    // The prompt names the runtime and the only toolset the model has.
+    assert.match(prompt, /omadia/);
+    assert.match(prompt, /mcp__omadia__/);
+  });
+
+  it('still replaces the system prompt when no omadia prompt is configured', async () => {
+    const { agent, argv } = makeAgent();
+    await agent.chat({ userMessage: 'hi' });
+    const prompt = valueAfter(argv(), '--system-prompt');
+    assert.ok(prompt && prompt.length > 0);
+    assert.match(prompt, /omadia/);
+  });
+
+  it('composeCliSystemPrompt keeps the caller prompt first and appends the runtime context once', () => {
+    const composed = composeCliSystemPrompt('Persona text.');
+    assert.ok(composed.startsWith('Persona text.'));
+    assert.equal(composed.split('mcp__omadia__').length, 2);
+    assert.equal(composeCliSystemPrompt(undefined), composeCliSystemPrompt(''));
+  });
+});
+
+describe('CliChatAgent turn context reaches the loopback server (OM-82)', () => {
+  it('constructs the loopback server inside the async context chat() was called in', async () => {
+    const turnStore = new AsyncLocalStorage<string>();
+    let storeAtConstruction: string | undefined = 'never-called';
+
+    const agent = new CliChatAgent({
+      dispatch: {
+        listDispatchableToolSpecs: () => [],
+      } as CliChatAgentDeps['dispatch'],
+      // The factory runs where `LoopbackMcpServer` takes its snapshot. If server
+      // creation were hoisted out of the turn (e.g. into the constructor), this
+      // would read `undefined` and the snapshot would carry no user context.
+      createLoopbackServer: () => {
+        storeAtConstruction = turnStore.getStore();
+        return {
+          start: async () => ({ url: 'http://127.0.0.1:1/mcp', port: 1, bearer: 'b' }),
+          stop: async () => {},
+        } as never;
+      },
+      spawnFn: (() => {
+        const stdout = new PassThrough();
+        const stderr = new PassThrough();
+        const stdin = new PassThrough();
+        const child = Object.assign(new PassThrough(), {
+          stdin,
+          stdout,
+          stderr,
+          exitCode: null as number | null,
+          signalCode: null as NodeJS.Signals | null,
+          kill: () => true,
+        });
+        stdin.on('finish', () => {
+          stdout.end(
+            JSON.stringify({ type: 'result', is_error: false, result: 'ok', num_turns: 1 }) + '\n',
+          );
+          child.exitCode = 0;
+          child.emit('close', 0, null);
+        });
+        return child;
+      }) as unknown as CliChatAgentDeps['spawnFn'],
+    });
+
+    await turnStore.run('turn:te-printline/silvio', () => agent.chat({ userMessage: 'hi' }));
+    assert.equal(storeAtConstruction, 'turn:te-printline/silvio');
+  });
+});
+
+describe('StreamJsonParser foreign tool marking (OM-81)', () => {
+  it('flags tool calls outside mcp__omadia__* as foreign', () => {
+    const p = new StreamJsonParser(() => 0);
+    const events = p.push(
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          content: [
+            { type: 'tool_use', id: 'a', name: 'Bash', input: { command: 'whoami' } },
+            { type: 'tool_use', id: 'b', name: 'mcp__omadia__query_processes', input: {} },
+          ],
+        },
+      }),
+    );
+    const byId = new Map(events.map((e) => [(e as { id: string }).id, e]));
+    const bash = byId.get('a') as { type: string; foreign?: true };
+    const omadia = byId.get('b') as { type: string; foreign?: true };
+    assert.equal(bash.type, 'tool_use');
+    assert.equal(bash.foreign, true);
+    assert.equal(omadia.type, 'tool_use');
+    assert.equal('foreign' in omadia, false);
   });
 });

--- a/middleware/test/cliBridge/loopbackMcpServer.test.ts
+++ b/middleware/test/cliBridge/loopbackMcpServer.test.ts
@@ -1,4 +1,5 @@
 import { strict as assert } from 'node:assert';
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { afterEach, describe, it } from 'node:test';
 
 import { LoopbackMcpServer } from '../../packages/harness-orchestrator/src/loopbackMcpServer.js';
@@ -448,5 +449,66 @@ describe('LoopbackMcpServer', () => {
     };
     assert.equal(payload.error?.code, 413);
     assert.equal(payload.error?.message, 'Payload Too Large');
+  });
+
+  /**
+   * OM-82 (#993) — on the subscription path a tool call arrives as an HTTP
+   * request from the external `claude` process, i.e. in a fresh async context.
+   * Every AsyncLocalStorage the channel turn set (routineTurnContext,
+   * privacyHandle, toolIdempotency, ...) was undefined inside `dispatch()`, so
+   * `manage_routine` answered "no user context" to a user who was in a channel.
+   * The server must capture the turn's async context when it is created and
+   * run each dispatch inside it.
+   */
+  it('runs tools/call inside the async context the server was created in', async (t) => {
+    const turnStore = new AsyncLocalStorage<{ readonly tenant: string; readonly userId: string }>();
+    const fakeDispatch = {
+      async dispatch(name: string) {
+        const turn = turnStore.getStore();
+        return { content: `${name}:${turn ? `${turn.tenant}/${turn.userId}` : 'no-context'}` };
+      },
+    } as unknown as ToolDispatchService;
+
+    // Construct inside the turn scope, exactly as CliChatAgent.runLifecycle does.
+    server = turnStore.run({ tenant: 'te-printline', userId: 'silvio' }, () =>
+      new LoopbackMcpServer({
+        dispatch: fakeDispatch,
+        bearer: 'secret-token',
+        tools: [{ name: 'manage_routine', description: 'r', input_schema: { type: 'object', properties: {} } }],
+      }),
+    );
+
+    let handle: Awaited<ReturnType<typeof server.start>>;
+    try {
+      handle = await server.start();
+    } catch (error) {
+      if (isSandboxListenDenied(error)) {
+        t.skip('sandbox blocks loopback listeners');
+        return;
+      }
+      throw error;
+    }
+
+    // The call comes from outside the turn scope (a different async context).
+    assert.equal(turnStore.getStore(), undefined);
+    const callResponse = await fetch(handle.url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${handle.bearer}`,
+        'Content-Type': 'application/json',
+        Accept: MCP_ACCEPT,
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'tools/call',
+        params: { name: 'manage_routine', arguments: { action: 'list' } },
+        id: 7,
+      }),
+    });
+    assert.equal(callResponse.status, 200);
+    const payload = parseMcpJson(await callResponse.text()) as {
+      result?: { content?: Array<{ text?: string }> };
+    };
+    assert.equal(payload.result?.content?.[0]?.text, 'manage_routine:te-printline/silvio');
   });
 });

--- a/middleware/test/manageRoutineTool.test.ts
+++ b/middleware/test/manageRoutineTool.test.ts
@@ -159,7 +159,11 @@ describe('ManageRoutineTool — create', () => {
       cron: '0 9 * * 1',
       prompt: 'p',
     });
-    assert.match(result, /^Error: cannot create routine outside a channel/);
+    // OM-82 (#993) — the message no longer blames the caller ("outside a
+    // channel turn"); a subscription-CLI user IS in a channel and the context
+    // was dropped crossing the loopback boundary. It now reads as a runtime fault.
+    assert.match(result, /^Error: routines are unavailable in this session/);
+    assert.doesNotMatch(result, /outside a channel/);
     assert.equal(calls.length, 0);
   });
 


### PR DESCRIPTION
Beta test round 4 (TE Printline, 03.09.2026), cluster A. Umbrella #1006.

Closes #991
Closes #992
Closes #993

## What

The subscription path spawns the Claude Code CLI as a child process. `--allowedTools mcp__omadia__*` only pre-approves omadia's MCP tools, it does not remove the CLI's built-ins, so the agent could run `Bash` (`whoami && hostname`) on the tester's Mac with none of omadia's gates involved.

- **OM-81** `cliChatAgent.ts` argv now carries `--tools ""` (drop the built-in tool set), `--disallowedTools <CLI_BUILTIN_TOOL_DENYLIST>` (belt for CLIs that ignore `--tools`), `--permission-mode dontAsk` (deny instead of prompt), `--setting-sources ""` (the host user's `~/.claude` hooks and allow rules no longer apply). `tool_use` events whose name is not `mcp__omadia__*` are marked `foreign` in the stream and on the channel-sdk event type.
- **OM-83** `--system-prompt` replaces `--append-system-prompt`; `composeCliSystemPrompt()` states the runtime and the only toolset, so the model stops believing it is Claude Code.
- **OM-82** `loopbackMcpServer.ts` captures `AsyncLocalStorage.snapshot()` at construction (per turn) and runs every `tools/call` inside it, so `routineTurnContext` survives the process hop and `manage_routine` works from a CLI-backed chat. The no-context error is reworded as a runtime fault.
- Docs: CHANGELOG, `security-architecture.md` §3a + reviewer checklist, handoff note.

Follow-ups filed: #1007 (`claudeCliAdapter.ts` second spawn path), #1008 (render `foreign` in trace/receipts).

## Test plan

- [x] `harness-orchestrator` + `harness-channel-sdk` typecheck
- [x] `test/cliBridge/cliChatAgent.test.ts`, `loopbackMcpServer.test.ts`, `manageRoutineTool.test.ts`: 35 pass (argv gate, deny list, permission mode, setting sources, system prompt, foreign marking, ALS propagation incl. hoisting guard)
- [x] Reviewed by omadia-reviewer (blocking items resolved) and a cross-vendor security review
- [ ] Manual: CLI-backed chat asked for `whoami` refuses; `manage_routine create` succeeds

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/1009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791032405&installation_model_id=428086&pr_number=1009&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F1009&signature=0f9e457d480efdc1003f3a6b4d6c8e3d9b9266109dfce4a084c88b73b8e6536a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->