### PR TITLE
fix: dashboard and readiness banner tell the truth about the runtime (OM-72, OM-74, OM-75, OM-78, OM-84)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -65,8 +65,12 @@ carries a new `cause` field — `no_llm_access` (no key, no OAuth, no CLI login
 anywhere), `no_assignment` (an access exists, the orchestrator points elsewhere)
 or `unknown` — computed from the same credential verdicts the providers page
 renders, without a network probe. The banner renders a distinct title, body and
-CTA for `no_assignment` ("Orchestrator nicht zugeordnet" → "Zuordnung öffnen").
-A 503 without a cause (older middleware) keeps the no-access copy.
+CTA for `no_assignment` ("Orchestrator nicht zugeordnet" → "Zuordnung öffnen")
+and for `unknown` ("Agent-Runtime antwortet nicht"), which by construction
+means access and assignment are set — e.g. a stored but rejected key — so the
+no-access sentence would be false there. A 503 without a cause (older
+middleware) keeps the no-access copy. The verdict is memoised for 8 s so a
+dashboard load with several probing widgets runs one credential lookup.
 
 **No more promises about a control that does not exist (#1002, OM-72).** The
 banner body no longer says chat is available "sofort" nor that routines need

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,56 @@ changelog.
 
 ## [Unreleased]
 
+### Fixed — dashboard and readiness banner read one runtime truth (#999, #1000, #1001, #1002, #1003)
+
+2026-09-03 — omadia beta test round 4 (TE Printline, OM-72/74/75/78/84). The
+dashboard said "LLM verbunden · 3 von 3 erledigt" while the readiness card two
+centimetres below said "LLM-Zugang fehlt". Both were right from their own
+viewpoint: the onboarding tick checked whether an access was *stored*, the card
+probed whether the orchestrator runtime *answered*. The tester had a working
+subscription login; the orchestrator was still assigned to `anthropic`, for
+which no key existed, so nothing ran — and the only text on screen told him to
+add the key or subscription he already had, and promised chat "sofort".
+
+**Onboarding step 1 follows the live runtime (#1001, OM-78).** Step 1 now ticks
+on the same probe the banner uses (`/operator/agents` answering instead of
+503ing), not on a stored key or CLI login. The counter can no longer reach
+"3 von 3" for a system that cannot run an agent. When an access exists but the
+runtime is down, the step names the missing orchestrator assignment and links
+straight to it instead of offering to connect an access again.
+
+**The CLI wording follows the assignment (#999, OM-74).** "Ein LLM-Anbieter ist
+verbunden und sein Schlüssel wurde geprüft" was shown to a subscription user who
+never stored a key. The done-copy now reads off what the orchestrator is
+actually assigned to: a keyless subscription CLI gets the CLI sentence, a
+key-based provider the key sentence.
+
+**The readiness banner names the cause (#1000, OM-75).** The operator-agents 503
+carries a new `cause` field — `no_llm_access` (no key, no OAuth, no CLI login
+anywhere), `no_assignment` (an access exists, the orchestrator points elsewhere)
+or `unknown` — computed from the same credential verdicts the providers page
+renders, without a network probe. The banner renders a distinct title, body and
+CTA for `no_assignment` ("Orchestrator nicht zugeordnet" → "Zuordnung öffnen").
+A 503 without a cause (older middleware) keeps the no-access copy.
+
+**No more promises about a control that does not exist (#1002, OM-72).** The
+banner body no longer says chat is available "sofort" nor that routines need
+"einen Neustart der Middleware" — the web UI has no restart control, and the
+only one (Tray → Restart) sits behind an icon that is still missing (#888).
+
+**Embeddings are no longer silently off (#1003, OM-84).** A default install runs
+without an embedding provider, which disables process memory, semantic search
+and dedup; nothing in setup said so and the tester learned it from an agent
+failing mid-answer. New `GET /api/v1/admin/embedding-provider/status` answers
+from the registry alone (the existing `GET /` counts the corpus and is too
+heavy for a card rendered on every dashboard load). The dashboard gets a
+"Gedächtnis / Embeddings" health card linking to the embedding-provider setting,
+and the onboarding card names the limitation while no provider is published.
+
+API additions: `cause` on the `multi_orchestrator_unavailable` 503 of
+`/api/v1/operator/agents`; `GET /api/v1/admin/embedding-provider/status`
+(`capabilityPublished`, `activeProviderId`, `activeModel`, `installedProviderIds`).
+
 ### Fixed — The desktop app no longer renames the user's Mac on every start
 
 2026-09-03 — Beta round 4, OM-70 (#1004). Since v0.142 the Mac of the tester

--- a/docs/middleware-agent-handoff.md
+++ b/docs/middleware-agent-handoff.md
@@ -1437,6 +1437,32 @@ conversationSend{Registry,Service}.ts`, plugin-api 1.8.0) — Gruppen-Nudges,
 Gegenstück zu targetedSend. Tests: `test/conductorTimerStep.test.ts`,
 `test/conversationSendService.test.ts`.
 
+### Runtime-Readiness-Cause + Embedding-Status (Beta-Runde 4, #1000 / #1003)
+
+Zwei kleine API-Ergänzungen, damit Dashboard und Readiness-Banner dieselbe
+Wahrheit lesen (OM-74/75/78/84):
+
+- **`cause` auf dem `multi_orchestrator_unavailable`-503 von
+  `GET /api/v1/operator/agents`.** Werte: `no_llm_access` (kein Key, kein
+  OAuth, kein CLI-Login bei irgendeinem Provider), `no_assignment` (ein Zugang
+  existiert, aber der Provider, dem der Orchestrator per `llm_provider`
+  zugeordnet ist, hat keinen), `unknown` (Zugang und Zuordnung passen; Runtime
+  aus anderem Grund down, z. B. DATABASE_URL, Boot). Berechnung in
+  `src/platform/pluginLlmReadiness.ts` (`computeRuntimeReadinessCause` pur,
+  `resolveRuntimeReadinessCause` mit denselben Credential-Verdicts wie die
+  Providers-Admin, ohne Netz-Probe; `memoizeRuntimeReadinessCause` teilt ein
+  Verdict 8 s zwischen parallelen Aufrufern). Router-Dep `getReadinessCause`
+  in `routes/operatorAgents.ts` ist optional; ohne sie bleibt das 503-Payload
+  unverändert, ein Reject degradiert zu `unknown`. Wiring-Pin in
+  `test/operatorAgentsRouter.test.ts`.
+- **`GET /api/v1/admin/embedding-provider/status`** (auth wie der Rest des
+  Routers): `{ capabilityPublished, activeProviderId, activeModel,
+  installedProviderIds }` aus der Registry allein. Das bestehende `GET /`
+  zählt den Korpus pro Vektorspalte und ist für eine Karte, die bei jedem
+  Dashboard-Load rendert, zu teuer. Konsument: `web-ui/app/page.tsx`
+  (Health-Karte „Gedächtnis / Embeddings“, Onboarding-Hinweis). Tests:
+  `test/runtimeReadinessCause.test.ts`, `test/adminEmbeddingProviderRoute.test.ts`.
+
 ## 4. Migration Managed Agents → Lokal
 
 ### Warum migriert

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -170,6 +170,7 @@ import { createAdminTranscriptionProviderRouter } from './routes/adminTranscript
 import { createAdminCliBackendsRouter } from './routes/adminCliBackends.js';
 import { registerClaudeCliAdapter } from './platform/claudeCliAdapter.js';
 import {
+  memoizeRuntimeReadinessCause,
   resolvePluginLlmReadiness,
   resolveRuntimeReadinessCause,
   type RuntimeReadinessCause,
@@ -3413,13 +3414,19 @@ async function main(): Promise<void> {
   // OM-75 / OM-78 (#1000, #1001) — the readiness verdict the operator-agents
   // 503 carries. Hoisted out of the mount so the wiring-pin tests' lazy
   // `createOperatorAgentsRouter\(\{…\}\)` match still spans every option.
-  const resolveOperatorRuntimeReadinessCause = (): Promise<RuntimeReadinessCause> =>
-    resolveRuntimeReadinessCause({
-      providerIds: [...new Set(listModels().map((m) => m.provider))],
-      orchestratorConfig: installedRegistry.get('@omadia/orchestrator')?.config,
-      vault: secretVault,
-      llmProviderCatalog,
-    });
+  // `async` so a synchronous throw from `listModels()` / the registry lands in
+  // the router's `.catch` instead of escaping the handler. Memoised for a few
+  // seconds: a fresh dashboard fires several 503-probing widgets at once, and
+  // each would otherwise re-run the credential lookup and CLI detection.
+  const resolveOperatorRuntimeReadinessCause = memoizeRuntimeReadinessCause(
+    async (): Promise<RuntimeReadinessCause> =>
+      resolveRuntimeReadinessCause({
+        providerIds: [...new Set(listModels().map((m) => m.provider))],
+        orchestratorConfig: installedRegistry.get('@omadia/orchestrator')?.config,
+        vault: secretVault,
+        llmProviderCatalog,
+      }),
+  );
 
   // US9 / T037 — operator-facing Agents dashboard backend. Mounts at
   // /api/v1/operator/agents/*. 503s when the orchestratorRegistry@1
@@ -3437,6 +3444,13 @@ async function main(): Promise<void> {
       getChatSessionStore,
       getPluginCatalog: () => pluginCatalog,
       getInstalledRegistry: () => installedRegistry,
+      // OM-75 / OM-78 (#1000, #1001) — decorate the 503 with WHY the runtime
+      // is down, so the readiness banner can tell "no access at all" from
+      // "access exists, orchestrator not assigned to it". Same credential
+      // verdicts the providers admin renders; no network probe. Kept above
+      // the closure-heavy options so the wiring-pin tests' lazy regex, which
+      // ends at the first closing paren-brace pair, still sees it.
+      getReadinessCause: resolveOperatorRuntimeReadinessCause,
       // W0c (#861) — the per-agent grant read model needs the graph store.
       // Same graphPool-guarded shape as the other AgentGraphStore sites; when
       // no DATABASE_URL is set the route degrades to its own 503.
@@ -3573,11 +3587,6 @@ async function main(): Promise<void> {
           serviceRegistry.get<OperatorAgentIdentityStore>('agentIdentityStore');
         return store ? { store } : undefined;
       },
-      // OM-75 / OM-78 (#1000, #1001) — decorate the 503 with WHY the runtime
-      // is down, so the readiness banner can tell "no access at all" from
-      // "access exists, orchestrator not assigned to it". Same credential
-      // verdicts the providers admin renders; no network probe.
-      getReadinessCause: resolveOperatorRuntimeReadinessCause,
     }),
   );
   console.log(

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -11,6 +11,7 @@ import { registerOpenAiAdapter } from '@omadia/llm-adapter-openai';
 import { registerOpenAiResponsesAdapter } from '@omadia/llm-adapter-openai-responses';
 import {
   defaultLlmAdapters,
+  listModels,
   LlmProviderCatalog,
   readProviderApiKey,
   readProviderOAuthTokens,
@@ -168,7 +169,11 @@ import { createAdminEmbeddingProviderRouter } from './routes/adminEmbeddingProvi
 import { createAdminTranscriptionProviderRouter } from './routes/adminTranscriptionProvider.js';
 import { createAdminCliBackendsRouter } from './routes/adminCliBackends.js';
 import { registerClaudeCliAdapter } from './platform/claudeCliAdapter.js';
-import { resolvePluginLlmReadiness } from './platform/pluginLlmReadiness.js';
+import {
+  resolvePluginLlmReadiness,
+  resolveRuntimeReadinessCause,
+  type RuntimeReadinessCause,
+} from './platform/pluginLlmReadiness.js';
 import { createServiceRegistryBackedSqlGrantStore } from './platform/pluginSqlGrantStore.js';
 import { createVaultStatusRouter } from './routes/vaultStatus.js';
 import { createBuilderRouter } from './routes/builder.js';
@@ -3405,6 +3410,17 @@ async function main(): Promise<void> {
     '[middleware] memory-backend endpoint ready at /api/v1/admin/memory/backend',
   );
 
+  // OM-75 / OM-78 (#1000, #1001) — the readiness verdict the operator-agents
+  // 503 carries. Hoisted out of the mount so the wiring-pin tests' lazy
+  // `createOperatorAgentsRouter\(\{…\}\)` match still spans every option.
+  const resolveOperatorRuntimeReadinessCause = (): Promise<RuntimeReadinessCause> =>
+    resolveRuntimeReadinessCause({
+      providerIds: [...new Set(listModels().map((m) => m.provider))],
+      orchestratorConfig: installedRegistry.get('@omadia/orchestrator')?.config,
+      vault: secretVault,
+      llmProviderCatalog,
+    });
+
   // US9 / T037 — operator-facing Agents dashboard backend. Mounts at
   // /api/v1/operator/agents/*. 503s when the orchestratorRegistry@1
   // service is not published (no DATABASE_URL / orchestrator plugin not
@@ -3557,6 +3573,11 @@ async function main(): Promise<void> {
           serviceRegistry.get<OperatorAgentIdentityStore>('agentIdentityStore');
         return store ? { store } : undefined;
       },
+      // OM-75 / OM-78 (#1000, #1001) — decorate the 503 with WHY the runtime
+      // is down, so the readiness banner can tell "no access at all" from
+      // "access exists, orchestrator not assigned to it". Same credential
+      // verdicts the providers admin renders; no network probe.
+      getReadinessCause: resolveOperatorRuntimeReadinessCause,
     }),
   );
   console.log(

--- a/middleware/src/platform/pluginLlmReadiness.ts
+++ b/middleware/src/platform/pluginLlmReadiness.ts
@@ -262,3 +262,90 @@ export async function resolvePluginLlmReadiness(
         : undefined;
   return await resolveProviderVerification(provider, { ...deps, cliSnapshot });
 }
+
+/**
+ * OM-75 / OM-78 (#1000, #1001) — WHY the agent runtime is down, for the
+ * `multi_orchestrator_unavailable` 503 the readiness banner probes.
+ *
+ * The banner used to render one fixed text ("no key or subscription yet") for
+ * every 503. In the round-4 beta test that text was wrong at the moment it
+ * mattered: the tester HAD a working subscription login, and what was missing
+ * was the orchestrator's provider assignment (`llm_provider` still on the
+ * default `anthropic`, for which no key exists). Two different remedies, one
+ * message. This verdict tells them apart:
+ *
+ *   - `no_llm_access`  → no provider has any credential (key, OAuth, CLI login)
+ *   - `no_assignment`  → some provider has access, but the one the orchestrator
+ *                        is assigned to does not
+ *   - `unknown`        → access and assignment line up; the runtime is down
+ *                        for another reason (DATABASE_URL, boot, crash)
+ */
+export type RuntimeReadinessCause = 'no_llm_access' | 'no_assignment' | 'unknown';
+
+export interface RuntimeReadinessCauseInputs {
+  /** Credential verdict per provider id, as `resolveProviderVerification`
+   *  reports it. Any status other than `no_key` counts as "has access". */
+  readonly providerStatuses: ReadonlyMap<string, ProviderVerification['status']>;
+  /** The provider the orchestrator is assigned to (`llm_provider`, defaulted). */
+  readonly assignedProvider: string;
+}
+
+/** Pure verdict. Kept separate from the I/O so it can be tested exhaustively. */
+export function computeRuntimeReadinessCause(
+  inputs: RuntimeReadinessCauseInputs,
+): RuntimeReadinessCause {
+  const hasAccess = (status: ProviderVerification['status'] | undefined): boolean =>
+    status !== undefined && status !== 'no_key';
+  const anyAccess = [...inputs.providerStatuses.values()].some(hasAccess);
+  if (!anyAccess) return 'no_llm_access';
+  if (!hasAccess(inputs.providerStatuses.get(inputs.assignedProvider))) {
+    return 'no_assignment';
+  }
+  return 'unknown';
+}
+
+export interface RuntimeReadinessCauseDeps extends PluginLlmReadinessDeps {
+  /** Every provider id the credential lookup should consider. The providers
+   *  admin derives this from `listModels()`; passing it in keeps this module
+   *  free of the model registry. */
+  readonly providerIds: readonly string[];
+  /** The orchestrator plugin's installed config (`llm_provider` is read from
+   *  it). `undefined` when the plugin is not installed. */
+  readonly orchestratorConfig: Record<string, unknown> | undefined;
+}
+
+/**
+ * I/O wrapper around `computeRuntimeReadinessCause`: resolves every provider's
+ * verdict WITHOUT touching the network (cached probes, durable records, one
+ * CLI detection), reads the orchestrator's assignment, and never throws — a
+ * failure inside the lookup degrades to `unknown`, because this only decorates
+ * an error response that is being sent anyway.
+ */
+export async function resolveRuntimeReadinessCause(
+  deps: RuntimeReadinessCauseDeps,
+): Promise<RuntimeReadinessCause> {
+  try {
+    const cliSnapshot =
+      'cliSnapshot' in deps
+        ? deps.cliSnapshot
+        : await (deps.detectCli ?? detectCliSnapshot)();
+    const entries = await Promise.all(
+      deps.providerIds.map(async (id) => {
+        const verdict = await resolveProviderVerification(id as ProviderId, {
+          ...deps,
+          cliSnapshot,
+        });
+        return [id, verdict.status] as const;
+      }),
+    );
+    const assignedProvider =
+      readStringConfig(deps.orchestratorConfig ?? {}, 'llm_provider') ??
+      DEFAULT_PROVIDER;
+    return computeRuntimeReadinessCause({
+      providerStatuses: new Map(entries),
+      assignedProvider,
+    });
+  } catch {
+    return 'unknown';
+  }
+}

--- a/middleware/src/platform/pluginLlmReadiness.ts
+++ b/middleware/src/platform/pluginLlmReadiness.ts
@@ -349,3 +349,33 @@ export async function resolveRuntimeReadinessCause(
     return 'unknown';
   }
 }
+
+/** How long one readiness verdict is shared between callers. A dashboard load
+ *  fires several widgets that all probe `/operator/agents` within the same
+ *  second; the verdict cannot change faster than an operator can click. */
+export const READINESS_CAUSE_MEMO_MS = 8_000;
+
+/**
+ * Share one in-flight / recent verdict across a burst of 503s. The resolver's
+ * result is cached for `ttlMs` from the moment it was REQUESTED, so concurrent
+ * callers join the same promise instead of each spawning a CLI detection. A
+ * rejected resolver is not cached: the next caller retries.
+ */
+export function memoizeRuntimeReadinessCause(
+  resolver: () => Promise<RuntimeReadinessCause>,
+  ttlMs: number = READINESS_CAUSE_MEMO_MS,
+  now: () => number = Date.now,
+): () => Promise<RuntimeReadinessCause> {
+  let memo: { readonly at: number; readonly value: Promise<RuntimeReadinessCause> } | undefined;
+  return () => {
+    const t = now();
+    if (memo !== undefined && t - memo.at < ttlMs) return memo.value;
+    const value = resolver();
+    const entry = { at: t, value };
+    memo = entry;
+    value.catch(() => {
+      if (memo === entry) memo = undefined;
+    });
+    return value;
+  };
+}

--- a/middleware/src/routes/adminEmbeddingProvider.ts
+++ b/middleware/src/routes/adminEmbeddingProvider.ts
@@ -424,6 +424,25 @@ export function createAdminEmbeddingProviderRouter(deps: AdminEmbeddingProviderD
     };
   }
 
+  /**
+   * OM-84 (#1003) — the cheap readiness summary for the dashboard health strip.
+   *
+   * `GET /` counts the stored corpus per vector column, which is right for the
+   * switch page and wrong for a card that renders on every dashboard load. This
+   * route answers the one question the card asks (is `embeddingClient@1`
+   * published, and by whom) from the registry alone. No pool, no counts.
+   */
+  router.get('/status', (_req: Request, res: Response) => {
+    const providerIds = installedProviderIds(deps);
+    const activeId = activeProviderId(deps, providerIds);
+    res.json({
+      capabilityPublished: deps.getEmbeddingClient() !== undefined,
+      activeProviderId: activeId,
+      activeModel: readActiveMetadata(deps),
+      installedProviderIds: providerIds,
+    });
+  });
+
   router.get('/', async (_req: Request, res: Response) => {
     // Express 4 does not forward async-handler rejections to error middleware:
     // an uncaught pool failure would hang the request. Catch → 500.

--- a/middleware/src/routes/operatorAgents.ts
+++ b/middleware/src/routes/operatorAgents.ts
@@ -37,6 +37,7 @@ import {
   type UninstallFromTeamOutcome,
 } from '../platform/teamsProvisionerService.js';
 import type { DelegatedTokenSet } from '../platform/teamsDelegatedSignIn.js';
+import type { RuntimeReadinessCause } from '../platform/pluginLlmReadiness.js';
 import { loadTeamsTargetDirectory } from '../services/teamsTargetDirectoryService.js';
 import {
   resetTeamsIdentity,
@@ -1558,6 +1559,12 @@ export interface OperatorAgentsRouterOptions {
    *  others; the identity routes 503 while it returns undefined (no
    *  DATABASE_URL, tests / minimal mounts). */
   readonly getAgentIdentity?: () => OperatorAgentIdentityDeps | undefined;
+  /** OM-75 / OM-78 (#1000, #1001) — why the runtime is down. The readiness
+   *  banner probes `GET /` and reads `cause` off the 503 so it can name the
+   *  actual remedy (add access vs. assign the orchestrator). Optional: tests
+   *  and minimal mounts omit it and the 503 carries no `cause`. Must not
+   *  throw; a rejection degrades to `unknown`. */
+  readonly getReadinessCause?: () => Promise<RuntimeReadinessCause>;
 }
 
 export function createOperatorAgentsRouter(
@@ -1576,11 +1583,23 @@ export function createOperatorAgentsRouter(
   }
 
   function unavailable(res: Response): void {
-    res.status(503).json({
+    const body = {
       error: 'multi_orchestrator_unavailable',
       message:
         'orchestratorRegistry@1 is not published — DATABASE_URL must be set and the orchestrator plugin must be active.',
-    });
+    };
+    const readinessCause = options.getReadinessCause;
+    if (readinessCause === undefined) {
+      res.status(503).json(body);
+      return;
+    }
+    // The cause is a decoration on an error that is being sent regardless, so
+    // a failing lookup must never turn the 503 into a hung request or a 500.
+    void readinessCause()
+      .catch((): RuntimeReadinessCause => 'unknown')
+      .then((cause) => {
+        res.status(503).json({ ...body, cause });
+      });
   }
 
   function slugParam(req: Request, res: Response): string | undefined {

--- a/middleware/test/adminEmbeddingProviderRoute.test.ts
+++ b/middleware/test/adminEmbeddingProviderRoute.test.ts
@@ -188,6 +188,8 @@ describe('mount-time auth', () => {
     const dispatcher = new Agent({ keepAliveTimeout: 10, keepAliveMaxTimeout: 10 });
     try {
       assert.equal((await undiciFetch(base, { dispatcher })).status, 401);
+      // OM-84 (#1003) — the dashboard's status summary sits behind the same guard.
+      assert.equal((await undiciFetch(`${base}/status`, { dispatcher })).status, 401);
       assert.equal(
         (
           await undiciFetch(`${base}/switch`, {

--- a/middleware/test/adminEmbeddingProviderRoute.test.ts
+++ b/middleware/test/adminEmbeddingProviderRoute.test.ts
@@ -102,6 +102,50 @@ describe('GET /api/v1/admin/embedding-provider', () => {
   });
 });
 
+// OM-84 (#1003) — the dashboard health card's cheap summary. It must answer
+// from the registry alone (the full GET counts the corpus) and say plainly
+// whether `embeddingClient@1` is published.
+describe('GET /api/v1/admin/embedding-provider/status', () => {
+  it('reports the published capability and its provider', async () => {
+    harness = await makeHarness([
+      { id: OLLAMA, status: 'active' },
+      { id: KG_NEON, status: 'active', config: {} },
+    ]);
+    const res = await undiciFetch(`${harness.baseUrl}/status`);
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as {
+      capabilityPublished: boolean;
+      activeProviderId: string | null;
+      activeModel: { modelId: string; dimensions: number } | null;
+      installedProviderIds: string[];
+    };
+    assert.equal(body.capabilityPublished, true);
+    assert.equal(body.activeProviderId, OLLAMA);
+    assert.deepEqual(body.activeModel, {
+      modelId: 'ollama:nomic-embed-text',
+      dimensions: 768,
+    });
+    assert.deepEqual(body.installedProviderIds, [OLLAMA]);
+  });
+
+  it('reports capabilityPublished=false when no embedding provider is active (the round-4 default install)', async () => {
+    harness = await makeHarness([
+      { id: OPENAI, status: 'inactive', config: {} },
+      { id: KG_NEON, status: 'active', config: {} },
+    ]);
+    const res = await undiciFetch(`${harness.baseUrl}/status`);
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as {
+      capabilityPublished: boolean;
+      activeProviderId: string | null;
+      activeModel: unknown;
+    };
+    assert.equal(body.capabilityPublished, false);
+    assert.equal(body.activeProviderId, null);
+    assert.equal(body.activeModel, null);
+  });
+});
+
 describe('mount-time auth', () => {
   it('lets no route escape the guard applied at mount', async () => {
     const registry = new InMemoryInstalledRegistry();

--- a/middleware/test/operatorAgentsRouter.test.ts
+++ b/middleware/test/operatorAgentsRouter.test.ts
@@ -3233,6 +3233,68 @@ describe('createOperatorAgentsRouter', () => {
         `http://127.0.0.1:${String(addr.port)}/api/v1/operator/agents`,
       );
       assert.equal(res.status, 503);
+      // Without a cause resolver the payload is exactly what it always was.
+      const body = (await res.json()) as Record<string, unknown>;
+      assert.equal(body['error'], 'multi_orchestrator_unavailable');
+      assert.equal('cause' in body, false);
+    } finally {
+      await new Promise<void>((r) => s.close(() => r()));
+    }
+  });
+
+  // OM-75 / OM-78 (#1000, #1001) — the readiness banner reads `cause` off this
+  // 503 to tell "no access at all" from "access exists, orchestrator not
+  // assigned to it". A failing resolver must degrade, never hang or 500.
+  it('503 carries the readiness cause when a resolver is wired', async () => {
+    const app = express();
+    app.use(express.json());
+    app.use(
+      '/api/v1/operator/agents',
+      createOperatorAgentsRouter({
+        getConfigStore: () => undefined,
+        getRegistry: () => undefined,
+        getChatSessionStore: () => undefined,
+        getReadinessCause: async () => 'no_assignment',
+      }),
+    );
+    const s = await listenLoopback(app);
+    try {
+      const addr = s.address() as AddressInfo;
+      const res = await fetch(
+        `http://127.0.0.1:${String(addr.port)}/api/v1/operator/agents`,
+      );
+      assert.equal(res.status, 503);
+      const body = (await res.json()) as Record<string, unknown>;
+      assert.equal(body['error'], 'multi_orchestrator_unavailable');
+      assert.equal(body['cause'], 'no_assignment');
+    } finally {
+      await new Promise<void>((r) => s.close(() => r()));
+    }
+  });
+
+  it('503 degrades the cause to unknown when the resolver rejects', async () => {
+    const app = express();
+    app.use(express.json());
+    app.use(
+      '/api/v1/operator/agents',
+      createOperatorAgentsRouter({
+        getConfigStore: () => undefined,
+        getRegistry: () => undefined,
+        getChatSessionStore: () => undefined,
+        getReadinessCause: async () => {
+          throw new Error('vault exploded');
+        },
+      }),
+    );
+    const s = await listenLoopback(app);
+    try {
+      const addr = s.address() as AddressInfo;
+      const res = await fetch(
+        `http://127.0.0.1:${String(addr.port)}/api/v1/operator/agents`,
+      );
+      assert.equal(res.status, 503);
+      const body = (await res.json()) as Record<string, unknown>;
+      assert.equal(body['cause'], 'unknown');
     } finally {
       await new Promise<void>((r) => s.close(() => r()));
     }

--- a/middleware/test/operatorAgentsRouter.test.ts
+++ b/middleware/test/operatorAgentsRouter.test.ts
@@ -1201,6 +1201,13 @@ describe('createOperatorAgentsRouter', () => {
       'index.ts must pass getAgentGraphStore to createOperatorAgentsRouter — without it every GET /:slug/grants 503s',
     );
     assert.match(mount, /new AgentGraphStore\(graphPool\)/, 'the option must construct the real store from graphPool');
+    // OM-75 / OM-78 (#1000, #1001) — without this the readiness banner never
+    // learns WHY the runtime is down and falls back to the no-access copy.
+    assert.match(
+      mount,
+      /getReadinessCause:/,
+      'index.ts must pass getReadinessCause to createOperatorAgentsRouter — without it the 503 carries no cause',
+    );
   });
 
   it('index.ts wires syncBotConfig into the provisioning runner (wiring pin, #910)', async () => {

--- a/middleware/test/runtimeReadinessCause.test.ts
+++ b/middleware/test/runtimeReadinessCause.test.ts
@@ -122,6 +122,7 @@ function snapshot(
       }),
     ),
     generatedAt: 0,
+    cliToolsDir: '/tmp/cli-tools',
   };
 }
 

--- a/middleware/test/runtimeReadinessCause.test.ts
+++ b/middleware/test/runtimeReadinessCause.test.ts
@@ -15,8 +15,10 @@ import { providerApiKeyVaultKey } from '@omadia/llm-provider';
 
 import {
   computeRuntimeReadinessCause,
+  memoizeRuntimeReadinessCause,
   resolveRuntimeReadinessCause,
   type LlmProviderCatalogView,
+  type RuntimeReadinessCause,
 } from '../src/platform/pluginLlmReadiness.js';
 import { __clearVerificationCache } from '../src/platform/providerCredentialVerifier.js';
 import type {
@@ -183,6 +185,48 @@ test('resolveRuntimeReadinessCause: a stored anthropic key on the default assign
     detectCli: async () => snapshot([{ id: 'claude', loggedIn: 'no' }]),
   });
   assert.equal(cause, 'unknown');
+});
+
+// ── The memo ────────────────────────────────────────────────────────────────
+
+test('memoizeRuntimeReadinessCause: concurrent callers within the TTL share one resolver run', async () => {
+  let calls = 0;
+  let clock = 1_000;
+  const memo = memoizeRuntimeReadinessCause(
+    async () => {
+      calls += 1;
+      return 'no_assignment';
+    },
+    5_000,
+    () => clock,
+  );
+  const [a, b, c] = await Promise.all([memo(), memo(), memo()]);
+  assert.deepEqual([a, b, c], ['no_assignment', 'no_assignment', 'no_assignment']);
+  assert.equal(calls, 1);
+
+  clock += 4_999;
+  assert.equal(await memo(), 'no_assignment');
+  assert.equal(calls, 1, 'still inside the TTL');
+
+  clock += 1;
+  assert.equal(await memo(), 'no_assignment');
+  assert.equal(calls, 2, 'TTL elapsed → recomputed');
+});
+
+test('memoizeRuntimeReadinessCause: a rejected run is not cached, the next caller retries', async () => {
+  let calls = 0;
+  const memo = memoizeRuntimeReadinessCause(
+    async (): Promise<RuntimeReadinessCause> => {
+      calls += 1;
+      if (calls === 1) throw new Error('first run explodes');
+      return 'unknown';
+    },
+    5_000,
+    () => 1_000,
+  );
+  await assert.rejects(memo(), /first run explodes/);
+  assert.equal(await memo(), 'unknown');
+  assert.equal(calls, 2);
 });
 
 test('resolveRuntimeReadinessCause: a throwing lookup degrades to unknown instead of failing the 503', async () => {

--- a/middleware/test/runtimeReadinessCause.test.ts
+++ b/middleware/test/runtimeReadinessCause.test.ts
@@ -1,0 +1,202 @@
+/**
+ * OM-75 / OM-78 (#1000, #1001) — the readiness banner's `cause`.
+ *
+ * Round-4 beta test: the tester had a working subscription login and every
+ * operator surface still 503ed, because the orchestrator was assigned to the
+ * default `anthropic` provider for which no key existed. The banner told him to
+ * "add a key or subscription", which he had already done. These tests pin the
+ * verdict that lets the banner name the actual remedy.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { providerApiKeyVaultKey } from '@omadia/llm-provider';
+
+import {
+  computeRuntimeReadinessCause,
+  resolveRuntimeReadinessCause,
+  type LlmProviderCatalogView,
+} from '../src/platform/pluginLlmReadiness.js';
+import { __clearVerificationCache } from '../src/platform/providerCredentialVerifier.js';
+import type {
+  CliBackendsSnapshot,
+  CliBackendStatus,
+  CliLoginState,
+} from '../src/platform/cliBackendDetector.js';
+import { InMemorySecretVault } from '../src/secrets/vault.js';
+
+const statuses = (
+  entries: Array<[string, 'no_key' | 'unverified' | 'verified' | 'invalid']>,
+): ReadonlyMap<string, 'no_key' | 'unverified' | 'verified' | 'invalid'> =>
+  new Map(entries);
+
+test('computeRuntimeReadinessCause: nothing has access → no_llm_access', () => {
+  assert.equal(
+    computeRuntimeReadinessCause({
+      providerStatuses: statuses([
+        ['anthropic', 'no_key'],
+        ['openai', 'no_key'],
+        ['claude-cli', 'no_key'],
+      ]),
+      assignedProvider: 'anthropic',
+    }),
+    'no_llm_access',
+  );
+});
+
+test('computeRuntimeReadinessCause: an empty provider list is no access, not unknown', () => {
+  assert.equal(
+    computeRuntimeReadinessCause({
+      providerStatuses: statuses([]),
+      assignedProvider: 'anthropic',
+    }),
+    'no_llm_access',
+  );
+});
+
+test('computeRuntimeReadinessCause: CLI logged in, orchestrator still on anthropic → no_assignment (the round-4 case)', () => {
+  assert.equal(
+    computeRuntimeReadinessCause({
+      providerStatuses: statuses([
+        ['anthropic', 'no_key'],
+        ['claude-cli', 'verified'],
+      ]),
+      assignedProvider: 'anthropic',
+    }),
+    'no_assignment',
+  );
+});
+
+test('computeRuntimeReadinessCause: assigned to a provider the list does not know → no_assignment', () => {
+  assert.equal(
+    computeRuntimeReadinessCause({
+      providerStatuses: statuses([['claude-cli', 'verified']]),
+      assignedProvider: 'some-uninstalled-plugin-provider',
+    }),
+    'no_assignment',
+  );
+});
+
+test('computeRuntimeReadinessCause: an unverified key still counts as access — the runtime does not gate on the probe', () => {
+  assert.equal(
+    computeRuntimeReadinessCause({
+      providerStatuses: statuses([['anthropic', 'unverified']]),
+      assignedProvider: 'anthropic',
+    }),
+    'unknown',
+  );
+});
+
+test('computeRuntimeReadinessCause: access and assignment line up → unknown (down for another reason)', () => {
+  assert.equal(
+    computeRuntimeReadinessCause({
+      providerStatuses: statuses([
+        ['anthropic', 'verified'],
+        ['claude-cli', 'verified'],
+      ]),
+      assignedProvider: 'claude-cli',
+    }),
+    'unknown',
+  );
+});
+
+// ── The I/O wrapper ─────────────────────────────────────────────────────────
+
+function snapshot(
+  backends: Array<{ id: string; loggedIn: CliLoginState }>,
+): CliBackendsSnapshot {
+  return {
+    backends: backends.map(
+      (backend): CliBackendStatus => ({
+        id: backend.id,
+        label: backend.id,
+        bin: backend.id,
+        installed: true,
+        loggedIn: backend.loggedIn,
+        billing: 'subscription',
+        detail: `${backend.id} probe fixture`,
+        installable: true,
+      }),
+    ),
+    generatedAt: 0,
+  };
+}
+
+const catalog: LlmProviderCatalogView = {
+  get(id: string) {
+    return id === 'claude-cli'
+      ? { label: 'Claude (subscription CLI)', policy: { requiresApiKey: false } }
+      : { label: id };
+  },
+};
+
+test('resolveRuntimeReadinessCause: fresh install, nothing configured → no_llm_access', async () => {
+  __clearVerificationCache();
+  const cause = await resolveRuntimeReadinessCause({
+    providerIds: ['anthropic', 'claude-cli'],
+    orchestratorConfig: {},
+    vault: new InMemorySecretVault(),
+    llmProviderCatalog: catalog,
+    detectCli: async () => snapshot([{ id: 'claude', loggedIn: 'no' }]),
+  });
+  assert.equal(cause, 'no_llm_access');
+});
+
+test('resolveRuntimeReadinessCause: CLI logged in, llm_provider unset (defaults to anthropic) → no_assignment', async () => {
+  __clearVerificationCache();
+  const cause = await resolveRuntimeReadinessCause({
+    providerIds: ['anthropic', 'claude-cli'],
+    orchestratorConfig: {},
+    vault: new InMemorySecretVault(),
+    llmProviderCatalog: catalog,
+    detectCli: async () => snapshot([{ id: 'claude', loggedIn: 'yes' }]),
+  });
+  assert.equal(cause, 'no_assignment');
+});
+
+test('resolveRuntimeReadinessCause: CLI logged in AND assigned → unknown', async () => {
+  __clearVerificationCache();
+  const cause = await resolveRuntimeReadinessCause({
+    providerIds: ['anthropic', 'claude-cli'],
+    orchestratorConfig: { llm_provider: 'claude-cli' },
+    vault: new InMemorySecretVault(),
+    llmProviderCatalog: catalog,
+    detectCli: async () => snapshot([{ id: 'claude', loggedIn: 'yes' }]),
+  });
+  assert.equal(cause, 'unknown');
+});
+
+test('resolveRuntimeReadinessCause: a stored anthropic key on the default assignment → unknown', async () => {
+  __clearVerificationCache();
+  const vault = new InMemorySecretVault();
+  await vault.set(
+    '@omadia/orchestrator',
+    providerApiKeyVaultKey('anthropic'),
+    'sk-ant-test',
+  );
+  const cause = await resolveRuntimeReadinessCause({
+    providerIds: ['anthropic', 'claude-cli'],
+    orchestratorConfig: {},
+    vault,
+    llmProviderCatalog: catalog,
+    detectCli: async () => snapshot([{ id: 'claude', loggedIn: 'no' }]),
+  });
+  assert.equal(cause, 'unknown');
+});
+
+test('resolveRuntimeReadinessCause: a throwing lookup degrades to unknown instead of failing the 503', async () => {
+  __clearVerificationCache();
+  const cause = await resolveRuntimeReadinessCause({
+    providerIds: ['anthropic'],
+    orchestratorConfig: {},
+    vault: {
+      get: async () => {
+        throw new Error('vault exploded');
+      },
+    },
+    llmProviderCatalog: catalog,
+    detectCli: async () => undefined,
+  });
+  assert.equal(cause, 'unknown');
+});

--- a/web-ui/app/__tests__/page.test.tsx
+++ b/web-ui/app/__tests__/page.test.tsx
@@ -21,12 +21,14 @@ const {
   mockListOperatorAgents,
   mockMcp,
   mockGetCliBackends,
+  mockGetEmbeddingStatus,
 } = vi.hoisted(() => ({
   mockGetProviders: vi.fn(),
   mockListStorePlugins: vi.fn(),
   mockListOperatorAgents: vi.fn(),
   mockMcp: vi.fn(),
   mockGetCliBackends: vi.fn(),
+  mockGetEmbeddingStatus: vi.fn(),
 }));
 
 vi.mock('next-intl/server', () => ({
@@ -49,6 +51,7 @@ vi.mock('../_lib/api', () => ({
   getProviders: mockGetProviders,
   listStorePlugins: mockListStorePlugins,
   getCliBackends: mockGetCliBackends,
+  getEmbeddingProviderStatus: mockGetEmbeddingStatus,
 }));
 
 vi.mock('../_lib/agents', () => ({
@@ -64,14 +67,23 @@ vi.mock('../_components/dashboard/DashboardOnboarding', () => ({
   DashboardOnboarding: ({
     llmVerified,
     cliLoggedIn,
+    runtimeUp,
+    assignedProviderKind,
+    embeddingsOff,
   }: {
     llmVerified: boolean;
     cliLoggedIn: boolean;
+    runtimeUp: boolean;
+    assignedProviderKind: 'cli' | 'api' | null;
+    embeddingsOff: boolean;
   }): React.ReactElement => (
     <div
       data-testid="onboarding"
       data-llm-verified={String(llmVerified)}
       data-cli-logged-in={String(cliLoggedIn)}
+      data-runtime-up={String(runtimeUp)}
+      data-assigned-kind={String(assignedProviderKind)}
+      data-embeddings-off={String(embeddingsOff)}
     />
   ),
 }));
@@ -123,6 +135,12 @@ describe('dashboard — LLM health derivation', () => {
     mockListOperatorAgents.mockResolvedValue({ agents: [] });
     mockMcp.mockResolvedValue({});
     mockGetCliBackends.mockResolvedValue({ backends: [], generatedAt: Date.now() });
+    mockGetEmbeddingStatus.mockResolvedValue({
+      capabilityPublished: true,
+      activeProviderId: '@omadia/embeddings',
+      activeModel: { modelId: 'ollama:nomic-embed-text', dimensions: 768 },
+      installedProviderIds: ['@omadia/embeddings'],
+    });
   });
 
   it('a verified provider reads OK and names the active provider', async () => {
@@ -226,5 +244,109 @@ describe('dashboard — LLM health derivation', () => {
     });
     render(await DashboardPage());
     expect(screen.getByTestId('onboarding').dataset['cliLoggedIn']).toBe('true');
+  });
+
+  // OM-78 (#1001) — the runtime signal handed to onboarding is the operator
+  // route's answer, the same probe the readiness banner uses. A 503 there
+  // means "not up", whatever the provider list says.
+  it('OM-78: runtimeUp follows /operator/agents, not the provider list', async () => {
+    mockGetProviders.mockResolvedValue(
+      providersResponse([provider({ status: 'verified', connected: true })]),
+    );
+    mockListOperatorAgents.mockRejectedValue(
+      Object.assign(new Error('503'), { status: 503 }),
+    );
+    render(await DashboardPage());
+    const onboarding = screen.getByTestId('onboarding').dataset;
+    expect(onboarding['llmVerified']).toBe('true');
+    expect(onboarding['runtimeUp']).toBe('false');
+  });
+
+  it('OM-78: runtimeUp is true once the operator route answers', async () => {
+    mockGetProviders.mockResolvedValue(providersResponse([provider()]));
+    render(await DashboardPage());
+    expect(screen.getByTestId('onboarding').dataset['runtimeUp']).toBe('true');
+  });
+
+  // OM-74 (#999) — the done-copy follows what the orchestrator is ASSIGNED to.
+  it('OM-74: a claude-cli assignment is reported as kind=cli', async () => {
+    mockGetProviders.mockResolvedValue({
+      ...providersResponse([
+        provider({ id: 'claude-cli', label: 'Claude (subscription CLI)', toolLess: true }),
+        provider(),
+      ]),
+      assignments: [
+        {
+          pluginId: '@omadia/orchestrator',
+          label: 'Orchestrator',
+          installed: true,
+          provider: 'claude-cli',
+          model: 'claude-cli:opus-cli',
+          modelKey: 'orchestrator_model',
+        },
+      ],
+    });
+    render(await DashboardPage());
+    expect(screen.getByTestId('onboarding').dataset['assignedKind']).toBe('cli');
+  });
+
+  it('OM-74: an anthropic assignment is reported as kind=api', async () => {
+    mockGetProviders.mockResolvedValue(providersResponse([provider()]));
+    render(await DashboardPage());
+    expect(screen.getByTestId('onboarding').dataset['assignedKind']).toBe('api');
+  });
+});
+
+// OM-84 (#1003) — memory, semantic search and dedup hang off embeddingClient@1.
+// A default install has none, and no surface said so.
+describe('dashboard — embeddings health card', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetProviders.mockResolvedValue(providersResponse([provider()]));
+    mockListStorePlugins.mockResolvedValue({ items: [] });
+    mockListOperatorAgents.mockResolvedValue({ agents: [] });
+    mockMcp.mockResolvedValue({});
+    mockGetCliBackends.mockResolvedValue({ backends: [], generatedAt: Date.now() });
+  });
+
+  async function renderEmbeddingsCard(): Promise<string> {
+    render(await DashboardPage());
+    const title = screen.getByText('health.embeddings.title');
+    const card = title.closest('li');
+    if (!card) throw new Error('embeddings health card not found');
+    return card.textContent ?? '';
+  }
+
+  it('reads OK and names the model when the capability is published', async () => {
+    mockGetEmbeddingStatus.mockResolvedValue({
+      capabilityPublished: true,
+      activeProviderId: '@omadia/embeddings',
+      activeModel: { modelId: 'ollama:nomic-embed-text', dimensions: 768 },
+      installedProviderIds: ['@omadia/embeddings'],
+    });
+    const text = await renderEmbeddingsCard();
+    expect(text).toContain('health.ok');
+    expect(text).toContain('health.embeddings.active:{"model":"ollama:nomic-embed-text"}');
+    expect(screen.getByTestId('onboarding').dataset['embeddingsOff']).toBe('false');
+  });
+
+  it('reads WARN and says so when no embedding provider is published (the round-4 default install)', async () => {
+    mockGetEmbeddingStatus.mockResolvedValue({
+      capabilityPublished: false,
+      activeProviderId: null,
+      activeModel: null,
+      installedProviderIds: [],
+    });
+    const text = await renderEmbeddingsCard();
+    expect(text).toContain('health.warn');
+    expect(text).toContain('health.embeddings.none');
+    expect(screen.getByTestId('onboarding').dataset['embeddingsOff']).toBe('true');
+  });
+
+  it('does not claim "off" when the status route is unreachable', async () => {
+    mockGetEmbeddingStatus.mockRejectedValue(new Error('boom'));
+    const text = await renderEmbeddingsCard();
+    expect(text).toContain('health.embeddings.unknown');
+    expect(screen.getByTestId('onboarding').dataset['embeddingsOff']).toBe('false');
   });
 });

--- a/web-ui/app/__tests__/page.test.tsx
+++ b/web-ui/app/__tests__/page.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen } from '@testing-library/react';
+import { cleanup, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { AdminProvider, ProvidersResponse } from '../_lib/api';
+import { ApiError, type AdminProvider, type ProvidersResponse } from '../_lib/api';
 
 /**
  * Dashboard LLM-health derivation (OM-02/03/04).
@@ -47,7 +47,10 @@ vi.mock('next/link', () => ({
   }): React.ReactElement => <a href={href}>{children}</a>,
 }));
 
-vi.mock('../_lib/api', () => ({
+// `ApiError` stays real: page.tsx narrows the operator-agents rejection with
+// `instanceof ApiError` to tell the structured 503 from any other failure.
+vi.mock('../_lib/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../_lib/api')>()),
   getProviders: mockGetProviders,
   listStorePlugins: mockListStorePlugins,
   getCliBackends: mockGetCliBackends,
@@ -69,12 +72,16 @@ vi.mock('../_components/dashboard/DashboardOnboarding', () => ({
     cliLoggedIn,
     runtimeUp,
     assignedProviderKind,
+    assignedProviderStatus,
+    assignedProviderLabel,
     embeddingsOff,
   }: {
     llmVerified: boolean;
     cliLoggedIn: boolean;
     runtimeUp: boolean;
-    assignedProviderKind: 'cli' | 'api' | null;
+    assignedProviderKind: 'cli' | 'oauth' | 'api' | null;
+    assignedProviderStatus: string | null;
+    assignedProviderLabel: string | null;
     embeddingsOff: boolean;
   }): React.ReactElement => (
     <div
@@ -83,6 +90,8 @@ vi.mock('../_components/dashboard/DashboardOnboarding', () => ({
       data-cli-logged-in={String(cliLoggedIn)}
       data-runtime-up={String(runtimeUp)}
       data-assigned-kind={String(assignedProviderKind)}
+      data-assigned-status={String(assignedProviderStatus)}
+      data-assigned-label={String(assignedProviderLabel)}
       data-embeddings-off={String(embeddingsOff)}
     />
   ),
@@ -254,7 +263,7 @@ describe('dashboard — LLM health derivation', () => {
       providersResponse([provider({ status: 'verified', connected: true })]),
     );
     mockListOperatorAgents.mockRejectedValue(
-      Object.assign(new Error('503'), { status: 503 }),
+      new ApiError(503, 'GET /v1/operator/agents failed: 503', '{"error":"multi_orchestrator_unavailable"}'),
     );
     render(await DashboardPage());
     const onboarding = screen.getByTestId('onboarding').dataset;
@@ -264,6 +273,20 @@ describe('dashboard — LLM health derivation', () => {
 
   it('OM-78: runtimeUp is true once the operator route answers', async () => {
     mockGetProviders.mockResolvedValue(providersResponse([provider()]));
+    render(await DashboardPage());
+    expect(screen.getByTestId('onboarding').dataset['runtimeUp']).toBe('true');
+  });
+
+  it('OM-78: a transient 500 (or a network blip) does not un-tick step 1 — only the structured 503 does', async () => {
+    mockGetProviders.mockResolvedValue(providersResponse([provider()]));
+    mockListOperatorAgents.mockRejectedValue(
+      new ApiError(500, 'GET /v1/operator/agents failed: 500'),
+    );
+    render(await DashboardPage());
+    expect(screen.getByTestId('onboarding').dataset['runtimeUp']).toBe('true');
+
+    cleanup();
+    mockListOperatorAgents.mockRejectedValue(new TypeError('fetch failed'));
     render(await DashboardPage());
     expect(screen.getByTestId('onboarding').dataset['runtimeUp']).toBe('true');
   });
@@ -290,10 +313,45 @@ describe('dashboard — LLM health derivation', () => {
     expect(screen.getByTestId('onboarding').dataset['assignedKind']).toBe('cli');
   });
 
-  it('OM-74: an anthropic assignment is reported as kind=api', async () => {
-    mockGetProviders.mockResolvedValue(providersResponse([provider()]));
+  it('OM-74: an anthropic assignment is reported as kind=api with its status and label', async () => {
+    mockGetProviders.mockResolvedValue(
+      providersResponse([provider({ status: 'unverified', connected: true })]),
+    );
     render(await DashboardPage());
-    expect(screen.getByTestId('onboarding').dataset['assignedKind']).toBe('api');
+    const onboarding = screen.getByTestId('onboarding').dataset;
+    expect(onboarding['assignedKind']).toBe('api');
+    expect(onboarding['assignedStatus']).toBe('unverified');
+    expect(onboarding['assignedLabel']).toBe('Anthropic');
+  });
+
+  it('OM-74: an OAuth subscription assignment is reported as kind=oauth', async () => {
+    mockGetProviders.mockResolvedValue({
+      ...providersResponse([
+        provider({ id: 'openai-chatgpt', label: 'ChatGPT', oauthConnect: true, status: 'verified' }),
+      ]),
+      assignments: [
+        {
+          pluginId: '@omadia/orchestrator',
+          label: 'Orchestrator',
+          installed: true,
+          provider: 'openai-chatgpt',
+          model: 'openai-chatgpt:gpt-5',
+          modelKey: 'orchestrator_model',
+        },
+      ],
+    });
+    render(await DashboardPage());
+    expect(screen.getByTestId('onboarding').dataset['assignedKind']).toBe('oauth');
+  });
+
+  it('OM-74: no matching provider row reports kind=null, not api', async () => {
+    mockGetProviders.mockResolvedValue({
+      ...providersResponse([]),
+    });
+    render(await DashboardPage());
+    const onboarding = screen.getByTestId('onboarding').dataset;
+    expect(onboarding['assignedKind']).toBe('null');
+    expect(onboarding['assignedStatus']).toBe('null');
   });
 });
 

--- a/web-ui/app/_components/RuntimeReadinessBanner.tsx
+++ b/web-ui/app/_components/RuntimeReadinessBanner.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { motion } from 'framer-motion';
-import { KeyRound } from 'lucide-react';
+import { Cpu, KeyRound } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 
 import { Button } from './ui/Button';
@@ -13,8 +13,8 @@ import { Button } from './ui/Button';
  * RuntimeReadinessBanner — turns the fresh-install "everything 503s" state
  * into a visible, actionable hint.
  *
- * On a fresh install the orchestrator plugin has no LLM API key, so it never
- * publishes chatAgent@1 / orchestratorRegistry@1: every operator surface
+ * On a fresh install the orchestrator plugin has no usable LLM access, so it
+ * never publishes chatAgent@1 / orchestratorRegistry@1: every operator surface
  * (agents, channels, skills, chat) answers 503
  * `multi_orchestrator_unavailable`, and routines aren't mounted at all. The
  * individual pages then surface raw "GET … failed: 503" strings with no hint
@@ -22,15 +22,32 @@ import { Button } from './ui/Button';
  *
  * Detection is a probe of one representative operator route, looking for the
  * structured 503. It re-probes on tab focus, and on a heartbeat while the
- * card is visible, so it clears itself the moment the key is saved (the
- * operator routes go live without a restart).
+ * card is visible, so it clears itself the moment the runtime comes up.
+ *
+ * OM-75 (#1000) — the 503 carries a `cause`, and the copy follows it. In the
+ * round-4 beta test the tester HAD a working subscription login; what was
+ * missing was the orchestrator's provider assignment. The old single text
+ * ("add a key or subscription") sent him back to a step he had completed, and
+ * promised chat "right away" once he did. Two causes, two texts:
+ *
+ *   - `no_llm_access`  → no key, no OAuth, no CLI login anywhere
+ *   - `no_assignment`  → access exists, the orchestrator points elsewhere
+ *
+ * A 503 without a cause (older middleware) renders the no-access copy.
  *
  * Mounted once in the root layout, next to SessionWatcher. Renders nothing
  * on /login + /setup.
  */
 
-/** Heartbeat cadence while the card is visible — catches the key being saved. */
+/** Heartbeat cadence while the card is visible — catches the fix landing. */
 const HEARTBEAT_MS = 60 * 1000;
+
+/** Mirrors `RuntimeReadinessCause` in middleware/src/platform/pluginLlmReadiness.ts. */
+export type RuntimeReadinessCause = 'no_llm_access' | 'no_assignment' | 'unknown';
+
+function parseCause(value: unknown): RuntimeReadinessCause {
+  return value === 'no_assignment' || value === 'unknown' ? value : 'no_llm_access';
+}
 
 function isAuthPage(pathname: string): boolean {
   return pathname === '/login' || pathname === '/setup';
@@ -40,14 +57,16 @@ export function RuntimeReadinessBanner(): React.ReactElement | null {
   const pathname = usePathname();
   const onAuthPage = isAuthPage(pathname);
 
-  const [unavailable, setUnavailable] = useState(false);
+  // `null` = runtime is up (or not this card's concern); a cause = show it.
+  const [cause, setCause] = useState<RuntimeReadinessCause | null>(null);
   const [dismissed, setDismissed] = useState(false);
+  const unavailable = cause !== null;
 
   // ── Initial probe + focus re-check + heartbeat-while-visible ────────────
   // One effect à la SessionWatcher: the probe lives inside so every
   // setState happens after an await (no sync-setState-in-effect). The
   // heartbeat is only armed while the card shows — its job is to clear the
-  // card once the key lands and the operator routes come up.
+  // card once the fix lands and the operator routes come up.
   useEffect(() => {
     if (onAuthPage) return;
     let cancelled = false;
@@ -60,14 +79,19 @@ export function RuntimeReadinessBanner(): React.ReactElement | null {
         if (cancelled) return;
         if (res.status !== 503) {
           // 200 = runtime is up; 401/403 = not this card's concern.
-          setUnavailable(false);
+          setCause(null);
           return;
         }
         const body = (await res.json().catch(() => null)) as {
           error?: string;
+          cause?: unknown;
         } | null;
         if (cancelled) return;
-        setUnavailable(body?.error === 'multi_orchestrator_unavailable');
+        setCause(
+          body?.error === 'multi_orchestrator_unavailable'
+            ? parseCause(body.cause)
+            : null,
+        );
       } catch {
         // Network blip — leave state intact; the next probe retries.
       }
@@ -90,25 +114,34 @@ export function RuntimeReadinessBanner(): React.ReactElement | null {
     };
   }, [onAuthPage, unavailable, dismissed]);
 
-  if (onAuthPage || !unavailable || dismissed) return null;
+  if (onAuthPage || cause === null || dismissed) return null;
 
   // No AnimatePresence exit animation on purpose: the card leaves when the
   // runtime comes up — an instant disappearance is fine, and it keeps the
   // clear-on-heartbeat path deterministic under fake timers in tests.
-  return <ReadinessCard onDismiss={() => setDismissed(true)} />;
+  return <ReadinessCard cause={cause} onDismiss={() => setDismissed(true)} />;
 }
 
 /** Non-blocking bottom-right card, styled after SessionWarningCard. */
 function ReadinessCard({
+  cause,
   onDismiss,
 }: {
+  cause: RuntimeReadinessCause;
   onDismiss: () => void;
 }): React.ReactElement {
   const t = useTranslations('runtimeReadiness');
+  // `unknown` (access + assignment line up, runtime down for another reason)
+  // still gets the access copy: it is the only place in the UI that links to
+  // the provider page, and the operator needs to end up there either way.
+  const noAssignment = cause === 'no_assignment';
+  const Icon = noAssignment ? Cpu : KeyRound;
 
   return (
     <motion.div
       role="alert"
+      data-testid="runtime-readiness-card"
+      data-cause={cause}
       initial={{ opacity: 0, y: 24 }}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: 24 }}
@@ -116,11 +149,11 @@ function ReadinessCard({
       className="fixed bottom-5 right-5 z-[80] w-[min(92vw,24rem)] border border-[color:var(--rule-strong)] bg-[color:var(--paper)] p-4 shadow-[0_24px_60px_-20px_rgba(0,0,0,0.45)]"
     >
       <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.2em] text-[color:var(--accent)]">
-        <KeyRound className="size-3.5" aria-hidden />
-        {t('title')}
+        <Icon className="size-3.5" aria-hidden />
+        {noAssignment ? t('titleNoAssignment') : t('title')}
       </div>
       <p className="mt-2 text-[13px] leading-relaxed text-[color:var(--ink)]">
-        {t('body')}
+        {noAssignment ? t('bodyNoAssignment') : t('body')}
       </p>
       <div className="mt-4 flex items-center gap-2">
         <Link
@@ -128,7 +161,7 @@ function ReadinessCard({
           onClick={onDismiss}
           className="flex-1 border border-[color:var(--ink)] bg-[color:var(--ink)] px-3 py-2 text-center text-[11px] uppercase tracking-[0.16em] text-[color:var(--paper)] transition hover:border-[color:var(--accent)] hover:bg-[color:var(--accent)]"
         >
-          {t('cta')}
+          {noAssignment ? t('ctaNoAssignment') : t('cta')}
         </Link>
         <Button
           type="button"

--- a/web-ui/app/_components/RuntimeReadinessBanner.tsx
+++ b/web-ui/app/_components/RuntimeReadinessBanner.tsx
@@ -131,11 +131,23 @@ function ReadinessCard({
   onDismiss: () => void;
 }): React.ReactElement {
   const t = useTranslations('runtimeReadiness');
-  // `unknown` (access + assignment line up, runtime down for another reason)
-  // still gets the access copy: it is the only place in the UI that links to
-  // the provider page, and the operator needs to end up there either way.
+  // `unknown` means access AND assignment are set (that is how the middleware
+  // derives it), so the no-access sentence would be a measured falsehood —
+  // e.g. a stored-but-invalid key. It gets its own copy; the CTA still leads
+  // to the provider page because that is where the access is checked.
   const noAssignment = cause === 'no_assignment';
+  const unknown = cause === 'unknown';
   const Icon = noAssignment ? Cpu : KeyRound;
+  const title = noAssignment
+    ? t('titleNoAssignment')
+    : unknown
+      ? t('titleUnknown')
+      : t('title');
+  const body = noAssignment
+    ? t('bodyNoAssignment')
+    : unknown
+      ? t('bodyUnknown')
+      : t('body');
 
   return (
     <motion.div
@@ -150,10 +162,10 @@ function ReadinessCard({
     >
       <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.2em] text-[color:var(--accent)]">
         <Icon className="size-3.5" aria-hidden />
-        {noAssignment ? t('titleNoAssignment') : t('title')}
+        {title}
       </div>
       <p className="mt-2 text-[13px] leading-relaxed text-[color:var(--ink)]">
-        {noAssignment ? t('bodyNoAssignment') : t('body')}
+        {body}
       </p>
       <div className="mt-4 flex items-center gap-2">
         <Link

--- a/web-ui/app/_components/__tests__/RuntimeReadinessBanner.test.tsx
+++ b/web-ui/app/_components/__tests__/RuntimeReadinessBanner.test.tsx
@@ -129,9 +129,30 @@ describe('<RuntimeReadinessBanner />', () => {
     expect(screen.queryByText('Orchestrator nicht zugeordnet')).not.toBeInTheDocument();
   });
 
+  // `unknown` is derived as "access AND assignment are set" — e.g. an invalid
+  // key. Telling that operator no key is stored would be false.
+  it('does not claim a missing access when the 503 says cause=unknown', async () => {
+    respondWith(503, {
+      error: 'multi_orchestrator_unavailable',
+      cause: 'unknown',
+    });
+    renderWithIntl(<RuntimeReadinessBanner />, { locale: 'de' });
+    await flush();
+
+    expect(screen.getByText('Agent-Runtime antwortet nicht')).toBeInTheDocument();
+    expect(screen.queryByText(TITLE_DE)).not.toBeInTheDocument();
+    const card = screen.getByTestId('runtime-readiness-card');
+    expect(card.dataset['cause']).toBe('unknown');
+    expect(card.textContent).toMatch(/Zugang und Zuordnung sind gesetzt/);
+    expect(card.textContent).not.toMatch(/kein LLM-API-Key/);
+    expect(
+      screen.getByRole('link', { name: /LLM-Zugang öffnen/i }),
+    ).toHaveAttribute('href', '/admin/providers');
+  });
+
   // OM-72 (#1002) / OM-75 — the body must not promise "sofort verfügbar" nor
-  // point at a middleware restart the UI does not offer.
-  it('does not promise instant availability or a restart control', async () => {
+  // point at a middleware restart the UI does not offer. Both locales.
+  it('does not promise instant availability or a restart control (de)', async () => {
     respondWith(503, { error: 'multi_orchestrator_unavailable' });
     renderWithIntl(<RuntimeReadinessBanner />, { locale: 'de' });
     await flush();
@@ -139,6 +160,16 @@ describe('<RuntimeReadinessBanner />', () => {
     const card = screen.getByTestId('runtime-readiness-card');
     expect(card.textContent).not.toMatch(/sofort verfügbar/);
     expect(card.textContent).not.toMatch(/Neustart der Middleware/);
+  });
+
+  it('does not promise instant availability or a restart control (en)', async () => {
+    respondWith(503, { error: 'multi_orchestrator_unavailable' });
+    renderWithIntl(<RuntimeReadinessBanner />, { locale: 'en' });
+    await flush();
+
+    const card = screen.getByTestId('runtime-readiness-card');
+    expect(card.textContent).not.toMatch(/right away/);
+    expect(card.textContent).not.toMatch(/middleware restart/i);
   });
 
   it('clears itself once a heartbeat sees the runtime come up', async () => {

--- a/web-ui/app/_components/__tests__/RuntimeReadinessBanner.test.tsx
+++ b/web-ui/app/_components/__tests__/RuntimeReadinessBanner.test.tsx
@@ -96,6 +96,51 @@ describe('<RuntimeReadinessBanner />', () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
+  // OM-75 (#1000) — two causes, two texts. The tester had a working
+  // subscription login and was still told to "add a key or subscription".
+  it('names the missing assignment when the 503 says cause=no_assignment', async () => {
+    respondWith(503, {
+      error: 'multi_orchestrator_unavailable',
+      cause: 'no_assignment',
+    });
+    renderWithIntl(<RuntimeReadinessBanner />, { locale: 'de' });
+    await flush();
+
+    expect(screen.getByText('Orchestrator nicht zugeordnet')).toBeInTheDocument();
+    expect(screen.queryByText(TITLE_DE)).not.toBeInTheDocument();
+    expect(screen.getByText(/keinem Provider mit Zugang zugeordnet/)).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /Zuordnung öffnen/i }),
+    ).toHaveAttribute('href', '/admin/providers');
+    expect(screen.getByTestId('runtime-readiness-card').dataset['cause']).toBe(
+      'no_assignment',
+    );
+  });
+
+  it('keeps the access copy for cause=no_llm_access and for a 503 without a cause', async () => {
+    respondWith(503, {
+      error: 'multi_orchestrator_unavailable',
+      cause: 'no_llm_access',
+    });
+    renderWithIntl(<RuntimeReadinessBanner />, { locale: 'de' });
+    await flush();
+
+    expect(screen.getByText(TITLE_DE)).toBeInTheDocument();
+    expect(screen.queryByText('Orchestrator nicht zugeordnet')).not.toBeInTheDocument();
+  });
+
+  // OM-72 (#1002) / OM-75 — the body must not promise "sofort verfügbar" nor
+  // point at a middleware restart the UI does not offer.
+  it('does not promise instant availability or a restart control', async () => {
+    respondWith(503, { error: 'multi_orchestrator_unavailable' });
+    renderWithIntl(<RuntimeReadinessBanner />, { locale: 'de' });
+    await flush();
+
+    const card = screen.getByTestId('runtime-readiness-card');
+    expect(card.textContent).not.toMatch(/sofort verfügbar/);
+    expect(card.textContent).not.toMatch(/Neustart der Middleware/);
+  });
+
   it('clears itself once a heartbeat sees the runtime come up', async () => {
     respondWith(503, { error: 'multi_orchestrator_unavailable' });
     renderWithIntl(<RuntimeReadinessBanner />, { locale: 'de' });

--- a/web-ui/app/_components/dashboard/DashboardOnboarding.tsx
+++ b/web-ui/app/_components/dashboard/DashboardOnboarding.tsx
@@ -24,8 +24,11 @@ import {
 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 
+import type { ProviderCredentialStatus } from '../../_lib/api';
 import type { Plugin } from '../../_lib/storeTypes';
 import { isInstalled } from '../../_lib/pluginCounts';
+import { LlmStepBody, type AssignedProviderKind } from './LlmStep';
+import { StepShell } from './StepShell';
 import {
   BUSINESS_CASES,
   PLUGIN_CATEGORIES,
@@ -230,10 +233,16 @@ export interface DashboardOnboardingProps {
   runtimeUp: boolean;
   /**
    * OM-74 (#999) — what the orchestrator is actually assigned to, so the
-   * done-copy names the right thing. `'cli'` for a keyless subscription CLI
-   * provider, `'api'` for a key-based provider, `null` when unknown.
+   * done-copy names the right thing. `'cli'` for a keyless subscription CLI,
+   * `'oauth'` for an OAuth subscription, `'api'` for a key-based provider,
+   * `null` when unknown (providers call failed). See `LlmStep.tsx`.
    */
-  assignedProviderKind: 'cli' | 'api' | null;
+  assignedProviderKind: AssignedProviderKind;
+  /** The assigned provider's credential verdict. "Its key was verified" is
+   *  rendered only for `'verified'`. `null` when unknown. */
+  assignedProviderStatus: ProviderCredentialStatus | null;
+  /** The assigned provider's display label for the neutral fallback copy. */
+  assignedProviderLabel: string | null;
   /** OM-84 (#1003) — `embeddingClient@1` is NOT published: process memory,
    *  semantic search and dedup are off. Surfaced as a note under the steps
    *  because nothing in setup mentioned embeddings at all. */
@@ -255,6 +264,8 @@ export function DashboardOnboarding({
   cliLoggedIn,
   runtimeUp,
   assignedProviderKind,
+  assignedProviderStatus,
+  assignedProviderLabel,
   embeddingsOff,
   hasInstalledPlugin,
 }: DashboardOnboardingProps): React.ReactElement | null {
@@ -313,7 +324,7 @@ export function DashboardOnboarding({
   ];
   const llmDone = steps[0].done;
   // An access exists but the runtime is down: the missing piece is almost
-  // always the orchestrator's provider assignment (OM-79), so the step says
+  // always the orchestrator's provider assignment (#994), so the step says
   // that instead of offering to connect an access the operator already has.
   const accessWithoutRuntime = !llmDone && (llmVerified || cliLoggedIn);
   // #886 — step 3's RESULT copy. Counted here with the same OM-27 predicate the
@@ -372,58 +383,15 @@ export function DashboardOnboarding({
         icon={Cpu}
         title={t('llmStep.title')}
       >
-        {llmDone ? (
-          // OM-74 (#999) — the copy follows the orchestrator's ASSIGNMENT, not
-          // the mere presence of a CLI login. "Its key was verified" was shown
-          // to a subscription user who never stored a key.
-          <p className="mt-2 max-w-2xl text-[13px] leading-relaxed text-[color:var(--fg-muted)]">
-            {assignedProviderKind === 'cli'
-              ? t('llmStep.doneViaCli')
-              : t('llmStep.doneViaProvider')}
-          </p>
-        ) : accessWithoutRuntime ? (
-          <>
-            <p
-              data-testid="onboarding-step-1-assign-hint"
-              className="mt-2 max-w-2xl text-[13px] leading-relaxed text-[color:var(--fg-muted)]"
-            >
-              {t('llmStep.accessWithoutRuntime')}
-            </p>
-            <div className="mt-4 flex flex-wrap items-center gap-3">
-              <Link
-                href="/admin/providers"
-                className="inline-flex items-center gap-2 rounded-full bg-[color:var(--accent)] px-4 py-2 text-[12px] font-semibold uppercase tracking-[0.16em] text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)] transition-colors hover:bg-[color:var(--accent-hover)]"
-              >
-                {t('llmStep.assignOrchestrator')}
-                <ArrowRight className="size-3.5" aria-hidden />
-              </Link>
-            </div>
-          </>
-        ) : (
-          <>
-            <p className="mt-2 max-w-2xl text-[13px] leading-relaxed text-[color:var(--fg-muted)]">
-              {t('llmStep.description')}
-            </p>
-            {/* Step 1 offers both supported LLM access paths directly so the
-                CTA matches the promise in the copy above. */}
-            <div className="mt-4 flex flex-wrap items-center gap-3">
-              <Link
-                href="/admin/providers"
-                className="inline-flex items-center gap-2 rounded-full bg-[color:var(--accent)] px-4 py-2 text-[12px] font-semibold uppercase tracking-[0.16em] text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)] transition-colors hover:bg-[color:var(--accent-hover)]"
-              >
-                {t('llmStep.connectApiKey')}
-                <ArrowRight className="size-3.5" aria-hidden />
-              </Link>
-              <Link
-                href="/admin/providers?tab=subscriptions"
-                className="inline-flex items-center gap-2 rounded-full border border-[color:var(--accent)] px-4 py-2 text-[12px] font-semibold uppercase tracking-[0.16em] text-[color:var(--accent)] transition-colors hover:bg-[color:var(--accent-subtle)]"
-              >
-                {t('llmStep.connectSubscription')}
-                <ArrowRight className="size-3.5" aria-hidden />
-              </Link>
-            </div>
-          </>
-        )}
+        {/* Body lives in `LlmStep.tsx` (three states: done / access without
+            runtime / nothing yet) so this file stays under the size limit. */}
+        <LlmStepBody
+          done={llmDone}
+          accessWithoutRuntime={accessWithoutRuntime}
+          assignedProviderKind={assignedProviderKind}
+          assignedProviderStatus={assignedProviderStatus}
+          assignedProviderLabel={assignedProviderLabel}
+        />
       </StepShell>
 
       {/* Step 2 — business case. */}
@@ -503,72 +471,6 @@ export function DashboardOnboarding({
         </p>
       ) : null}
     </section>
-  );
-}
-
-/**
- * OM-01/12 — the shared frame for a step: number, "n of total", a checkmark
- * when done, and the step's own content.
- *
- * The old card had three bare `t('step', {n})` labels inside a ternary, so the
- * user saw a number with nothing to compare it to and no indication that
- * anything had been achieved. `n of total` and the checked state are the whole
- * point of this component.
- */
-function StepShell({
-  n,
-  total,
-  done,
-  icon: Icon,
-  title,
-  children,
-}: {
-  n: number;
-  total: number;
-  done: boolean;
-  icon: LucideIcon;
-  title: string;
-  children: React.ReactNode;
-}): React.ReactElement {
-  const t = useTranslations('dashboard.onboarding');
-  return (
-    <div
-      data-testid={`onboarding-step-${n}`}
-      data-done={done ? 'true' : 'false'}
-      className={`mt-6 rounded-lg border p-5 ${
-        done
-          ? 'border-[color:var(--border)] bg-[color:var(--card)]/40'
-          : 'border-[color:var(--accent)]/50 bg-[color:var(--accent-subtle)]'
-      }`}
-    >
-      <div className="flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.2em]">
-        {done ? (
-          <Check
-            className="size-3.5 text-[color:var(--success)]"
-            aria-hidden
-            data-testid={`onboarding-step-${n}-check`}
-          />
-        ) : (
-          <Icon className="size-3.5 text-[color:var(--accent)]" aria-hidden />
-        )}
-        <span
-          className={
-            done
-              ? 'text-[color:var(--fg-subtle)]'
-              : 'text-[color:var(--accent)]'
-          }
-        >
-          {t('stepOfTotal', { n, total })}
-        </span>
-        {done ? (
-          <span className="text-[color:var(--success)]">{t('applied')}</span>
-        ) : null}
-      </div>
-      <h3 className="font-display mt-1 text-lg font-medium text-[color:var(--fg-strong)]">
-        {title}
-      </h3>
-      {children}
-    </div>
   );
 }
 

--- a/web-ui/app/_components/dashboard/DashboardOnboarding.tsx
+++ b/web-ui/app/_components/dashboard/DashboardOnboarding.tsx
@@ -216,6 +216,28 @@ export interface DashboardOnboardingProps {
    * "Schritt 1: LLM verbinden". Counts as satisfying step 1.
    */
   cliLoggedIn: boolean;
+  /**
+   * OM-78 (#1001) — the agent runtime actually answers (`/operator/agents`
+   * came back instead of 503 `multi_orchestrator_unavailable`).
+   *
+   * This is what step 1 ticks on now. `llmVerified` / `cliLoggedIn` say that
+   * an ACCESS exists; they do not say the orchestrator can use it. In the
+   * round-4 beta test the dashboard read "LLM verbunden · 3 von 3 erledigt"
+   * while the readiness card two centimetres below said "LLM-Zugang fehlt",
+   * because the orchestrator was still assigned to a provider without a key.
+   * One page, two verdicts. The card and this step now read the same signal.
+   */
+  runtimeUp: boolean;
+  /**
+   * OM-74 (#999) — what the orchestrator is actually assigned to, so the
+   * done-copy names the right thing. `'cli'` for a keyless subscription CLI
+   * provider, `'api'` for a key-based provider, `null` when unknown.
+   */
+  assignedProviderKind: 'cli' | 'api' | null;
+  /** OM-84 (#1003) — `embeddingClient@1` is NOT published: process memory,
+   *  semantic search and dedup are off. Surfaced as a note under the steps
+   *  because nothing in setup mentioned embeddings at all. */
+  embeddingsOff: boolean;
   /** At least one plugin is installed — satisfies step 3. */
   hasInstalledPlugin: boolean;
 }
@@ -231,6 +253,9 @@ export function DashboardOnboarding({
   plugins,
   llmVerified,
   cliLoggedIn,
+  runtimeUp,
+  assignedProviderKind,
+  embeddingsOff,
   hasInstalledPlugin,
 }: DashboardOnboardingProps): React.ReactElement | null {
   const t = useTranslations('dashboard.onboarding');
@@ -276,12 +301,21 @@ export function DashboardOnboarding({
   // Step 1 is LLM access — the actual blocker the card never mentioned.
   // A fixed-length tuple, not a bare array: the three steps are a closed set,
   // and `noUncheckedIndexedAccess` would otherwise make every read optional.
+  //
+  // OM-78 (#1001) — step 1 ticks on the RUNTIME, not on a stored access. An
+  // access that the orchestrator is not assigned to used to tick this step
+  // while every operator route 503ed; the counter reached "3 von 3" for a
+  // system that could not run a single agent.
   const steps: readonly [OnboardingStep, OnboardingStep, OnboardingStep] = [
-    { id: 'llmAccess', done: llmVerified || cliLoggedIn },
+    { id: 'llmAccess', done: runtimeUp },
     { id: 'businessCase', done: selectedCase !== null },
     { id: 'install', done: hasInstalledPlugin },
   ];
   const llmDone = steps[0].done;
+  // An access exists but the runtime is down: the missing piece is almost
+  // always the orchestrator's provider assignment (OM-79), so the step says
+  // that instead of offering to connect an access the operator already has.
+  const accessWithoutRuntime = !llmDone && (llmVerified || cliLoggedIn);
   // #886 — step 3's RESULT copy. Counted here with the same OM-27 predicate the
   // dashboard health tile uses, over the same `plugins` array `page.tsx` derives
   // `hasInstalledPlugin` from — so the badge and the sentence underneath it read
@@ -339,11 +373,32 @@ export function DashboardOnboarding({
         title={t('llmStep.title')}
       >
         {llmDone ? (
+          // OM-74 (#999) — the copy follows the orchestrator's ASSIGNMENT, not
+          // the mere presence of a CLI login. "Its key was verified" was shown
+          // to a subscription user who never stored a key.
           <p className="mt-2 max-w-2xl text-[13px] leading-relaxed text-[color:var(--fg-muted)]">
-            {cliLoggedIn && !llmVerified
+            {assignedProviderKind === 'cli'
               ? t('llmStep.doneViaCli')
               : t('llmStep.doneViaProvider')}
           </p>
+        ) : accessWithoutRuntime ? (
+          <>
+            <p
+              data-testid="onboarding-step-1-assign-hint"
+              className="mt-2 max-w-2xl text-[13px] leading-relaxed text-[color:var(--fg-muted)]"
+            >
+              {t('llmStep.accessWithoutRuntime')}
+            </p>
+            <div className="mt-4 flex flex-wrap items-center gap-3">
+              <Link
+                href="/admin/providers"
+                className="inline-flex items-center gap-2 rounded-full bg-[color:var(--accent)] px-4 py-2 text-[12px] font-semibold uppercase tracking-[0.16em] text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)] transition-colors hover:bg-[color:var(--accent-hover)]"
+              >
+                {t('llmStep.assignOrchestrator')}
+                <ArrowRight className="size-3.5" aria-hidden />
+              </Link>
+            </div>
+          </>
         ) : (
           <>
             <p className="mt-2 max-w-2xl text-[13px] leading-relaxed text-[color:var(--fg-muted)]">
@@ -426,6 +481,27 @@ export function DashboardOnboarding({
           />
         )}
       </StepShell>
+
+      {/* OM-84 (#1003) — a default install runs with embeddings OFF: process
+          memory, semantic search and dedup are all disabled, and nothing in
+          setup says so. The tester found out when an agent failed mid-answer.
+          Not a fourth step (there is no keyless embedding path yet), but the
+          card must not read as "done" without naming the limitation. */}
+      {embeddingsOff ? (
+        <p
+          data-testid="onboarding-embeddings-note"
+          className="mt-6 max-w-2xl border-l-2 border-[color:var(--accent)] pl-4 text-[13px] leading-relaxed text-[color:var(--fg-muted)]"
+        >
+          {t('embeddingsNote')}{' '}
+          <Link
+            href="/admin/embedding-provider"
+            className="inline-flex items-center gap-1 font-semibold text-[color:var(--accent)] hover:underline"
+          >
+            {t('embeddingsCta')}
+            <ArrowRight className="size-3.5" aria-hidden />
+          </Link>
+        </p>
+      ) : null}
     </section>
   );
 }

--- a/web-ui/app/_components/dashboard/LlmStep.tsx
+++ b/web-ui/app/_components/dashboard/LlmStep.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+
+import type { ProviderCredentialStatus } from '../../_lib/api';
+
+/**
+ * Body of onboarding step 1 ("LLM verbinden"). The step frame (number,
+ * checkmark, title) stays in `DashboardOnboarding`'s `StepShell`; this file
+ * owns only what the operator reads INSIDE the step, in its three states:
+ *
+ *   1. runtime up          → a sentence that names what the orchestrator
+ *                            actually runs on (OM-74, #999)
+ *   2. access, no runtime  → the assignment is missing (OM-78 / #1001, the
+ *                            handoff gap of #994)
+ *   3. nothing yet         → the two connect CTAs
+ *
+ * Extracted so `DashboardOnboarding.tsx` stays under the file-size limit.
+ */
+
+/** What KIND of provider the orchestrator is assigned to. `null` = unknown
+ *  (the providers call failed or no assignment matched a provider row). */
+export type AssignedProviderKind = 'cli' | 'oauth' | 'api' | null;
+
+export interface LlmStepBodyProps {
+  /** Step 1 is done: `/operator/agents` answers (see `DashboardOnboarding`). */
+  readonly done: boolean;
+  /** A stored access exists (verified key or CLI login) but `done` is false. */
+  readonly accessWithoutRuntime: boolean;
+  readonly assignedProviderKind: AssignedProviderKind;
+  /** The assigned provider's credential verdict; `null` when unknown. */
+  readonly assignedProviderStatus: ProviderCredentialStatus | null;
+  /** The assigned provider's display label; `null` when unknown. */
+  readonly assignedProviderLabel: string | null;
+}
+
+const PRIMARY_CTA =
+  'inline-flex items-center gap-2 rounded-full bg-[color:var(--accent)] px-4 py-2 text-[12px] font-semibold uppercase tracking-[0.16em] text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)] transition-colors hover:bg-[color:var(--accent-hover)]';
+const SECONDARY_CTA =
+  'inline-flex items-center gap-2 rounded-full border border-[color:var(--accent)] px-4 py-2 text-[12px] font-semibold uppercase tracking-[0.16em] text-[color:var(--accent)] transition-colors hover:bg-[color:var(--accent-subtle)]';
+const BODY = 'mt-2 max-w-2xl text-[13px] leading-relaxed text-[color:var(--fg-muted)]';
+
+/**
+ * OM-74 (#999) — the done-copy follows the orchestrator's ASSIGNMENT and the
+ * verdict on that assignment's credential. "Its key was verified" was shown to
+ * a subscription user who never stored a key; it must also not be shown for
+ * an unverified or rejected key that the runtime happens to run on, nor when
+ * the provider list is unavailable (kind `null`).
+ */
+function doneCopy(
+  t: ReturnType<typeof useTranslations<'dashboard.onboarding.llmStep'>>,
+  kind: AssignedProviderKind,
+  status: ProviderCredentialStatus | null,
+  label: string | null,
+): string {
+  if (kind === 'cli') return t('doneViaCli');
+  if (kind === 'oauth') return t('doneViaOauth');
+  if (kind === 'api' && status === 'verified') return t('doneViaProvider');
+  return label === null
+    ? t('doneViaRuntimeNoLabel')
+    : t('doneViaRuntime', { label });
+}
+
+export function LlmStepBody({
+  done,
+  accessWithoutRuntime,
+  assignedProviderKind,
+  assignedProviderStatus,
+  assignedProviderLabel,
+}: LlmStepBodyProps): React.ReactElement {
+  const t = useTranslations('dashboard.onboarding.llmStep');
+
+  if (done) {
+    return (
+      <p data-testid="onboarding-step-1-done-copy" className={BODY}>
+        {doneCopy(t, assignedProviderKind, assignedProviderStatus, assignedProviderLabel)}
+      </p>
+    );
+  }
+
+  if (accessWithoutRuntime) {
+    // An access exists but the runtime is down: the missing piece is almost
+    // always the orchestrator's provider assignment (#994), so the step says
+    // that instead of offering to connect an access the operator already has.
+    return (
+      <>
+        <p data-testid="onboarding-step-1-assign-hint" className={BODY}>
+          {t('accessWithoutRuntime')}
+        </p>
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <Link href="/admin/providers" className={PRIMARY_CTA}>
+            {t('assignOrchestrator')}
+            <ArrowRight className="size-3.5" aria-hidden />
+          </Link>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <p className={BODY}>{t('description')}</p>
+      {/* Step 1 offers both supported LLM access paths directly so the CTA
+          matches the promise in the copy above. */}
+      <div className="mt-4 flex flex-wrap items-center gap-3">
+        <Link href="/admin/providers" className={PRIMARY_CTA}>
+          {t('connectApiKey')}
+          <ArrowRight className="size-3.5" aria-hidden />
+        </Link>
+        <Link href="/admin/providers?tab=subscriptions" className={SECONDARY_CTA}>
+          {t('connectSubscription')}
+          <ArrowRight className="size-3.5" aria-hidden />
+        </Link>
+      </div>
+    </>
+  );
+}

--- a/web-ui/app/_components/dashboard/StepShell.tsx
+++ b/web-ui/app/_components/dashboard/StepShell.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { Check, type LucideIcon } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+
+/**
+ * OM-01/12 — the shared frame for an onboarding step: number, "n of total", a
+ * checkmark when done, and the step's own content.
+ *
+ * The old card had three bare `t('step', {n})` labels inside a ternary, so the
+ * user saw a number with nothing to compare it to and no indication that
+ * anything had been achieved. `n of total` and the checked state are the whole
+ * point of this component.
+ *
+ * Lives in its own file so `DashboardOnboarding.tsx` stays under the size
+ * limit; the step BODIES (e.g. `LlmStep.tsx`) are siblings.
+ */
+export interface StepShellProps {
+  readonly n: number;
+  readonly total: number;
+  readonly done: boolean;
+  readonly icon: LucideIcon;
+  readonly title: string;
+  readonly children: React.ReactNode;
+}
+
+export function StepShell({
+  n,
+  total,
+  done,
+  icon: Icon,
+  title,
+  children,
+}: StepShellProps): React.ReactElement {
+  const t = useTranslations('dashboard.onboarding');
+  return (
+    <div
+      data-testid={`onboarding-step-${n}`}
+      data-done={done ? 'true' : 'false'}
+      className={`mt-6 rounded-lg border p-5 ${
+        done
+          ? 'border-[color:var(--border)] bg-[color:var(--card)]/40'
+          : 'border-[color:var(--accent)]/50 bg-[color:var(--accent-subtle)]'
+      }`}
+    >
+      <div className="flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.2em]">
+        {done ? (
+          <Check
+            className="size-3.5 text-[color:var(--success)]"
+            aria-hidden
+            data-testid={`onboarding-step-${n}-check`}
+          />
+        ) : (
+          <Icon className="size-3.5 text-[color:var(--accent)]" aria-hidden />
+        )}
+        <span
+          className={
+            done
+              ? 'text-[color:var(--fg-subtle)]'
+              : 'text-[color:var(--accent)]'
+          }
+        >
+          {t('stepOfTotal', { n, total })}
+        </span>
+        {done ? (
+          <span className="text-[color:var(--success)]">{t('applied')}</span>
+        ) : null}
+      </div>
+      <h3 className="font-display mt-1 text-lg font-medium text-[color:var(--fg-strong)]">
+        {title}
+      </h3>
+      {children}
+    </div>
+  );
+}

--- a/web-ui/app/_components/dashboard/__tests__/DashboardOnboarding.test.tsx
+++ b/web-ui/app/_components/dashboard/__tests__/DashboardOnboarding.test.tsx
@@ -54,16 +54,27 @@ function renderCard(
     plugins: Plugin[] | null;
     llmVerified: boolean;
     cliLoggedIn: boolean;
+    runtimeUp: boolean;
+    assignedProviderKind: 'cli' | 'api' | null;
+    embeddingsOff: boolean;
     hasInstalledPlugin: boolean;
   }> = {},
 ) {
+  // OM-78 (#1001) — a stored access implies the runtime is up in the default
+  // fixture, so the pre-existing step-model tests keep describing the happy
+  // path. The OM-78 tests below set `runtimeUp` explicitly.
+  const runtimeUp =
+    over.runtimeUp ?? Boolean(over.llmVerified || over.cliLoggedIn);
   return renderWithIntl(
     <DashboardOnboarding
       plugins={[]}
       llmVerified={false}
       cliLoggedIn={false}
+      assignedProviderKind={over.cliLoggedIn ? 'cli' : 'api'}
+      embeddingsOff={false}
       hasInstalledPlugin={false}
       {...over}
+      runtimeUp={runtimeUp}
     />,
     { locale: 'de' },
   );
@@ -134,6 +145,94 @@ describe('<DashboardOnboarding /> — OM-01/12 step model', () => {
   it('shows overall progress', () => {
     renderCard({ llmVerified: true, hasInstalledPlugin: true });
     expect(screen.getByText(/2 von 3 erledigt/)).toBeTruthy();
+  });
+});
+
+/**
+ * Round 4 (OM-74 / OM-78 / OM-84) — the card said "LLM verbunden · 3 von 3
+ * erledigt" while the readiness banner on the same page said "LLM-Zugang
+ * fehlt". Step 1 now ticks on the runtime, the done-copy follows the
+ * orchestrator's assignment, and a missing embedding provider is named.
+ */
+describe('<DashboardOnboarding /> — round-4 readiness truth', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    __resetOnboardingStores();
+  });
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('OM-78: step 1 stays OPEN while the runtime is down, even with a verified key', () => {
+    renderCard({ llmVerified: true, runtimeUp: false });
+
+    const step1 = screen.getByTestId('onboarding-step-1');
+    expect(step1.dataset['done']).toBe('false');
+    expect(screen.queryByTestId('onboarding-step-1-check')).toBeNull();
+    // The counter cannot claim progress the runtime does not have.
+    expect(screen.getByText(/0 von 3 erledigt/)).toBeTruthy();
+  });
+
+  it('OM-78/OM-79: a stored access without a runtime points at the assignment, not at connecting again', () => {
+    renderCard({ cliLoggedIn: true, runtimeUp: false });
+
+    expect(screen.getByTestId('onboarding-step-1-assign-hint')).toBeTruthy();
+    expect(screen.getByText(/Zuordnung des Orchestrators/)).toBeTruthy();
+    const step1 = screen.getByTestId('onboarding-step-1');
+    const links = Array.from(step1.querySelectorAll('a'));
+    expect(links).toHaveLength(1);
+    expect(links[0]?.getAttribute('href')).toBe('/admin/providers');
+    expect(screen.getByText(/Orchestrator zuordnen/)).toBeTruthy();
+    // The "connect an access" CTAs are gone: the operator already has one.
+    expect(screen.queryByText(/API-Schlüssel hinterlegen/)).toBeNull();
+  });
+
+  it('OM-78: the counter never reaches 3 von 3 while the runtime is down', () => {
+    renderCard({
+      llmVerified: true,
+      cliLoggedIn: true,
+      hasInstalledPlugin: true,
+      runtimeUp: false,
+    });
+    expect(screen.queryByText(/3 von 3 erledigt/)).toBeNull();
+    expect(screen.getByText(/1 von 3 erledigt/)).toBeTruthy();
+  });
+
+  it('OM-74: the done-copy follows the ASSIGNMENT — a CLI-backed orchestrator is not "its key was verified"', () => {
+    renderCard({
+      cliLoggedIn: true,
+      llmVerified: true,
+      runtimeUp: true,
+      assignedProviderKind: 'cli',
+    });
+    expect(screen.getByText(/Abo-CLI angemeldet/)).toBeTruthy();
+    expect(screen.queryByText(/Schlüssel wurde geprüft/)).toBeNull();
+  });
+
+  it('OM-74: an API-key assignment keeps the key copy even when a CLI is also logged in', () => {
+    renderCard({
+      cliLoggedIn: true,
+      llmVerified: true,
+      runtimeUp: true,
+      assignedProviderKind: 'api',
+    });
+    expect(screen.getByText(/Schlüssel wurde geprüft/)).toBeTruthy();
+    expect(screen.queryByText(/Abo-CLI angemeldet/)).toBeNull();
+  });
+
+  it('OM-84: names the missing embedding provider and links to its setting', () => {
+    renderCard({ llmVerified: true, embeddingsOff: true });
+
+    const note = screen.getByTestId('onboarding-embeddings-note');
+    expect(note.textContent).toMatch(/Gedächtnis eingeschränkt/);
+    expect(note.querySelector('a')?.getAttribute('href')).toBe(
+      '/admin/embedding-provider',
+    );
+  });
+
+  it('OM-84: stays silent about embeddings when a provider is published', () => {
+    renderCard({ llmVerified: true, embeddingsOff: false });
+    expect(screen.queryByTestId('onboarding-embeddings-note')).toBeNull();
   });
 
   it('the selected business case survives a remount', () => {

--- a/web-ui/app/_components/dashboard/__tests__/DashboardOnboarding.test.tsx
+++ b/web-ui/app/_components/dashboard/__tests__/DashboardOnboarding.test.tsx
@@ -55,14 +55,18 @@ function renderCard(
     llmVerified: boolean;
     cliLoggedIn: boolean;
     runtimeUp: boolean;
-    assignedProviderKind: 'cli' | 'api' | null;
+    assignedProviderKind: 'cli' | 'oauth' | 'api' | null;
+    assignedProviderStatus: 'no_key' | 'unverified' | 'verified' | 'invalid' | null;
+    assignedProviderLabel: string | null;
     embeddingsOff: boolean;
     hasInstalledPlugin: boolean;
   }> = {},
 ) {
   // OM-78 (#1001) — a stored access implies the runtime is up in the default
   // fixture, so the pre-existing step-model tests keep describing the happy
-  // path. The OM-78 tests below set `runtimeUp` explicitly.
+  // path. The OM-78 tests below set `runtimeUp` explicitly. Likewise the
+  // default assignment mirrors the access flags: CLI login → CLI assignment,
+  // verified key → verified API assignment.
   const runtimeUp =
     over.runtimeUp ?? Boolean(over.llmVerified || over.cliLoggedIn);
   return renderWithIntl(
@@ -71,6 +75,8 @@ function renderCard(
       llmVerified={false}
       cliLoggedIn={false}
       assignedProviderKind={over.cliLoggedIn ? 'cli' : 'api'}
+      assignedProviderStatus={over.llmVerified ? 'verified' : 'no_key'}
+      assignedProviderLabel="Anthropic"
       embeddingsOff={false}
       hasInstalledPlugin={false}
       {...over}
@@ -173,7 +179,7 @@ describe('<DashboardOnboarding /> — round-4 readiness truth', () => {
     expect(screen.getByText(/0 von 3 erledigt/)).toBeTruthy();
   });
 
-  it('OM-78/OM-79: a stored access without a runtime points at the assignment, not at connecting again', () => {
+  it('OM-78 / #994: a stored access without a runtime points at the assignment, not at connecting again', () => {
     renderCard({ cliLoggedIn: true, runtimeUp: false });
 
     expect(screen.getByTestId('onboarding-step-1-assign-hint')).toBeTruthy();
@@ -209,15 +215,65 @@ describe('<DashboardOnboarding /> — round-4 readiness truth', () => {
     expect(screen.queryByText(/Schlüssel wurde geprüft/)).toBeNull();
   });
 
-  it('OM-74: an API-key assignment keeps the key copy even when a CLI is also logged in', () => {
+  it('OM-74: a VERIFIED API-key assignment keeps the key copy even when a CLI is also logged in', () => {
     renderCard({
       cliLoggedIn: true,
       llmVerified: true,
       runtimeUp: true,
       assignedProviderKind: 'api',
+      assignedProviderStatus: 'verified',
     });
     expect(screen.getByText(/Schlüssel wurde geprüft/)).toBeTruthy();
     expect(screen.queryByText(/Abo-CLI angemeldet/)).toBeNull();
+  });
+
+  it('OM-74: an UNVERIFIED key that the runtime happens to run on is not called "geprüft"', () => {
+    renderCard({
+      runtimeUp: true,
+      assignedProviderKind: 'api',
+      assignedProviderStatus: 'unverified',
+      assignedProviderLabel: 'Anthropic',
+    });
+    const copy = screen.getByTestId('onboarding-step-1-done-copy');
+    expect(copy.textContent).toMatch(/Agent-Runtime läuft über Anthropic/);
+    expect(copy.textContent).not.toMatch(/geprüft/);
+  });
+
+  it('OM-74: a rejected (invalid) key is not called "geprüft" either', () => {
+    renderCard({
+      runtimeUp: true,
+      assignedProviderKind: 'api',
+      assignedProviderStatus: 'invalid',
+      assignedProviderLabel: 'OpenAI',
+    });
+    const copy = screen.getByTestId('onboarding-step-1-done-copy');
+    expect(copy.textContent).toMatch(/läuft über OpenAI/);
+    expect(copy.textContent).not.toMatch(/geprüft/);
+  });
+
+  it('OM-74: an OAuth subscription assignment gets its own neutral sentence', () => {
+    renderCard({
+      runtimeUp: true,
+      assignedProviderKind: 'oauth',
+      assignedProviderStatus: 'verified',
+      assignedProviderLabel: 'ChatGPT',
+    });
+    const copy = screen.getByTestId('onboarding-step-1-done-copy');
+    expect(copy.textContent).toMatch(/Abo ist verbunden/);
+    expect(copy.textContent).not.toMatch(/geprüft/);
+    expect(copy.textContent).not.toMatch(/Abo-CLI/);
+  });
+
+  it('OM-74: an unknown assignment (providers call failed) falls back to the label-less sentence', () => {
+    renderCard({
+      runtimeUp: true,
+      assignedProviderKind: null,
+      assignedProviderStatus: null,
+      assignedProviderLabel: null,
+    });
+    const copy = screen.getByTestId('onboarding-step-1-done-copy');
+    expect(copy.textContent).toMatch(/Die Agent-Runtime läuft\./);
+    expect(copy.textContent).not.toMatch(/geprüft/);
   });
 
   it('OM-84: names the missing embedding provider and links to its setting', () => {

--- a/web-ui/app/_lib/api.ts
+++ b/web-ui/app/_lib/api.ts
@@ -4295,6 +4295,23 @@ export async function getEmbeddingProvider(): Promise<EmbeddingProviderState> {
 }
 
 /**
+ * OM-84 (#1003) — the cheap readiness summary behind the dashboard's
+ * "memory / embeddings" health card. Unlike `getEmbeddingProvider` it does not
+ * count the stored corpus, so it is safe to call on every dashboard load.
+ */
+export interface EmbeddingProviderStatus {
+  /** `embeddingClient@1` is published — memory, semantic search and dedup work. */
+  capabilityPublished: boolean;
+  activeProviderId: string | null;
+  activeModel: { modelId: string; dimensions: number } | null;
+  installedProviderIds: string[];
+}
+
+export async function getEmbeddingProviderStatus(): Promise<EmbeddingProviderStatus> {
+  return getJson<EmbeddingProviderStatus>('/v1/admin/embedding-provider/status');
+}
+
+/**
  * Switch the active embedding provider, live.
  *
  * DESTRUCTIVE: the stored vectors are discarded and re-embedded, one paid

--- a/web-ui/app/page.tsx
+++ b/web-ui/app/page.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react';
 
 import {
+  ApiError,
   getCliBackends,
   getEmbeddingProviderStatus,
   getProviders,
@@ -75,9 +76,12 @@ export default async function DashboardPage(): Promise<React.ReactElement> {
       ? cliP.value.backends.some((b) => b.loggedIn === 'yes')
       : false;
   // OM-78 (#1001) — the ONE readiness signal this page and the
-  // RuntimeReadinessBanner share: `/operator/agents` answered instead of
-  // 503ing. Everything that claims "LLM connected" reads this.
-  const runtimeUp = agents !== null;
+  // RuntimeReadinessBanner share: `/operator/agents` answered, or failed with
+  // anything OTHER than its structured 503. Only the 503 means "runtime down";
+  // a transient 500 or a network blip must not un-tick step 1.
+  const runtimeUp =
+    agentP.status === 'fulfilled' ||
+    !(agentP.reason instanceof ApiError && agentP.reason.status === 503);
 
   // Middleware is "connected" if any call came back at all — a transport
   // failure rejects every call with the same network error.
@@ -103,18 +107,24 @@ export default async function DashboardPage(): Promise<React.ReactElement> {
     )?.label ??
     verified[0]?.label ??
     null;
-  // OM-74 (#999) — what KIND of provider the orchestrator is assigned to. A
-  // keyless subscription CLI (`toolLess`, or the built-in `claude-cli` id)
-  // must not be described as "its key was verified".
+  // OM-74 (#999) — what KIND of provider the orchestrator is assigned to, and
+  // whether its credential was actually proved. A keyless subscription CLI
+  // (`toolLess`, or the built-in `claude-cli` id) and an OAuth subscription
+  // (`oauthConnect`) have no key to describe as "verified"; a key-based
+  // provider earns that sentence only with `status === 'verified'`.
   const assignedProvider = providers?.providers.find(
     (p) => p.id === activeAssignment?.provider,
   );
-  const assignedProviderKind: 'cli' | 'api' | null =
+  const assignedProviderKind: 'cli' | 'oauth' | 'api' | null =
     assignedProvider === undefined
       ? null
       : assignedProvider.toolLess === true || assignedProvider.id === 'claude-cli'
         ? 'cli'
-        : 'api';
+        : assignedProvider.oauthConnect === true
+          ? 'oauth'
+          : 'api';
+  const assignedProviderStatus = assignedProvider?.status ?? null;
+  const assignedProviderLabel = assignedProvider?.label ?? null;
   // OM-84 (#1003) — only claim "off" when the status route actually said so.
   const embeddingsOff = embeddings !== null && !embeddings.capabilityPublished;
   // A rejected key is the most actionable signal, so it wins the detail line.
@@ -301,6 +311,8 @@ export default async function DashboardPage(): Promise<React.ReactElement> {
           cliLoggedIn={cliLoggedIn}
           runtimeUp={runtimeUp}
           assignedProviderKind={assignedProviderKind}
+          assignedProviderStatus={assignedProviderStatus}
+          assignedProviderLabel={assignedProviderLabel}
           embeddingsOff={embeddingsOff}
           hasInstalledPlugin={installedCount > 0}
         />

--- a/web-ui/app/page.tsx
+++ b/web-ui/app/page.tsx
@@ -11,7 +11,12 @@ import {
   Store,
 } from 'lucide-react';
 
-import { getCliBackends, getProviders, listStorePlugins } from './_lib/api';
+import {
+  getCliBackends,
+  getEmbeddingProviderStatus,
+  getProviders,
+  listStorePlugins,
+} from './_lib/api';
 import { getMcpServerSummary, listOperatorAgents } from './_lib/agents';
 import { redirectIfUnauthorized } from './_lib/authRedirect';
 import { cn } from './_lib/cn';
@@ -41,7 +46,7 @@ type Tone = 'ok' | 'warn' | 'down' | 'neutral';
 export default async function DashboardPage(): Promise<React.ReactElement> {
   const t = await getTranslations('dashboard');
 
-  const [provP, plugP, agentP, mcpP, cliP] = await Promise.allSettled([
+  const [provP, plugP, agentP, mcpP, cliP, embP] = await Promise.allSettled([
     getProviders(),
     listStorePlugins(),
     listOperatorAgents(),
@@ -50,10 +55,13 @@ export default async function DashboardPage(): Promise<React.ReactElement> {
     // besides a probed provider key, and onboarding ignored it entirely: a user
     // logged into the Claude CLI was still told "Schritt 1: LLM verbinden".
     getCliBackends(),
+    // OM-84 (#1003) — is `embeddingClient@1` published? The cheap status
+    // route, not the corpus-counting page snapshot.
+    getEmbeddingProviderStatus(),
   ]);
 
   // 401 anywhere → re-login (redirect throws and escapes before render).
-  for (const r of [provP, plugP, agentP, mcpP, cliP]) {
+  for (const r of [provP, plugP, agentP, mcpP, cliP, embP]) {
     if (r.status === 'rejected') await redirectIfUnauthorized(r.reason);
   }
 
@@ -61,10 +69,15 @@ export default async function DashboardPage(): Promise<React.ReactElement> {
   const plugins = plugP.status === 'fulfilled' ? plugP.value : null;
   const agents = agentP.status === 'fulfilled' ? agentP.value : null;
   const mcp = mcpP.status === 'fulfilled' ? mcpP.value : null;
+  const embeddings = embP.status === 'fulfilled' ? embP.value : null;
   const cliLoggedIn =
     cliP.status === 'fulfilled'
       ? cliP.value.backends.some((b) => b.loggedIn === 'yes')
       : false;
+  // OM-78 (#1001) — the ONE readiness signal this page and the
+  // RuntimeReadinessBanner share: `/operator/agents` answered instead of
+  // 503ing. Everything that claims "LLM connected" reads this.
+  const runtimeUp = agents !== null;
 
   // Middleware is "connected" if any call came back at all — a transport
   // failure rejects every call with the same network error.
@@ -90,6 +103,20 @@ export default async function DashboardPage(): Promise<React.ReactElement> {
     )?.label ??
     verified[0]?.label ??
     null;
+  // OM-74 (#999) — what KIND of provider the orchestrator is assigned to. A
+  // keyless subscription CLI (`toolLess`, or the built-in `claude-cli` id)
+  // must not be described as "its key was verified".
+  const assignedProvider = providers?.providers.find(
+    (p) => p.id === activeAssignment?.provider,
+  );
+  const assignedProviderKind: 'cli' | 'api' | null =
+    assignedProvider === undefined
+      ? null
+      : assignedProvider.toolLess === true || assignedProvider.id === 'claude-cli'
+        ? 'cli'
+        : 'api';
+  // OM-84 (#1003) — only claim "off" when the status route actually said so.
+  const embeddingsOff = embeddings !== null && !embeddings.capabilityPublished;
   // A rejected key is the most actionable signal, so it wins the detail line.
   const llmDetail = ((): string => {
     if (rejected.length > 0) return t('health.llm.invalid');
@@ -148,6 +175,36 @@ export default async function DashboardPage(): Promise<React.ReactElement> {
           ? t('health.orchestrators.available', { count: orchestratorCount })
           : t('health.orchestrators.none'),
       href: '/operator/agents',
+      manage: t('health.manage'),
+    },
+    {
+      // OM-84 (#1003) — memory, semantic search and dedup all hang off
+      // `embeddingClient@1`. A default install has none, and until now no
+      // surface said so: the tester learned it from an agent failing mid-answer.
+      title: t('health.embeddings.title'),
+      tone: !middlewareOk
+        ? 'down'
+        : embeddings === null
+          ? 'neutral'
+          : embeddings.capabilityPublished
+            ? 'ok'
+            : 'warn',
+      status:
+        embeddings !== null && embeddings.capabilityPublished
+          ? t('health.ok')
+          : t('health.warn'),
+      detail:
+        embeddings === null
+          ? t('health.embeddings.unknown')
+          : embeddings.capabilityPublished
+            ? t('health.embeddings.active', {
+                model:
+                  embeddings.activeModel?.modelId ??
+                  embeddings.activeProviderId ??
+                  '',
+              })
+            : t('health.embeddings.none'),
+      href: '/admin/embedding-provider',
       manage: t('health.manage'),
     },
     {
@@ -242,6 +299,9 @@ export default async function DashboardPage(): Promise<React.ReactElement> {
           plugins={plugins?.items ?? null}
           llmVerified={verified.length > 0}
           cliLoggedIn={cliLoggedIn}
+          runtimeUp={runtimeUp}
+          assignedProviderKind={assignedProviderKind}
+          embeddingsOff={embeddingsOff}
           hasInstalledPlugin={installedCount > 0}
         />
 

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -120,6 +120,9 @@
         "description": "Ohne verbundenes LLM kann kein Orchestrator laufen. Verbinde zuerst einen API-Provider oder ein Abo-CLI.",
         "doneViaProvider": "Ein LLM-Anbieter ist verbunden und sein Schlüssel wurde geprüft.",
         "doneViaCli": "Du bist in einer Abo-CLI angemeldet und der Orchestrator läuft darüber.",
+        "doneViaOauth": "Ein Abo ist verbunden und die Agent-Runtime läuft darüber.",
+        "doneViaRuntime": "Die Agent-Runtime läuft über {label}.",
+        "doneViaRuntimeNoLabel": "Die Agent-Runtime läuft.",
         "accessWithoutRuntime": "Ein LLM-Zugang ist hinterlegt, aber die Agent-Runtime läuft noch nicht. Meist fehlt nur die Zuordnung des Orchestrators zu diesem Zugang.",
         "assignOrchestrator": "Orchestrator zuordnen"
       },
@@ -1333,7 +1336,9 @@
     "title": "LLM-Zugang fehlt",
     "body": "Die Agent-Runtime ist offline: Es ist noch kein LLM-API-Key und kein Abo hinterlegt. Hinterlege einen API-Key oder verbinde ein bestehendes Claude/Codex-Abo im LLM-Zugang und ordne den Orchestrator diesem Zugang zu. Diese Karte verschwindet, sobald die Runtime läuft.",
     "titleNoAssignment": "Orchestrator nicht zugeordnet",
-    "bodyNoAssignment": "Ein LLM-Zugang ist vorhanden, aber der Orchestrator ist noch keinem Provider mit Zugang zugeordnet. Wähle im LLM-Zugang unter Zuordnung den verbundenen Provider für den Orchestrator (bei einem Abo: Claude, subscription CLI). Die Runtime startet danach ohne Neustart.",
+    "bodyNoAssignment": "Ein LLM-Zugang ist vorhanden, aber der Orchestrator ist noch keinem Provider mit Zugang zugeordnet. Wähle im LLM-Zugang unter Zuordnung den verbundenen Provider für den Orchestrator, bei einem Abo „Claude (subscription CLI)“. Die Runtime startet danach ohne Neustart.",
+    "titleUnknown": "Agent-Runtime antwortet nicht",
+    "bodyUnknown": "Zugang und Zuordnung sind gesetzt, die Agent-Runtime antwortet trotzdem nicht. Prüfe den hinterlegten Zugang unter LLM-Zugang.",
     "cta": "LLM-Zugang öffnen",
     "ctaNoAssignment": "Zuordnung öffnen",
     "dismiss": "Später"

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -28,6 +28,12 @@
         "available": "{count, plural, one {# Orchestrator verfügbar} other {# Orchestratoren verfügbar}}",
         "none": "Kein Orchestrator konfiguriert"
       },
+      "embeddings": {
+        "title": "Gedächtnis / Embeddings",
+        "active": "Aktiv: {model}",
+        "none": "Kein Embedding-Anbieter konfiguriert. Prozessgedächtnis, semantische Suche und Dublettenerkennung sind aus.",
+        "unknown": "Status nicht abrufbar"
+      },
       "plugins": {
         "title": "Plugins",
         "installed": "{count, plural, one {# Plugin installiert} other {# Plugins installiert}}",
@@ -113,8 +119,12 @@
         "title": "LLM verbinden",
         "description": "Ohne verbundenes LLM kann kein Orchestrator laufen. Verbinde zuerst einen API-Provider oder ein Abo-CLI.",
         "doneViaProvider": "Ein LLM-Anbieter ist verbunden und sein Schlüssel wurde geprüft.",
-        "doneViaCli": "Du bist in einer Abo-CLI angemeldet — das reicht, um Orchestratoren zu betreiben."
+        "doneViaCli": "Du bist in einer Abo-CLI angemeldet und der Orchestrator läuft darüber.",
+        "accessWithoutRuntime": "Ein LLM-Zugang ist hinterlegt, aber die Agent-Runtime läuft noch nicht. Meist fehlt nur die Zuordnung des Orchestrators zu diesem Zugang.",
+        "assignOrchestrator": "Orchestrator zuordnen"
       },
+      "embeddingsNote": "Gedächtnis eingeschränkt: Es ist kein Embedding-Anbieter konfiguriert. Prozessgedächtnis, semantische Suche und Dublettenerkennung bleiben aus, bis einer eingerichtet ist.",
+      "embeddingsCta": "Embedding-Anbieter einrichten",
       "heading": "Erste Schritte",
       "kicker": "Einrichtung",
       "applied": "Installiert",
@@ -1321,8 +1331,11 @@
   },
   "runtimeReadiness": {
     "title": "LLM-Zugang fehlt",
-    "body": "Die Agent-Runtime ist offline — meistens, weil noch kein LLM-API-Key oder Abo hinterlegt ist. Hinterlege einen API-Key oder verbinde ein bestehendes Claude/Codex-Abo im LLM-Zugang; Chat, Agenten, Channels und Skills sind danach sofort verfügbar. Routinen brauchen zusätzlich einen Neustart der Middleware.",
+    "body": "Die Agent-Runtime ist offline: Es ist noch kein LLM-API-Key und kein Abo hinterlegt. Hinterlege einen API-Key oder verbinde ein bestehendes Claude/Codex-Abo im LLM-Zugang und ordne den Orchestrator diesem Zugang zu. Diese Karte verschwindet, sobald die Runtime läuft.",
+    "titleNoAssignment": "Orchestrator nicht zugeordnet",
+    "bodyNoAssignment": "Ein LLM-Zugang ist vorhanden, aber der Orchestrator ist noch keinem Provider mit Zugang zugeordnet. Wähle im LLM-Zugang unter Zuordnung den verbundenen Provider für den Orchestrator (bei einem Abo: Claude, subscription CLI). Die Runtime startet danach ohne Neustart.",
     "cta": "LLM-Zugang öffnen",
+    "ctaNoAssignment": "Zuordnung öffnen",
     "dismiss": "Später"
   },
   "agentDetailsModal": {

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -120,6 +120,9 @@
         "description": "Without a connected LLM no orchestrator can run. Connect an API provider or a subscription CLI first.",
         "doneViaProvider": "An LLM provider is connected and its key has been verified.",
         "doneViaCli": "You are logged into a subscription CLI and the orchestrator runs on it.",
+        "doneViaOauth": "A subscription is connected and the agent runtime runs on it.",
+        "doneViaRuntime": "The agent runtime runs on {label}.",
+        "doneViaRuntimeNoLabel": "The agent runtime is running.",
         "accessWithoutRuntime": "An LLM access is stored, but the agent runtime is not up yet. Usually the orchestrator just has not been assigned to that access.",
         "assignOrchestrator": "Assign the orchestrator"
       },
@@ -1333,7 +1336,9 @@
     "title": "LLM access missing",
     "body": "The agent runtime is offline: no LLM API key or subscription is connected yet. Add an API key or connect an existing Claude/Codex subscription in the LLM access settings, then assign the orchestrator to that access. This card disappears once the runtime is up.",
     "titleNoAssignment": "Orchestrator not assigned",
-    "bodyNoAssignment": "An LLM access exists, but the orchestrator is not assigned to a provider that has access yet. In LLM access, under Assignment, pick the connected provider for the orchestrator (for a subscription: Claude, subscription CLI). The runtime starts afterwards without a restart.",
+    "bodyNoAssignment": "An LLM access exists, but the orchestrator is not assigned to a provider that has access yet. In LLM access, under Assignment, pick the connected provider for the orchestrator, for a subscription \"Claude (subscription CLI)\". The runtime starts afterwards without a restart.",
+    "titleUnknown": "Agent runtime not responding",
+    "bodyUnknown": "Access and assignment are set, but the agent runtime still does not respond. Check the stored access under LLM access.",
     "cta": "Open LLM access",
     "ctaNoAssignment": "Open assignment",
     "dismiss": "Later"

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -28,6 +28,12 @@
         "available": "{count, plural, one {# orchestrator available} other {# orchestrators available}}",
         "none": "No orchestrator configured"
       },
+      "embeddings": {
+        "title": "Memory / embeddings",
+        "active": "Active: {model}",
+        "none": "No embedding provider configured. Process memory, semantic search and duplicate detection are off.",
+        "unknown": "Status unavailable"
+      },
       "plugins": {
         "title": "Plugins",
         "installed": "{count, plural, one {# plugin installed} other {# plugins installed}}",
@@ -113,8 +119,12 @@
         "title": "Connect an LLM",
         "description": "Without a connected LLM no orchestrator can run. Connect an API provider or a subscription CLI first.",
         "doneViaProvider": "An LLM provider is connected and its key has been verified.",
-        "doneViaCli": "You are logged into a subscription CLI — that is enough to run orchestrators."
+        "doneViaCli": "You are logged into a subscription CLI and the orchestrator runs on it.",
+        "accessWithoutRuntime": "An LLM access is stored, but the agent runtime is not up yet. Usually the orchestrator just has not been assigned to that access.",
+        "assignOrchestrator": "Assign the orchestrator"
       },
+      "embeddingsNote": "Memory is limited: no embedding provider is configured. Process memory, semantic search and duplicate detection stay off until one is set up.",
+      "embeddingsCta": "Set up an embedding provider",
       "heading": "Get started",
       "kicker": "Setup",
       "applied": "Installed",
@@ -1321,8 +1331,11 @@
   },
   "runtimeReadiness": {
     "title": "LLM access missing",
-    "body": "The agent runtime is offline — usually because no LLM API key or subscription is connected yet. Add an API key or connect an existing Claude/Codex subscription in the LLM access settings; chat, agents, channels and skills come online right away. Routines additionally need one middleware restart.",
+    "body": "The agent runtime is offline: no LLM API key or subscription is connected yet. Add an API key or connect an existing Claude/Codex subscription in the LLM access settings, then assign the orchestrator to that access. This card disappears once the runtime is up.",
+    "titleNoAssignment": "Orchestrator not assigned",
+    "bodyNoAssignment": "An LLM access exists, but the orchestrator is not assigned to a provider that has access yet. In LLM access, under Assignment, pick the connected provider for the orchestrator (for a subscription: Claude, subscription CLI). The runtime starts afterwards without a restart.",
     "cta": "Open LLM access",
+    "ctaNoAssignment": "Open assignment",
     "dismiss": "Later"
   },
   "agentDetailsModal": {


### PR DESCRIPTION
Beta test round 4 (TE Printline, 03.09.2026), cluster C. Umbrella #1006.

Closes #999
Closes #1000
Closes #1001
Closes #1002
Closes #1003

## What

The dashboard said "LLM connected, 3 of 3 done" while every operator route answered 503, because the tick measured "an access is stored" and the banner measured "the runtime is up". Both now read the same signal.

- **OM-78** Onboarding step 1 is done only when `/operator/agents` is up (a structured 503 `multi_orchestrator_unavailable`, not a transient error). Access-without-runtime shows an "assign the orchestrator" hint with one CTA to `/admin/providers`.
- **OM-75** The 503 payload carries a `cause` (`no_llm_access` | `no_assignment` | `unknown`), computed by `computeRuntimeReadinessCause()` from the existing provider verdicts and the cached CLI detection, memoized 8 s with in-flight dedup. The banner renders a distinct title/body/CTA per cause; the "available immediately" promise is gone.
- **OM-74** Step-1 done copy follows the assigned provider: CLI, OAuth, verified key, or a neutral "runtime runs via {label}" for unverified/invalid/unknown. `LlmStep.tsx` and `StepShell.tsx` extracted (DashboardOnboarding 883 -> 785 lines).
- **OM-72** "Routines need a middleware restart" removed from the banner (the UI has no restart control; see #888 for the invisible tray icon).
- **OM-84** `GET /api/v1/admin/embedding-provider/status` (registry-backed, cheap) feeds a new "Memory / Embeddings" health card and an onboarding note when embeddings are off.
- Docs: CHANGELOG, handoff §3 (cause field, memo, status route).

## Test plan

- [x] middleware: `runtimeReadinessCause` (incl. the round-4 case: CLI logged in, key absent, `llm_provider=anthropic` -> `no_assignment`), `operatorAgentsRouter` (cause present / degrades to unknown / wiring pin), `adminEmbeddingProviderRoute` (`/status`, auth), memo tests
- [x] web-ui: page / RuntimeReadinessBanner / DashboardOnboarding / i18n parity + structural: 92 pass; `i18n:check` 4409 keys; tsc, eslint clean
- [x] Reviewed by omadia-reviewer; both blocking truth regressions fixed in 4ded95a6
- [ ] Manual: fresh install + CLI login without assignment shows "orchestrator not assigned" on dashboard and banner

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/1012"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791033079&installation_model_id=428086&pr_number=1012&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F1012&signature=14361d29da97b16972e19961e7bb50725c88e23c39e00640676792422d2a5f71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->