### PR TITLE
chore(deps): bump fast-uri override to 3.1.7 (new high advisories)

### DIFF
--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -5208,9 +5208,9 @@
       "license": "Unlicense"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -106,7 +106,7 @@
   "overrides": {
     "esbuild": "^0.28.1",
     "axios": "1.18.1",
-    "fast-uri": "3.1.5",
+    "fast-uri": "3.1.7",
     "postcss": "8.5.23",
     "brace-expansion": "5.0.9"
   }


### PR DESCRIPTION
The required `audit (high+critical block) (middleware)` check turned red on every PR today (e.g. #1009): four new GHSA advisories for `fast-uri < 3.1.6` (host confusion via IDN / percent-encoded scheme, SSRF via IPv6 normalization and repeated hostname percent-decoding). `middleware/package.json` had `overrides.fast-uri = 3.1.5` from an earlier advisory, so `npm audit fix` could not move it.

- `overrides.fast-uri` 3.1.5 -> 3.1.7
- lockfile regenerated with `npm install --package-lock-only`; the only change is the `fast-uri` entry

## Test plan

- [x] `npm audit --package-lock-only` in middleware: high 0, critical 0 (11 moderate unchanged, same as main)
- [x] No source files touched; CI runs the full middleware suite

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/1011"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791032646&installation_model_id=428086&pr_number=1011&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F1011&signature=a8c5e3c2674368c2f31d89f46678e1e7bf30381f49b985aa84680b5c93a09b66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->