### PR TITLE
fix(desktop): mDNS no longer renames the Mac, shell dialogs get a parent (OM-70, OM-71)

### DIFF
--- a/desktop/src/appPageBoot.ts
+++ b/desktop/src/appPageBoot.ts
@@ -1,0 +1,36 @@
+/**
+ * The one sequence that puts the web UI on screen and then speaks (OM-71).
+ *
+ *   arm the ready gate → load the app URL → mark the shell running →
+ *   wait for the UI's ready ping (or the fallback) → remind about the key.
+ *
+ * Boot and restart both did this by hand, and both got the order wrong in the
+ * same way: the reminder followed `loadURL`, which resolves on the document,
+ * not on a screen. One function, called from both paths, so the order can be
+ * tested once and cannot drift apart again.
+ */
+import type { UiReadyGate, UiReadyOutcome } from './uiReadyGate';
+
+export interface ShowAppPageDeps {
+  readonly gate: UiReadyGate;
+  /** `win.loadURL(uiUrl)`. */
+  loadApp(): Promise<void>;
+  /** Runs as soon as the document is up (tray to "running"). */
+  onLoaded(): void;
+  /** The recovery-key reminder; only reached once the page is standing. */
+  remind(): Promise<void>;
+}
+
+/**
+ * Returns how the wait ended. `superseded` means a newer navigation replaced
+ * this one while we waited; the reminder then belongs to that one, not to us.
+ */
+export async function showAppPage(deps: ShowAppPageDeps): Promise<UiReadyOutcome> {
+  // Armed BEFORE the load so a fast renderer cannot ping into the void.
+  const ready = deps.gate.arm();
+  await deps.loadApp();
+  deps.onLoaded();
+  const outcome = await ready;
+  if (outcome !== 'superseded') await deps.remind();
+  return outcome;
+}

--- a/desktop/src/ipc.ts
+++ b/desktop/src/ipc.ts
@@ -27,6 +27,8 @@ export interface IpcDeps {
   boot: (forward: (p: BootProgress) => void) => Promise<string>;
   /** Called once the UI is serving so main can swap the wizard for the app window. */
   onReady: (uiUrl: string) => void;
+  /** OM-71: the web UI reports that its first real screen is standing. */
+  onUiReady: () => void;
 }
 
 /**
@@ -91,6 +93,8 @@ async function chooseDataDirWithSyncWarning(
 }
 
 export function registerIpc(deps: IpcDeps): void {
+  ipcMain.on(CH.uiReady, () => deps.onUiReady());
+
   ipcMain.handle(CH.getState, (): AppState => ({
     setupComplete: isSetupComplete(),
     encryptionAvailable: isEncryptionAvailable(),

--- a/desktop/src/ipcTypes.ts
+++ b/desktop/src/ipcTypes.ts
@@ -8,6 +8,8 @@ export const CH = {
   exportRecoveryKey: 'omadia:exportRecoveryKey',
   bootProgress: 'omadia:bootProgress',
   bootLog: 'omadia:bootLog',
+  /** OM-71: renderer → main, "the first real screen is standing". */
+  uiReady: 'omadia:uiReady',
 } as const;
 
 /** A single line streamed to the wizard/loading UI during boot. */

--- a/desktop/src/kernelEnvDefaults.ts
+++ b/desktop/src/kernelEnvDefaults.ts
@@ -1,0 +1,40 @@
+/**
+ * Environment defaults the desktop shell imposes on the kernel it spawns.
+ *
+ * The kernel's own defaults are tuned for self-hosters on a LAN. Some of them
+ * are wrong for a single-user app where user and services share one machine.
+ * Each entry here says which default it overrides and why; an explicit value in
+ * the user's environment always wins, so an operator can still opt back in.
+ */
+
+import { log } from './log';
+
+/** The slice of the kernel env this module decides. */
+export interface DesktopKernelEnvDefaults {
+  readonly OMADIA_UI_MDNS_ENABLED: 'true' | 'false';
+}
+
+/**
+ * OM-70 (#1004): the kernel advertises `_omadia._tcp` over mDNS by default so a
+ * desktop client can discover a self-hosted kernel on the LAN. Inside the
+ * desktop app there is nothing to discover, and the second responder claimed
+ * the Mac's own `<LocalHostName>.local`; macOS treated it as a foreign device
+ * and renamed the machine on every start (`-8` → `-9` → `-10`). Off unless the
+ * user set it themselves.
+ */
+export function desktopKernelEnvDefaults(
+  userEnv: NodeJS.ProcessEnv,
+): DesktopKernelEnvDefaults {
+  const explicit = userEnv['OMADIA_UI_MDNS_ENABLED'];
+  if (explicit === 'true' || explicit === 'false') return { OMADIA_UI_MDNS_ENABLED: explicit };
+  if (explicit !== undefined && explicit !== '') {
+    // The kernel parses `z.enum(['true','false'])`; anything else would take the
+    // boot down. Falling back to off is the safe reading, but an opt-in typo
+    // (`1`, `TRUE`) must not vanish silently.
+    log.warn(
+      `[supervisor] OMADIA_UI_MDNS_ENABLED=${JSON.stringify(explicit)} is not 'true' or 'false'; ` +
+        'the mDNS advertiser stays off',
+    );
+  }
+  return { OMADIA_UI_MDNS_ENABLED: 'false' };
+}

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -32,6 +32,8 @@ import {
   showSupersededBoot,
 } from './shellDialogs';
 import { maybeRemindRecoveryKey, showRecoveryKeyAction } from './recoveryKeyActions';
+import { createUiReadyGate } from './uiReadyGate';
+import { showAppPage } from './appPageBoot';
 
 // Stable app identity so userData resolves to ".../omadia" in both dev and
 // packaged builds (in dev the Electron CLI would otherwise name it "Electron").
@@ -53,6 +55,14 @@ let streamBootLogs = false;
 
 /** Bounded budget for replacing a dead renderer (OM-57). See `loadFailure.ts`. */
 let recoveryBudget: RecoveryBudget = initialRecoveryBudget();
+
+/**
+ * OM-71 — shell dialogs wait for the web UI's ready ping, not for `loadURL`.
+ * The fallback is generous: a slow first hydration must not be mistaken for a
+ * renderer that will never ping, and a late reminder still beats none.
+ */
+const UI_READY_FALLBACK_MS = 15_000;
+const uiReadyGate = createUiReadyGate(UI_READY_FALLBACK_MS);
 
 /**
  * `app.getLocale()` is only meaningful after the ready event, so the translator
@@ -182,7 +192,7 @@ async function recoverRenderer(): Promise<void> {
   if (!attempt.allowed) {
     log.error(`[main] giving up recovering ${page} after ${attempt.budget.attempts - 1} attempts`);
     setTrayStatus(trayActions(), 'error');
-    await showRecoveryExhausted(t, logFile());
+    await showRecoveryExhausted(win, t, logFile());
     return;
   }
 
@@ -234,11 +244,12 @@ function trayActions(): TrayActions {
     },
     restart: async () => {
       if (!supervisor || !win) return;
+      const w = win;
       const token = startNavigation('boot', 'restart');
       if (token === null) {
         // The arbiter refused (first-run setup is open). Say so: a menu action
         // that visibly does nothing is its own small version of this bug class.
-        await showRestartRefused(t);
+        await showRestartRefused(win, t);
         return;
       }
       await win.loadFile(rendererPath(LOADING_PAGE));
@@ -249,9 +260,12 @@ function trayActions(): TrayActions {
         const uiUrl = await supervisor.restart();
         streamBootLogs = false;
         if (!finishNavigation(token, 'app', 'restart')) return;
-        await win.loadURL(uiUrl);
-        setTrayStatus(trayActions(), 'running');
-        await maybeRemindRecoveryKey(t);
+        await showAppPage({
+          gate: uiReadyGate,
+          loadApp: () => w.loadURL(uiUrl),
+          onLoaded: () => setTrayStatus(trayActions(), 'running'),
+          remind: () => maybeRemindRecoveryKey(w, t),
+        });
       } catch (err) {
         log.error(`[main] restart failed: ${describeError(err)}`);
         setTrayStatus(trayActions(), 'error');
@@ -289,6 +303,7 @@ onLog((level, msg) => {
 
 async function bootExistingInstall(): Promise<void> {
   if (!win || !supervisor) return;
+  const w = win;
   const token = startNavigation('boot', 'boot-existing');
   if (token === null) return;
   await win.loadFile(rendererPath(LOADING_PAGE));
@@ -298,9 +313,12 @@ async function bootExistingInstall(): Promise<void> {
     const uiUrl = await supervisor.start();
     streamBootLogs = false;
     if (!finishNavigation(token, 'app', 'boot-existing')) return;
-    await win.loadURL(uiUrl);
-    setTrayStatus(trayActions(), 'running');
-    await maybeRemindRecoveryKey(t);
+    await showAppPage({
+      gate: uiReadyGate,
+      loadApp: () => w.loadURL(uiUrl),
+      onLoaded: () => setTrayStatus(trayActions(), 'running'),
+      remind: () => maybeRemindRecoveryKey(w, t),
+    });
   } catch (err) {
     streamBootLogs = false;
     await presentBootFailure(err);
@@ -365,7 +383,9 @@ async function onReady(): Promise<void> {
   // fullscreen item and a DevTools accelerator into customer builds).
   installApplicationMenu({
     checkForUpdates: checkForUpdatesAction,
-    showRecoveryKey: () => void showRecoveryKeyAction(t),
+    showRecoveryKey: () => {
+      if (win) void showRecoveryKeyAction(win, t);
+    },
   });
   supervisor = new Supervisor();
   setActiveSupervisor(supervisor);
@@ -393,6 +413,7 @@ async function onReady(): Promise<void> {
       void win?.loadURL(uiUrl);
       setTrayStatus(trayActions(), 'running');
     },
+    onUiReady: () => uiReadyGate.signal(),
   });
 
   initUpdater();

--- a/desktop/src/preload.ts
+++ b/desktop/src/preload.ts
@@ -32,6 +32,13 @@ const api = {
     ipcRenderer.on(CH.bootLog, listener);
     return () => ipcRenderer.removeListener(CH.bootLog, listener);
   },
+  /**
+   * OM-71 — the web UI calls this once its first real screen is up, so shell
+   * dialogs (the recovery-key reminder) wait for a page rather than a
+   * navigation. Fire-and-forget; the web UI must keep working in a browser
+   * where this bridge does not exist.
+   */
+  uiReady: (): void => ipcRenderer.send(CH.uiReady),
 };
 
 contextBridge.exposeInMainWorld('omadia', api);

--- a/desktop/src/recoveryKeyActions.ts
+++ b/desktop/src/recoveryKeyActions.ts
@@ -21,6 +21,7 @@
  * still caught on the next start. The proper fix is one line in that IPC
  * handler, and it is commented there so whoever works in `ipc.ts` finds it.
  */
+import type { BrowserWindow } from 'electron';
 import { exportRecoveryKey } from './secrets';
 import { log, logFile } from './log';
 import { describeError } from './bootFailure';
@@ -32,17 +33,17 @@ import {
 } from './shellDialogs';
 import type { ShellTranslate } from './shellStrings';
 
-export async function showRecoveryKeyAction(t: ShellTranslate): Promise<void> {
+export async function showRecoveryKeyAction(win: BrowserWindow, t: ShellTranslate): Promise<void> {
   let key: string;
   try {
     key = exportRecoveryKey();
   } catch (err) {
     log.error(`[main] recovery key unavailable: ${describeError(err)}`);
-    await showRecoveryKeyUnavailable(t, describeError(err), logFile());
+    await showRecoveryKeyUnavailable(win, t, describeError(err), logFile());
     return;
   }
 
-  await showRecoveryKey(t, key);
+  await showRecoveryKey(win, t, key);
 
   // Recorded AFTER the dialog closes, and guarded: `writeSetup` is a bare
   // `writeFileSync`, so a read-only directory or a full disk would otherwise
@@ -57,8 +58,14 @@ export async function showRecoveryKeyAction(t: ShellTranslate): Promise<void> {
   }
 }
 
-/** Ask once, for a boot-verified install that has never displayed the key. */
-export async function maybeRemindRecoveryKey(t: ShellTranslate): Promise<void> {
+/**
+ * Ask once, for a boot-verified install that has never displayed the key.
+ *
+ * Callers await the UI-ready gate first (OM-71): the reminder used to appear
+ * over "Loading login…" because `loadURL` resolves on the document, not on the
+ * screen the user is going to see.
+ */
+export async function maybeRemindRecoveryKey(win: BrowserWindow, t: ShellTranslate): Promise<void> {
   if (!needsRecoveryKeyReminder()) return;
-  if ((await showRecoveryReminder(t)) === 'show-now') await showRecoveryKeyAction(t);
+  if ((await showRecoveryReminder(win, t)) === 'show-now') await showRecoveryKeyAction(win, t);
 }

--- a/desktop/src/shellDialogs.ts
+++ b/desktop/src/shellDialogs.ts
@@ -12,8 +12,25 @@
  * Every function takes the translator rather than building one, so the locale is
  * resolved once at startup and no dialog can silently fall back to English.
  */
-import { BrowserWindow, clipboard, dialog } from 'electron';
+import { BrowserWindow, clipboard, dialog, type MessageBoxOptions, type MessageBoxReturnValue } from 'electron';
 import { fillPlaceholders, type ShellTranslate } from './shellStrings';
+
+/**
+ * Every dialog goes through here so it is attached to the main window (OM-71).
+ *
+ * Five of the seven used to call `dialog.showMessageBox(options)` without a
+ * parent. On macOS that is an application-modal, free-floating window: the
+ * reminder about the recovery key was half covered by a system dialog and the
+ * dialog that shows the key itself could get lost behind other windows. A
+ * destroyed window cannot parent anything, so that one case falls back to the
+ * old behaviour rather than throwing over the vault key.
+ */
+async function messageBox(
+  win: BrowserWindow,
+  options: MessageBoxOptions,
+): Promise<MessageBoxReturnValue> {
+  return win.isDestroyed() ? dialog.showMessageBox(options) : dialog.showMessageBox(win, options);
+}
 
 /** What the user chose in the boot-failure dialog. */
 export type BootFailureChoice = 'rerun-setup' | 'quit';
@@ -30,7 +47,7 @@ export type RecoveryReminderChoice = 'show-now' | 'later';
  * the only correct action, waiting, was not on offer.
  */
 export async function showSupersededBoot(win: BrowserWindow, t: ShellTranslate): Promise<void> {
-  await dialog.showMessageBox(win, {
+  await messageBox(win, {
     type: 'info',
     title: t('boot.superseded.title', 'Applying update'),
     message: t('boot.superseded.message', 'omadia is applying an update.'),
@@ -51,7 +68,7 @@ export async function showBootFailure(
   detail: string,
   logPath: string,
 ): Promise<BootFailureChoice> {
-  const { response } = await dialog.showMessageBox(win, {
+  const { response } = await messageBox(win, {
     type: 'error',
     title: t('boot.failed.title', 'omadia failed to start'),
     message: t('boot.failed.message', 'omadia could not start its local services.'),
@@ -76,10 +93,11 @@ export async function showBootFailure(
  * first version of the recovery path turned into a silent infinite loop.
  */
 export async function showRecoveryExhausted(
+  win: BrowserWindow,
   t: ShellTranslate,
   logPath: string,
 ): Promise<void> {
-  await dialog.showMessageBox({
+  await messageBox(win, {
     type: 'error',
     title: t('shell.loadFailed.exhausted.title', 'The interface could not be loaded'),
     message: t(
@@ -105,8 +123,8 @@ export async function showRecoveryExhausted(
  * The arbiter already refuses it; without this the tray item just did nothing
  * visible, which is its own small version of the same problem.
  */
-export async function showRestartRefused(t: ShellTranslate): Promise<void> {
-  await dialog.showMessageBox({
+export async function showRestartRefused(win: BrowserWindow, t: ShellTranslate): Promise<void> {
+  await messageBox(win, {
     type: 'info',
     title: t('shell.restartRefused.title', 'Cannot restart right now'),
     message: t('shell.restartRefused.message', 'First-run setup is still open.'),
@@ -121,9 +139,13 @@ export async function showRestartRefused(t: ShellTranslate): Promise<void> {
 }
 
 /** Show the vault recovery key, offering a clipboard copy. */
-export async function showRecoveryKey(t: ShellTranslate, key: string): Promise<void> {
+export async function showRecoveryKey(
+  win: BrowserWindow,
+  t: ShellTranslate,
+  key: string,
+): Promise<void> {
   const copyLabel = t('recovery.copy', 'Copy to clipboard');
-  const { response } = await dialog.showMessageBox({
+  const { response } = await messageBox(win, {
     type: 'info',
     title: t('recovery.title', 'Recovery key'),
     message: t('recovery.message', 'Keep this key somewhere safe.'),
@@ -142,12 +164,13 @@ export async function showRecoveryKey(t: ShellTranslate, key: string): Promise<v
 }
 
 export async function showRecoveryKeyUnavailable(
+  win: BrowserWindow,
   t: ShellTranslate,
   error: string,
   logPath: string,
 ): Promise<void> {
   const title = t('recovery.unavailableTitle', 'Recovery key unavailable');
-  await dialog.showMessageBox({
+  await messageBox(win, {
     type: 'error',
     title,
     message: title,
@@ -162,10 +185,11 @@ export async function showRecoveryKeyUnavailable(
 }
 
 export async function showRecoveryReminder(
+  win: BrowserWindow,
   t: ShellTranslate,
 ): Promise<RecoveryReminderChoice> {
   const menuItem = t('recovery.menuItem', 'Show recovery key…');
-  const { response } = await dialog.showMessageBox({
+  const { response } = await messageBox(win, {
     type: 'warning',
     title: t('recovery.reminder.title', 'Recovery key not saved yet'),
     message: t('recovery.reminder.message', 'You have not viewed your recovery key yet.'),

--- a/desktop/src/supervisor.ts
+++ b/desktop/src/supervisor.ts
@@ -11,6 +11,7 @@ import {
   platformDataDir,
 } from './paths';
 import { findFreePorts, isPortFree } from './ports';
+import { desktopKernelEnvDefaults } from './kernelEnvDefaults';
 import { startEmbeddedDb, stopEmbeddedDb, isEmbeddedDbRunning } from './embeddedDb';
 import type { EmbeddedDb } from './embeddedDb';
 import { stopChild, isConfirmedStopped } from './childLifecycle';
@@ -391,6 +392,9 @@ export class Supervisor extends EventEmitter {
       PLATFORM_DATA_DIR: platformDataDir(),
       // The browser opens signed diagram URLs against this host base.
       DIAGRAM_PUBLIC_BASE_URL: `http://127.0.0.1:${port}`,
+      // Desktop-only overrides of kernel defaults that assume a LAN self-host
+      // (OM-70: the mDNS advertiser renamed the user's Mac on every start).
+      ...desktopKernelEnvDefaults(process.env),
       ...allProviderKeys(),
     };
     // v1 wires only persistence + LLM. Embeddings (in-process), diagrams (hosted),

--- a/desktop/src/uiReadyGate.ts
+++ b/desktop/src/uiReadyGate.ts
@@ -1,0 +1,70 @@
+/**
+ * Wait for the web UI to say it is standing (OM-71 / #1005).
+ *
+ * `win.loadURL()` resolves when the document finished loading. For the web UI
+ * that is the moment it renders "Loading login…" and starts hydrating, so the
+ * recovery-key reminder fired over a page that was not there yet. The renderer
+ * pings `omadia:uiReady` (preload bridge) once its first real screen is up; this
+ * gate turns that ping into something a boot sequence can await.
+ *
+ * Bounded on purpose: a web UI that never pings (an older build in a mixed
+ * update, a renderer that died before hydrating) still gets its reminder after
+ * `fallbackMs`. The reminder exists to prevent silent data loss, so "late" beats
+ * "never".
+ */
+
+export type UiReadyOutcome = 'signal' | 'fallback' | 'superseded';
+
+/** Injectable timers so the gate is testable without waiting. */
+export interface GateTimers {
+  setTimeout(fn: () => void, ms: number): unknown;
+  clearTimeout(handle: unknown): void;
+}
+
+export interface UiReadyGate {
+  /**
+   * Start waiting. Call BEFORE `loadURL`, so a fast renderer cannot ping before
+   * anyone listens. A later `arm()` resolves the previous one as `superseded`.
+   */
+  arm(): Promise<UiReadyOutcome>;
+  /** The renderer's ping. Ignored when nothing is armed. */
+  signal(): void;
+}
+
+interface Pending {
+  readonly resolve: (outcome: UiReadyOutcome) => void;
+  readonly timer: unknown;
+}
+
+const defaultTimers: GateTimers = {
+  setTimeout: (fn, ms) => setTimeout(fn, ms),
+  clearTimeout: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
+};
+
+export function createUiReadyGate(
+  fallbackMs: number,
+  timers: GateTimers = defaultTimers,
+): UiReadyGate {
+  let pending: Pending | null = null;
+
+  const settle = (outcome: UiReadyOutcome): void => {
+    if (pending === null) return;
+    const current = pending;
+    pending = null;
+    timers.clearTimeout(current.timer);
+    current.resolve(outcome);
+  };
+
+  return {
+    arm() {
+      settle('superseded');
+      return new Promise<UiReadyOutcome>((resolve) => {
+        const timer = timers.setTimeout(() => settle('fallback'), fallbackMs);
+        pending = { resolve, timer };
+      });
+    },
+    signal() {
+      settle('signal');
+    },
+  };
+}

--- a/desktop/test/appPageBoot.test.mts
+++ b/desktop/test/appPageBoot.test.mts
@@ -1,0 +1,121 @@
+/**
+ * The reminder waits for the page, through the real gate wiring (OM-71).
+ *
+ * Uses the production gate with injected timers, so a partial revert (calling
+ * `remind()` straight after `loadApp()`, or arming after the load) goes red.
+ */
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { showAppPage } from '../src/appPageBoot.ts';
+import { createUiReadyGate, type GateTimers } from '../src/uiReadyGate.ts';
+
+function fakeTimers(): GateTimers & { fire(): void } {
+  const handles = new Map<number, () => void>();
+  let next = 1;
+  return {
+    setTimeout: (fn) => {
+      const id = next++;
+      handles.set(id, fn);
+      return id;
+    },
+    clearTimeout: (id) => {
+      handles.delete(id as number);
+    },
+    fire() {
+      for (const [id, fn] of [...handles]) {
+        handles.delete(id);
+        fn();
+      }
+    },
+  };
+}
+
+interface Trace {
+  readonly events: string[];
+  loadApp(): Promise<void>;
+  onLoaded(): void;
+  remind(): Promise<void>;
+}
+
+function trace(): Trace {
+  const events: string[] = [];
+  return {
+    events,
+    loadApp: async () => {
+      events.push('loadApp');
+    },
+    onLoaded: () => {
+      events.push('onLoaded');
+    },
+    remind: async () => {
+      events.push('remind');
+    },
+  };
+}
+
+/** Let the sequence advance to its `await ready`. */
+const settle = async (): Promise<void> => {
+  for (let i = 0; i < 5; i += 1) await Promise.resolve();
+};
+
+describe('showAppPage (OM-71)', () => {
+  it('does not remind before the UI pings, and does right after', async () => {
+    const timers = fakeTimers();
+    const gate = createUiReadyGate(10_000, timers);
+    const t = trace();
+    const run = showAppPage({ gate, ...t });
+    await settle();
+    assert.deepEqual(t.events, ['loadApp', 'onLoaded'], 'loaded, but no reminder yet');
+
+    gate.signal();
+    assert.equal(await run, 'signal');
+    assert.deepEqual(t.events, ['loadApp', 'onLoaded', 'remind']);
+  });
+
+  it('still reminds when the UI never pings (fallback)', async () => {
+    const timers = fakeTimers();
+    const gate = createUiReadyGate(10_000, timers);
+    const t = trace();
+    const run = showAppPage({ gate, ...t });
+    await settle();
+    timers.fire();
+    assert.equal(await run, 'fallback');
+    assert.deepEqual(t.events, ['loadApp', 'onLoaded', 'remind']);
+  });
+
+  it('a ping that lands during loadApp is not lost (gate is armed first)', async () => {
+    const timers = fakeTimers();
+    const gate = createUiReadyGate(10_000, timers);
+    const t = trace();
+    const run = showAppPage({
+      gate,
+      onLoaded: t.onLoaded,
+      remind: t.remind,
+      loadApp: async () => {
+        t.events.push('loadApp');
+        // A very fast renderer: pings before loadURL even resolves.
+        gate.signal();
+      },
+    });
+    assert.equal(await run, 'signal');
+    assert.deepEqual(t.events, ['loadApp', 'onLoaded', 'remind']);
+  });
+
+  it('a restart that supersedes the boot hands the reminder to the newer page', async () => {
+    const timers = fakeTimers();
+    const gate = createUiReadyGate(10_000, timers);
+    const first = trace();
+    const second = trace();
+    const bootRun = showAppPage({ gate, ...first });
+    await settle();
+    const restartRun = showAppPage({ gate, ...second });
+    await settle();
+    assert.equal(await bootRun, 'superseded');
+    assert.deepEqual(first.events, ['loadApp', 'onLoaded'], 'the superseded boot must not remind');
+
+    gate.signal();
+    assert.equal(await restartRun, 'signal');
+    assert.deepEqual(second.events, ['loadApp', 'onLoaded', 'remind']);
+  });
+});

--- a/desktop/test/helpers/electron-fake.d.mts
+++ b/desktop/test/helpers/electron-fake.d.mts
@@ -1,0 +1,16 @@
+/**
+ * Types for the test-only Electron fake, so a test can import its control
+ * surface (`__setDialogHandler`, `__lastClipboardText`) under `typecheck:test`.
+ * Runtime behaviour lives in `electron-fake.mjs`; keep the two in step.
+ */
+import type { MessageBoxOptions, MessageBoxReturnValue, BrowserWindow } from 'electron';
+
+export type DialogHandler = (
+  ...args: [BrowserWindow, MessageBoxOptions] | [MessageBoxOptions]
+) => Promise<MessageBoxReturnValue>;
+
+/** Install the handler every `dialog.showMessageBox` call is forwarded to. */
+export function __setDialogHandler(handler: DialogHandler | null): void;
+
+/** The last text written through `clipboard.writeText`, or null. */
+export function __lastClipboardText(): string | null;

--- a/desktop/test/helpers/electron-fake.mjs
+++ b/desktop/test/helpers/electron-fake.mjs
@@ -45,7 +45,35 @@ function unavailable(name) {
   );
 }
 
-export const dialog = unavailable('dialog');
+/**
+ * `dialog` is opt-in: a test installs a handler with `__setDialogHandler`, and
+ * every `showMessageBox` call is forwarded to it with the exact arguments the
+ * production code passed (so a test can assert on the parent window, OM-71).
+ * Without a handler it throws like every other unstubbed surface.
+ */
+let dialogHandler = null;
+export function __setDialogHandler(handler) {
+  dialogHandler = handler;
+}
+export const dialog = {
+  showMessageBox: (...args) => {
+    if (dialogHandler === null) {
+      throw new Error('electron.dialog.showMessageBox is not stubbed; call __setDialogHandler first');
+    }
+    return dialogHandler(...args);
+  },
+};
+
+/** Records the last text written, so a "copy" button can be asserted on. */
+let clipboardText = null;
+export function __lastClipboardText() {
+  return clipboardText;
+}
+export const clipboard = {
+  writeText: (text) => {
+    clipboardText = text;
+  },
+};
 export const ipcMain = unavailable('ipcMain');
 export const Menu = unavailable('Menu');
 export const Tray = unavailable('Tray');
@@ -55,4 +83,15 @@ export const BrowserWindow = unavailable('BrowserWindow');
 export const contextBridge = unavailable('contextBridge');
 export const ipcRenderer = unavailable('ipcRenderer');
 
-export default { app, safeStorage, dialog, ipcMain, Menu, Tray, shell, nativeImage, BrowserWindow };
+export default {
+  app,
+  safeStorage,
+  dialog,
+  clipboard,
+  ipcMain,
+  Menu,
+  Tray,
+  shell,
+  nativeImage,
+  BrowserWindow,
+};

--- a/desktop/test/kernelEnvDefaults.test.mts
+++ b/desktop/test/kernelEnvDefaults.test.mts
@@ -1,0 +1,84 @@
+/**
+ * Desktop-only kernel environment defaults (OM-70 / #1004).
+ *
+ * The kernel's mDNS advertiser defaults to ON for self-hosters. Inside the
+ * desktop app it is pointless (user and app share one machine) and harmful:
+ * `bonjour-service` claimed the Mac's own `.local` name, macOS treated the
+ * second responder as a foreign device and renamed the machine on every start
+ * (`MacBook-Pro-8` → `-9` → `-10`). The desktop therefore turns it off unless
+ * the user has explicitly decided otherwise in their environment.
+ */
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { desktopKernelEnvDefaults } from '../src/kernelEnvDefaults.ts';
+import { onLog } from '../src/log.ts';
+
+/** Collect every WARN line emitted while `fn` runs. */
+function warningsDuring(fn: () => void): string[] {
+  const lines: string[] = [];
+  const off = onLog((level, msg) => {
+    if (level === 'WARN') lines.push(msg);
+  });
+  try {
+    fn();
+  } finally {
+    off();
+  }
+  return lines;
+}
+
+describe('desktopKernelEnvDefaults (OM-70)', () => {
+  it('turns the mDNS advertiser off when the user has not set it', () => {
+    const env = desktopKernelEnvDefaults({});
+    assert.equal(env.OMADIA_UI_MDNS_ENABLED, 'false');
+  });
+
+  it('respects an explicit user choice, either way', () => {
+    assert.equal(
+      desktopKernelEnvDefaults({ OMADIA_UI_MDNS_ENABLED: 'true' }).OMADIA_UI_MDNS_ENABLED,
+      'true',
+    );
+    assert.equal(
+      desktopKernelEnvDefaults({ OMADIA_UI_MDNS_ENABLED: 'false' }).OMADIA_UI_MDNS_ENABLED,
+      'false',
+    );
+  });
+
+  it('treats an empty value as unset, without a warning', () => {
+    // An empty string would fail the kernel's `z.enum(['true','false'])` parse
+    // and take the whole boot down; the default is the safer reading.
+    let env: ReturnType<typeof desktopKernelEnvDefaults> | undefined;
+    const warnings = warningsDuring(() => {
+      env = desktopKernelEnvDefaults({ OMADIA_UI_MDNS_ENABLED: '' });
+    });
+    assert.equal(env?.OMADIA_UI_MDNS_ENABLED, 'false');
+    assert.deepEqual(warnings, []);
+  });
+
+  it('coerces a typo to off but says so, so an opt-in attempt is visible', () => {
+    for (const typo of ['1', 'TRUE', 'yes']) {
+      let env: ReturnType<typeof desktopKernelEnvDefaults> | undefined;
+      const warnings = warningsDuring(() => {
+        env = desktopKernelEnvDefaults({ OMADIA_UI_MDNS_ENABLED: typo });
+      });
+      assert.equal(env?.OMADIA_UI_MDNS_ENABLED, 'false', `${typo} must not reach the kernel`);
+      assert.equal(warnings.length, 1, `${typo} must produce exactly one warning`);
+      assert.ok(warnings[0]!.includes('OMADIA_UI_MDNS_ENABLED'), warnings[0]);
+      assert.ok(warnings[0]!.includes(typo), warnings[0]);
+    }
+  });
+
+  it('a valid value produces no warning', () => {
+    assert.deepEqual(
+      warningsDuring(() => desktopKernelEnvDefaults({ OMADIA_UI_MDNS_ENABLED: 'true' })),
+      [],
+    );
+  });
+
+  it('does not leak anything else into the kernel env', () => {
+    assert.deepEqual(Object.keys(desktopKernelEnvDefaults({ PATH: '/x' })), [
+      'OMADIA_UI_MDNS_ENABLED',
+    ]);
+  });
+});

--- a/desktop/test/shellDialogs.test.mts
+++ b/desktop/test/shellDialogs.test.mts
@@ -1,0 +1,107 @@
+/**
+ * Every native dialog is attached to the main window (OM-71 / #1005).
+ *
+ * Five of the seven dialogs in `shellDialogs.ts` were shown without a parent.
+ * On macOS an unparented `showMessageBox` is application-modal and free
+ * floating, so the reminder about the recovery key could be half covered by a
+ * system dialog. The one dialog that shows the key decrypting the local vault
+ * must not be the one that can get lost behind other windows.
+ *
+ * The electron fake forwards the exact `showMessageBox` arguments, so the
+ * assertion is on what the production code passes, not on a reimplementation.
+ */
+import { describe, it, beforeEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import type { BrowserWindow } from 'electron';
+
+import { __setDialogHandler, __lastClipboardText } from './helpers/electron-fake.mjs';
+import {
+  showBootFailure,
+  showRecoveryExhausted,
+  showRecoveryKey,
+  showRecoveryKeyUnavailable,
+  showRecoveryReminder,
+  showRestartRefused,
+  showSupersededBoot,
+} from '../src/shellDialogs.ts';
+import type { ShellTranslate } from '../src/shellStrings.ts';
+
+const t: ShellTranslate = (_key, fallback) => fallback;
+
+interface RecordedCall {
+  readonly args: unknown[];
+}
+
+function fakeWindow(destroyed = false): BrowserWindow {
+  return { isDestroyed: () => destroyed } as unknown as BrowserWindow;
+}
+
+let calls: RecordedCall[] = [];
+let nextResponse = 0;
+
+beforeEach(() => {
+  calls = [];
+  nextResponse = 0;
+  __setDialogHandler((...args: unknown[]) => {
+    calls.push({ args });
+    return Promise.resolve({ response: nextResponse, checkboxChecked: false });
+  });
+});
+
+/** Every dialog, called the way production calls it. */
+const dialogs: ReadonlyArray<readonly [string, (win: BrowserWindow) => Promise<unknown>]> = [
+  ['showSupersededBoot', (win) => showSupersededBoot(win, t)],
+  ['showBootFailure', (win) => showBootFailure(win, t, 'detail', '/log')],
+  ['showRecoveryExhausted', (win) => showRecoveryExhausted(win, t, '/log')],
+  ['showRestartRefused', (win) => showRestartRefused(win, t)],
+  ['showRecoveryKey', (win) => showRecoveryKey(win, t, 'KEY-1234')],
+  ['showRecoveryKeyUnavailable', (win) => showRecoveryKeyUnavailable(win, t, 'boom', '/log')],
+  ['showRecoveryReminder', (win) => showRecoveryReminder(win, t)],
+];
+
+describe('shellDialogs parent window (OM-71)', () => {
+  for (const [name, show] of dialogs) {
+    it(`${name} passes the main window as the dialog parent`, async () => {
+      const win = fakeWindow();
+      nextResponse = 1;
+      await show(win);
+      assert.equal(calls.length, 1, `${name} should show exactly one dialog`);
+      const [parent, options] = calls[0]!.args;
+      assert.equal(parent, win, `${name} must attach the dialog to the window`);
+      assert.equal(typeof options, 'object');
+      assert.ok((options as { title?: unknown }).title, `${name} options carry a title`);
+    });
+  }
+
+  it('falls back to an unparented dialog when the window is already destroyed', async () => {
+    // A dialog that would otherwise throw on a destroyed parent is worse than
+    // a free-floating one; the vault key must still be shown.
+    nextResponse = 1;
+    await showRecoveryReminder(fakeWindow(true), t);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0]!.args.length, 1, 'no parent argument for a destroyed window');
+    assert.equal(typeof calls[0]!.args[0], 'object');
+  });
+});
+
+describe('shellDialogs choices', () => {
+  it('showRecoveryReminder maps button 0 to show-now and 1 to later', async () => {
+    nextResponse = 0;
+    assert.equal(await showRecoveryReminder(fakeWindow(), t), 'show-now');
+    nextResponse = 1;
+    assert.equal(await showRecoveryReminder(fakeWindow(), t), 'later');
+  });
+
+  it('showRecoveryKey copies the key when the copy button is chosen', async () => {
+    nextResponse = 0;
+    await showRecoveryKey(fakeWindow(), t, 'KEY-COPY-ME');
+    assert.equal(__lastClipboardText(), 'KEY-COPY-ME');
+  });
+
+  it('showBootFailure maps the buttons to rerun-setup / quit', async () => {
+    nextResponse = 0;
+    assert.equal(await showBootFailure(fakeWindow(), t, 'd', '/log'), 'rerun-setup');
+    nextResponse = 1;
+    assert.equal(await showBootFailure(fakeWindow(), t, 'd', '/log'), 'quit');
+  });
+});

--- a/desktop/test/supervisorKernelEnv.test.mts
+++ b/desktop/test/supervisorKernelEnv.test.mts
@@ -1,0 +1,55 @@
+/**
+ * The kernel the desktop spawns must not advertise over mDNS (OM-70 / #1004).
+ *
+ * `desktopKernelEnvDefaults` is tested on its own; this pins the WIRING, i.e.
+ * that `Supervisor.kernelEnv()` actually spreads those defaults into the env
+ * handed to `spawn`. Dropping the spread leaves the pure helper green and this
+ * red. Reaching into the private method follows `supervisorRestartRace.test`:
+ * a boot to the real `spawn` needs port 8769 free and a health endpoint, which
+ * a unit test cannot promise.
+ */
+import { describe, it, afterEach, before } from 'node:test';
+import { strict as assert } from 'node:assert';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { Supervisor } from '../src/supervisor.ts';
+
+before(() => {
+  // `paths.ts` is compiled to CommonJS for the app and reads `__dirname` to
+  // find the repo root in dev mode. Under the ESM test loader that global does
+  // not exist, so give it the same answer the compiled `dist/` would have.
+  (globalThis as { __dirname?: string }).__dirname = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '..',
+    'dist',
+  );
+});
+
+type WithKernelEnv = { kernelEnv(port: number): NodeJS.ProcessEnv };
+
+function kernelEnv(): NodeJS.ProcessEnv {
+  return (new Supervisor() as unknown as WithKernelEnv).kernelEnv(8769);
+}
+
+const saved = process.env['OMADIA_UI_MDNS_ENABLED'];
+afterEach(() => {
+  if (saved === undefined) delete process.env['OMADIA_UI_MDNS_ENABLED'];
+  else process.env['OMADIA_UI_MDNS_ENABLED'] = saved;
+});
+
+describe('Supervisor.kernelEnv mDNS wiring (OM-70)', () => {
+  it('hands the kernel OMADIA_UI_MDNS_ENABLED=false by default', () => {
+    delete process.env['OMADIA_UI_MDNS_ENABLED'];
+    const env = kernelEnv();
+    assert.equal(env['OMADIA_UI_MDNS_ENABLED'], 'false');
+    // Sanity: this is the real kernel env, not a partial object.
+    assert.equal(env['PORT'], '8769');
+    assert.equal(env['HOST'], '127.0.0.1');
+  });
+
+  it("keeps the user's explicit opt-in", () => {
+    process.env['OMADIA_UI_MDNS_ENABLED'] = 'true';
+    assert.equal(kernelEnv()['OMADIA_UI_MDNS_ENABLED'], 'true');
+  });
+});

--- a/desktop/test/uiReadyGate.test.mts
+++ b/desktop/test/uiReadyGate.test.mts
@@ -1,0 +1,97 @@
+/**
+ * The recovery-key reminder waits for the page, not for the navigation (OM-71).
+ *
+ * `win.loadURL()` resolves when the document has loaded, which for the web UI
+ * is the moment it shows "Loading login…" and starts hydrating. The reminder
+ * used to fire right there, over a page that was not yet standing. The gate
+ * below waits for the UI's own ready ping, with a bounded fallback so a web UI
+ * that never pings (an older build, a crashed renderer) still gets its reminder.
+ */
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { createUiReadyGate, type GateTimers } from '../src/uiReadyGate.ts';
+
+interface FakeTimers extends GateTimers {
+  fire(): void;
+  readonly pending: number;
+}
+
+function fakeTimers(): FakeTimers {
+  const handles = new Map<number, () => void>();
+  let next = 1;
+  return {
+    setTimeout: (fn) => {
+      const id = next++;
+      handles.set(id, fn);
+      return id;
+    },
+    clearTimeout: (id) => {
+      handles.delete(id as number);
+    },
+    fire() {
+      for (const [id, fn] of [...handles]) {
+        handles.delete(id);
+        fn();
+      }
+    },
+    get pending() {
+      return handles.size;
+    },
+  };
+}
+
+describe('uiReadyGate (OM-71)', () => {
+  it('resolves with "signal" when the UI pings after arming', async () => {
+    const timers = fakeTimers();
+    const gate = createUiReadyGate(10_000, timers);
+    const armed = gate.arm();
+    gate.signal();
+    assert.equal(await armed, 'signal');
+    assert.equal(timers.pending, 0, 'the fallback timer is cleared after the ping');
+  });
+
+  it('resolves with "fallback" when the UI never pings', async () => {
+    const timers = fakeTimers();
+    const gate = createUiReadyGate(10_000, timers);
+    const armed = gate.arm();
+    timers.fire();
+    assert.equal(await armed, 'fallback');
+  });
+
+  it('ignores a ping that arrives before arming (stale renderer)', async () => {
+    const timers = fakeTimers();
+    const gate = createUiReadyGate(10_000, timers);
+    gate.signal();
+    const armed = gate.arm();
+    let settled = false;
+    void armed.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    assert.equal(settled, false, 'a stale ping must not satisfy a later arm');
+    gate.signal();
+    assert.equal(await armed, 'signal');
+  });
+
+  it('a second arm supersedes the first (a restart replaced the page)', async () => {
+    const timers = fakeTimers();
+    const gate = createUiReadyGate(10_000, timers);
+    const first = gate.arm();
+    const second = gate.arm();
+    assert.equal(await first, 'superseded');
+    assert.equal(timers.pending, 1, 'only the live arm keeps a fallback timer');
+    gate.signal();
+    assert.equal(await second, 'signal');
+  });
+
+  it('a ping after the fallback fired is ignored', async () => {
+    const timers = fakeTimers();
+    const gate = createUiReadyGate(10_000, timers);
+    const armed = gate.arm();
+    timers.fire();
+    assert.equal(await armed, 'fallback');
+    // Must not throw or resolve anything a second time.
+    gate.signal();
+  });
+});

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,26 @@ changelog.
 
 ## [Unreleased]
 
+### Fixed — The desktop app no longer renames the user's Mac on every start
+
+2026-09-03 — Beta round 4, OM-70 (#1004). Since v0.142 the Mac of the tester
+had been counting up: `MacBook-Pro-von-Silvio-8.local`, then `-9`, then `-10`,
+one increment per omadia start, with macOS announcing each time that the local
+hostname was "already in use on this network". The culprit was our own LAN
+pairing advertiser (#293): `bonjour-service` publishes `_omadia._tcp` with the
+machine's own host name as SRV target and answers A queries for it, so macOS
+saw a second responder defending its `.local` name, treated it as a foreign
+device and yielded. In a company network that name carries file shares,
+printers, SSH targets, backups and MDM inventory.
+
+Two layers. The desktop supervisor now passes `OMADIA_UI_MDNS_ENABLED=false`
+to the kernel unless the user set the variable themselves; on a single-user
+machine there is nothing to discover. And the advertiser itself never claims
+the OS name any more: self-hosters advertise as `<instance>-<machine>.local`
+(capped at 63 octets, a valid DNS label) or an explicit `host`, so two
+responders on one device can no longer collide. The variable is documented in
+`middleware/.env.example`.
+
 ### Fixed — MCP marketplace search now answers from the cached catalog when only the registry's search is broken
 
 2026-09-01 — Follow-up to the entry below, found by watching the deployed fix

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -56,6 +56,26 @@ the OS name any more: self-hosters advertise as `<instance>-<machine>.local`
 responders on one device can no longer collide. The variable is documented in
 `middleware/.env.example`.
 
+### Fixed — Shell dialogs are attached to the window, and the recovery-key reminder waits for the page
+
+2026-09-03 — Beta round 4, OM-71 (#1005). Five of the seven native dialogs,
+among them all three about the vault recovery key, were shown without a parent
+window. On macOS that is an application-modal, free-floating dialog: the
+reminder on start was half covered by a system dialog and unreadable, and the
+one dialog that shows the key decrypting the local database could get lost
+behind other windows. Every dialog now goes through one helper that attaches
+it to the main window (a destroyed window falls back to the old behaviour
+rather than throwing over the key).
+
+The reminder also fired the moment `loadURL` resolved, over a page that still
+read "Lade Login…" — `loadURL` resolves on the document, not on a screen. The
+web UI now tells the shell when its first real screen is standing
+(`omadia:uiReady` via the preload bridge; `/login` and `/setup` report once
+their provider fetch has settled, every other page on hydration), and both the
+boot and the restart path wait for that ping before speaking. A 15-second
+fallback keeps the reminder for an older or crashed renderer: it exists to
+prevent silent data loss, so late beats never.
+
 ### Fixed — MCP marketplace search now answers from the cached catalog when only the registry's search is broken
 
 2026-09-01 — Follow-up to the entry below, found by watching the deployed fix

--- a/middleware/.env.example
+++ b/middleware/.env.example
@@ -314,3 +314,9 @@ CONDUCTOR_EPHEMERAL_REAPER_INTERVAL_MS=60000
 # OFF by default — driving programmatic calls through a consumer ChatGPT
 # subscription is a ToS grey area; opt in explicitly and surface the notice.
 # CHATGPT_SUBSCRIPTION_EXPERIMENTAL=true
+
+# --- LAN pairing (mDNS, #293) -----------------------------------------------
+# Advertise `_omadia._tcp` so a desktop client on the same network can find this
+# kernel. Default true for self-hosters; the desktop app passes false because on
+# a single-user machine there is nothing to discover (OM-70, #1004).
+# OMADIA_UI_MDNS_ENABLED=true

--- a/middleware/src/config.ts
+++ b/middleware/src/config.ts
@@ -183,6 +183,9 @@ const ConfigSchema = z.object({
   // Advertise `_omadia._tcp` on the LAN for zero-config discovery. On by
   // default for self-hosters; harmless to leave on where there is no LAN
   // reachability (Fly), but set to `false` to silence the responder there.
+  // The desktop shell sets `false` (OM-70): on a single-user machine there is
+  // nothing to discover, and the responder used to claim the Mac's own `.local`
+  // name so macOS renamed the machine on every start.
   OMADIA_UI_MDNS_ENABLED: z
     .enum(['true', 'false'])
     .transform((v) => v === 'true')

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -5842,7 +5842,9 @@ async function main(): Promise<void> {
 
   // LAN zero-config discovery (#293): advertise `_omadia._tcp` so a desktop
   // client on the same network can pair with zero typing. Best-effort — a host
-  // with no LAN reachability (Fly) simply never gets discovered this way.
+  // with no LAN reachability (Fly) simply never gets discovered this way. The
+  // desktop shell disables it via env (OM-70); the advertiser itself never
+  // claims the machine's own host name (see pairing/mdns.ts).
   if (config.OMADIA_UI_MDNS_ENABLED) {
     const advertisedAuthMode: 'none' | 'password' | 'oidc' = pairingProviders
       ?.length

--- a/middleware/src/pairing/mdns.ts
+++ b/middleware/src/pairing/mdns.ts
@@ -15,11 +15,20 @@
  * Best-effort and fully optional: any failure to publish is logged and
  * swallowed (a host with no LAN reachability — e.g. a Fly machine — simply
  * never gets discovered this way, which is correct). Toggle with
- * `OMADIA_UI_MDNS_ENABLED`.
+ * `OMADIA_UI_MDNS_ENABLED`. The desktop app turns it off: user and kernel sit
+ * on one machine, so there is nobody to discover it.
+ *
+ * The advertised HOST is never the machine's own name (OM-70 / #1004).
+ * `bonjour-service` defaults the SRV target, and the A record it answers for,
+ * to `os.hostname()`. On macOS that is the same `<LocalHostName>.local` the
+ * system responder defends, so every start produced a name conflict and macOS
+ * renamed the Mac (`-8` → `-9` → `-10`). A derived host such as
+ * `omadia-<machine>.local` is unique per machine and cannot collide with it.
  *
  * `bonjour-service` is imported lazily so the dependency is only loaded when
  * advertising is actually enabled.
  */
+import os from 'node:os';
 
 export interface MdnsAdvertiseOptions {
   readonly port: number;
@@ -27,7 +36,56 @@ export interface MdnsAdvertiseOptions {
   readonly canvasPath: string;
   readonly protocolVersion: string;
   readonly authMode: 'none' | 'password' | 'oidc';
+  /**
+   * Host name to advertise as the SRV target. Defaults to
+   * `deriveAdvertisedHost(name, machineHostName)`; pass one to override. Must
+   * never be the machine's own `.local` name (see the header).
+   */
+  readonly host?: string;
+  /** The machine's host name used for the derived default. Defaults to `os.hostname()`. */
+  readonly machineHostName?: string;
+  /** Test seam: builds the responder instead of importing `bonjour-service`. */
+  readonly createResponder?: () => BonjourLike;
   readonly log?: (msg: string) => void;
+}
+
+/** One DNS label: lowercase, `[a-z0-9-]`, no leading/trailing/double dashes. */
+function dnsLabel(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * A DNS label is at most 63 octets. `dns-packet` writes the length byte
+ * unchecked, so a longer label goes out with its high bits set and is read
+ * back as a compression pointer: the record is malformed, not merely long.
+ */
+export const MAX_DNS_LABEL_OCTETS = 63;
+
+/** Truncate a label to `max` and drop any dash the cut left at the end. */
+function clampLabel(label: string, max: number): string {
+  return label.slice(0, Math.max(0, max)).replace(/-+$/, '');
+}
+
+/**
+ * The host name omadia advertises for itself: `<name>-<machine>.local`, with
+ * both parts reduced to DNS labels and a trailing `.local` on the machine name
+ * dropped first. Falls back to `omadia` for an unusable instance name and to
+ * `<name>.local` for an empty machine name, so the result is always a valid,
+ * non-empty host that differs from the machine's own. The label is capped at
+ * 63 octets by shortening the machine part first, then the instance part.
+ */
+export function deriveAdvertisedHost(name: string, machineHostName: string): string {
+  const instance = clampLabel(dnsLabel(name) || 'omadia', MAX_DNS_LABEL_OCTETS) || 'omadia';
+  const machineBudget = MAX_DNS_LABEL_OCTETS - instance.length - 1;
+  const machine = clampLabel(
+    dnsLabel(machineHostName.replace(/\.local\.?$/i, '')),
+    machineBudget,
+  );
+  return machine ? `${instance}-${machine}.local` : `${instance}.local`;
 }
 
 export interface MdnsAdvertisement {
@@ -45,26 +103,17 @@ export async function startMdnsAdvertiser(
   const log = opts.log ?? (() => {});
   const inert: MdnsAdvertisement = { async stop() {} };
   try {
-    // Lazy import: keep `bonjour-service` off the hot path when disabled. The
-    // specifier is held in a variable so the typecheck gate does not require
-    // the package to be installed in every workspace — it is a runtime dep
-    // (package.json) pulled in on deploy.
-    const specifier = 'bonjour-service';
-    const mod = (await import(specifier)) as {
-      Bonjour: new () => BonjourLike;
-      default?: new () => BonjourLike;
-    };
-    const Ctor = mod.Bonjour ?? mod.default;
-    if (!Ctor) {
-      log('[pairing/mdns] bonjour-service has no usable constructor — skipping');
-      return inert;
-    }
-    const bonjour = new Ctor();
+    const bonjour = opts.createResponder
+      ? opts.createResponder()
+      : await importResponder(log);
+    if (!bonjour) return inert;
+    const host = opts.host ?? deriveAdvertisedHost(opts.name, opts.machineHostName ?? os.hostname());
     const service = bonjour.publish({
       name: opts.name,
       type: 'omadia',
       protocol: 'tcp',
       port: opts.port,
+      host,
       txt: {
         path: opts.canvasPath,
         proto: opts.protocolVersion,
@@ -77,7 +126,7 @@ export async function startMdnsAdvertiser(
     });
     log(
       `[pairing/mdns] advertising _omadia._tcp "${opts.name}" on :${opts.port} ` +
-        `(auth=${opts.authMode}, proto=${opts.protocolVersion})`,
+        `(host=${host}, auth=${opts.authMode}, proto=${opts.protocolVersion})`,
     );
     return {
       async stop() {
@@ -99,13 +148,35 @@ export async function startMdnsAdvertiser(
   }
 }
 
+/**
+ * Lazy import: keep `bonjour-service` off the hot path when disabled. The
+ * specifier is held in a variable so the typecheck gate does not require the
+ * package to be installed in every workspace — it is a runtime dep
+ * (package.json) pulled in on deploy.
+ */
+async function importResponder(log: (msg: string) => void): Promise<BonjourLike | undefined> {
+  const specifier = 'bonjour-service';
+  const mod = (await import(specifier)) as {
+    Bonjour: new () => BonjourLike;
+    default?: new () => BonjourLike;
+  };
+  const Ctor = mod.Bonjour ?? mod.default;
+  if (!Ctor) {
+    log('[pairing/mdns] bonjour-service has no usable constructor — skipping');
+    return undefined;
+  }
+  return new Ctor();
+}
+
 /** Minimal structural type for the slice of `bonjour-service` we use. */
-interface BonjourLike {
+export interface BonjourLike {
   publish(config: {
     name: string;
     type: string;
     protocol: 'tcp' | 'udp';
     port: number;
+    /** SRV target and the A record the responder answers for. */
+    host?: string;
     txt?: Record<string, string>;
   }): { on?(event: string, cb: (err: unknown) => void): void };
   unpublishAll(cb?: () => void): void;

--- a/middleware/test/pairingMdns.test.ts
+++ b/middleware/test/pairingMdns.test.ts
@@ -1,0 +1,136 @@
+/**
+ * mDNS advertiser must never claim the machine's own host name (OM-70 / #1004).
+ *
+ * `bonjour-service` defaults the SRV target and the A record it answers for to
+ * `os.hostname()`. On macOS that is the same `<LocalHostName>.local` the
+ * system's own responder defends, so the OS saw a conflict on every omadia
+ * start and renamed the machine. The advertiser now always publishes a distinct
+ * host, derived from the instance name and the machine name, or the one the
+ * caller passes in.
+ */
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+
+import {
+  MAX_DNS_LABEL_OCTETS,
+  deriveAdvertisedHost,
+  startMdnsAdvertiser,
+  type BonjourLike,
+} from '../src/pairing/mdns.js';
+
+/** RFC 1035 label: 1-63 octets of [a-z0-9-], no leading or trailing dash. */
+function assertValidLabel(host: string): string {
+  assert.ok(host.endsWith('.local'), `${host} must end in .local`);
+  const label = host.slice(0, -'.local'.length);
+  assert.ok(label.length >= 1 && label.length <= MAX_DNS_LABEL_OCTETS, `${label} is ${label.length} octets`);
+  assert.match(label, /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/, `${label} is not a valid DNS label`);
+  return label;
+}
+
+interface Published {
+  readonly config: Parameters<BonjourLike['publish']>[0];
+}
+
+function fakeResponder(): { readonly published: Published[]; readonly create: () => BonjourLike } {
+  const published: Published[] = [];
+  const responder: BonjourLike = {
+    publish(config) {
+      published.push({ config });
+      return { on() {} };
+    },
+    unpublishAll(cb) {
+      cb?.();
+    },
+    destroy() {},
+  };
+  return { published, create: () => responder };
+}
+
+const baseOpts = {
+  port: 8769,
+  name: 'omadia',
+  canvasPath: '/omadia-ui/canvas',
+  protocolVersion: '1.0',
+  authMode: 'password' as const,
+};
+
+test('deriveAdvertisedHost: never equals the machine host name', () => {
+  const host = deriveAdvertisedHost('omadia', 'MacBook-Pro-von-Silvio-8.local');
+  assert.notEqual(host.toLowerCase(), 'macbook-pro-von-silvio-8.local');
+  assert.equal(host, 'omadia-macbook-pro-von-silvio-8.local');
+});
+
+test('deriveAdvertisedHost: sanitises the instance name into a DNS label', () => {
+  assert.equal(deriveAdvertisedHost('TE Printline / Büro', 'host'), 'te-printline-b-ro-host.local');
+  assert.equal(deriveAdvertisedHost('', 'host'), 'omadia-host.local');
+  assert.equal(deriveAdvertisedHost('!!!', ''), 'omadia.local');
+});
+
+test('deriveAdvertisedHost: caps the label at 63 octets by shortening the machine part', () => {
+  const longName = 'te-printline-viernheim-production-instance-number-one';
+  const longMachine = 'macbook-pro-von-silvio-lange-mit-einem-sehr-langen-namen-42.local';
+  const host = deriveAdvertisedHost(longName, longMachine);
+  const label = assertValidLabel(host);
+  assert.equal(label.length, MAX_DNS_LABEL_OCTETS);
+  assert.ok(label.startsWith(`${longName}-macbook`), 'the instance part is kept whole first');
+});
+
+test('deriveAdvertisedHost: no trailing dash when the cut lands on one', () => {
+  // 61 chars of instance leaves a budget of 1 for the machine part; the machine
+  // label starts with a dash-adjacent cut, so it must be dropped, not kept.
+  const instance = 'a'.repeat(61);
+  assert.equal(deriveAdvertisedHost(instance, 'x-y'), `${instance}-x.local`);
+  assert.equal(deriveAdvertisedHost('a'.repeat(62), 'box'), `${'a'.repeat(62)}.local`);
+});
+
+test('deriveAdvertisedHost: an over-long instance name alone is cut to 63 octets', () => {
+  const host = deriveAdvertisedHost('b'.repeat(80) + '-tail', 'box');
+  const label = assertValidLabel(host);
+  assert.equal(label, 'b'.repeat(63));
+});
+
+test('deriveAdvertisedHost: strips a trailing .local from the machine name only once', () => {
+  assert.equal(deriveAdvertisedHost('x', 'box.local'), 'x-box.local');
+  assert.equal(deriveAdvertisedHost('x', 'box'), 'x-box.local');
+});
+
+test('startMdnsAdvertiser: publishes the derived host, not the machine host name', async () => {
+  const fake = fakeResponder();
+  const logs: string[] = [];
+  const adv = await startMdnsAdvertiser({
+    ...baseOpts,
+    createResponder: fake.create,
+    machineHostName: 'MacBook-Pro-von-Silvio-8.local',
+    log: (m) => logs.push(m),
+  });
+  assert.equal(fake.published.length, 1);
+  const cfg = fake.published[0]!.config;
+  assert.equal(cfg.host, 'omadia-macbook-pro-von-silvio-8.local');
+  assert.equal(cfg.type, 'omadia');
+  assert.equal(cfg.port, 8769);
+  assert.ok(
+    logs.some((l) => l.includes('host=omadia-macbook-pro-von-silvio-8.local')),
+    'the advertised host is logged so a self-hoster can see what was claimed',
+  );
+  await adv.stop();
+});
+
+test('startMdnsAdvertiser: forwards an explicit host verbatim', async () => {
+  const fake = fakeResponder();
+  await startMdnsAdvertiser({
+    ...baseOpts,
+    host: 'pairing.example.local',
+    createResponder: fake.create,
+  });
+  assert.equal(fake.published[0]!.config.host, 'pairing.example.local');
+});
+
+test('startMdnsAdvertiser: a responder that throws yields an inert handle', async () => {
+  const adv = await startMdnsAdvertiser({
+    ...baseOpts,
+    createResponder: () => {
+      throw new Error('no multicast');
+    },
+  });
+  await adv.stop();
+});

--- a/web-ui/app/_components/DesktopUiReady.tsx
+++ b/web-ui/app/_components/DesktopUiReady.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+
+import { signalDesktopUiReady } from '../_lib/desktopShell';
+
+/**
+ * Tells the desktop shell that a real screen is standing (OM-71).
+ *
+ * Mounted once in the root layout. On every ordinary page, hydration of the
+ * layout IS the page standing. `/login` and `/setup` are excluded: both render
+ * a "Loading login…" shell first and only become a screen once their own
+ * provider fetch has settled, so they ping from inside that state change.
+ * Renders nothing.
+ */
+export function DesktopUiReady(): null {
+  const pathname = usePathname();
+  const selfReporting = pathname === '/login' || pathname === '/setup';
+
+  useEffect(() => {
+    if (selfReporting) return;
+    signalDesktopUiReady();
+  }, [selfReporting]);
+
+  return null;
+}

--- a/web-ui/app/_lib/__tests__/desktopShell.test.ts
+++ b/web-ui/app/_lib/__tests__/desktopShell.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { signalDesktopUiReady } from '../desktopShell';
+
+describe('signalDesktopUiReady (OM-71)', () => {
+  it('pings the desktop bridge when it is present', () => {
+    let pinged = 0;
+    const ok = signalDesktopUiReady({ omadia: { uiReady: () => void (pinged += 1) } });
+    expect(ok).toBe(true);
+    expect(pinged).toBe(1);
+  });
+
+  it('is a no-op in a plain browser', () => {
+    expect(signalDesktopUiReady({})).toBe(false);
+    expect(signalDesktopUiReady(undefined)).toBe(false);
+  });
+
+  it('survives a bridge that throws', () => {
+    expect(
+      signalDesktopUiReady({
+        omadia: {
+          uiReady: () => {
+            throw new Error('bridge gone');
+          },
+        },
+      }),
+    ).toBe(false);
+  });
+});

--- a/web-ui/app/_lib/desktopShell.ts
+++ b/web-ui/app/_lib/desktopShell.ts
@@ -1,0 +1,37 @@
+/**
+ * The narrow bridge the desktop shell's preload exposes to the web UI.
+ *
+ * Only present when the page runs inside the omadia desktop app; in a browser
+ * `window.omadia` is undefined and every call here is a no-op. Keep this the
+ * single place that knows the bridge's shape so a renamed channel breaks one
+ * file, not a scattered set of `(window as any)` casts.
+ */
+
+interface DesktopBridge {
+  /** OM-71: tell the shell the first real screen is standing. */
+  readonly uiReady?: () => void;
+}
+
+interface BridgeHost {
+  readonly omadia?: DesktopBridge;
+}
+
+/**
+ * Report that the UI is standing, so shell-owned dialogs (the recovery-key
+ * reminder) wait for a page instead of a navigation. Returns whether a bridge
+ * was there to tell. Never throws: a broken bridge must not take the page down.
+ */
+export function signalDesktopUiReady(host: BridgeHost | undefined = bridgeHost()): boolean {
+  const ping = host?.omadia?.uiReady;
+  if (typeof ping !== 'function') return false;
+  try {
+    ping();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function bridgeHost(): BridgeHost | undefined {
+  return typeof window === 'undefined' ? undefined : (window as unknown as BridgeHost);
+}

--- a/web-ui/app/layout.tsx
+++ b/web-ui/app/layout.tsx
@@ -12,6 +12,7 @@ import { Nav } from './_components/Nav';
 import { ThemeControls } from './_components/ThemeControls';
 import { SessionWatcher } from './_components/SessionWatcher';
 import { RuntimeReadinessBanner } from './_components/RuntimeReadinessBanner';
+import { DesktopUiReady } from './_components/DesktopUiReady';
 import { StreamRunner } from './_components/StreamRunner';
 import { ChatSessionsProvider } from './_lib/chatSessionsContext';
 import { StreamStoreProvider } from './_lib/streamStore';
@@ -155,6 +156,7 @@ export default async function RootLayout({
               <StreamRunner />
               <SessionWatcher />
               <RuntimeReadinessBanner />
+              <DesktopUiReady />
             </StreamStoreProvider>
           </ChatSessionsProvider>
         </NextIntlClientProvider>

--- a/web-ui/app/login/page.tsx
+++ b/web-ui/app/login/page.tsx
@@ -13,6 +13,7 @@ import {
   postAuthLogin,
   type AuthProviderSummary,
 } from '../_lib/api';
+import { signalDesktopUiReady } from '../_lib/desktopShell';
 
 type State =
   | { kind: 'loading' }
@@ -79,6 +80,12 @@ function LoginPageInner(): React.ReactElement {
   const [password, setPassword] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // OM-71 — the desktop shell waits for this before showing its own dialogs.
+  // "Loading login…" is not a screen; the first non-loading state is.
+  useEffect(() => {
+    if (state.kind !== 'loading') signalDesktopUiReady();
+  }, [state.kind]);
 
   useEffect(() => {
     let cancelled = false;

--- a/web-ui/app/setup/page.tsx
+++ b/web-ui/app/setup/page.tsx
@@ -11,6 +11,7 @@ import {
   getAuthProviders,
   postAuthSetup,
 } from '../_lib/api';
+import { signalDesktopUiReady } from '../_lib/desktopShell';
 
 type State =
   | { kind: 'loading' }
@@ -73,6 +74,11 @@ function SetupPageInner(): React.ReactElement {
   const [displayName, setDisplayName] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // OM-71 — see /login: the desktop shell waits for the first real screen.
+  useEffect(() => {
+    if (state.kind !== 'loading') signalDesktopUiReady();
+  }, [state.kind]);
 
   useEffect(() => {
     let cancelled = false;


### PR DESCRIPTION
Beta test round 4 (TE Printline, 03.09.2026), cluster D. Umbrella #1006.

Closes #1004
Closes #1005

## What

- **OM-70** omadia's in-process `bonjour-service` responder published `_omadia._tcp` without a `host`, so it claimed `os.hostname()` and macOS renamed the LocalHostName on every start (`-3` to `-10` across the test rounds). Desktop supervisor now passes `OMADIA_UI_MDNS_ENABLED=false` to the kernel unless the user set it explicitly (invalid values coerce to false with a warning). `startMdnsAdvertiser` takes a `host` option and otherwise derives `<instance>-<machine>.local`, capped at 63 octets, never the OS hostname. `.env.example` documents the variable.
- **OM-71** All seven `shellDialogs` calls take the `BrowserWindow` as parent (destroyed window falls back to unparented). The recovery-key reminder waits for a UI-ready signal: `uiReadyGate` armed before `loadURL`, web-ui pings `omadia:uiReady` via preload once the login/setup page leaves its loading state, 15 s fallback, one reminder per boot; boot and restart share `showAppPage()`.
- CHANGELOG entries for both.

## Test plan

- [x] `desktop`: typecheck, typecheck:test, `npm test` 199 pass (kernelEnvDefaults, supervisorKernelEnv wiring, shellDialogs parent args for all 7 dialogs, uiReadyGate, appPageBoot sequence)
- [x] `middleware`: `pairingMdns.test.ts` (published host, 63-octet cap, never equals machine name) 21 pass
- [x] `web-ui`: `desktopShell.test.ts`, i18n parity
- [x] Reviewed by omadia-reviewer; all findings resolved
- [ ] Manual on macOS: `scutil --get LocalHostName` stable across two omadia starts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/1010"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791032470&installation_model_id=428086&pr_number=1010&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F1010&signature=e3f5a38588020b8b02faac3c9d9ef10b9cec4ff309ca60682a8732e89aad62a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->