### PR TITLE
fix: subscription login hands off to the orchestrator, chat 503s explain themselves (OM-73, OM-76, OM-77, OM-79, OM-80)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,31 @@ changelog.
 
 ## [Unreleased]
 
+### Fixed — beta round 4 subscription hand-off (OM-73/76/77/79/80)
+
+2026-09-03 — Silvio Lange (TE Printline) round 4. The subscription path now
+carries a user from login to a working agent instead of stopping silently.
+
+- **OM-79** — after a successful `claude auth login`, the platform now points
+  every credential-less LLM plugin at the `claude-cli` provider automatically
+  (`autoAssignSubscriptionCli`, wired via a post-login hook in
+  `cliAuthService.setCliLoginAuthorizedHook`). Previously `llm_provider` stayed
+  on `anthropic`, the orchestrator asked the vault for a key it did not have,
+  and every operator surface answered 503 with no hint. A working API key is
+  never overridden. The assignment rules moved to `platform/providerAssignment.ts`
+  so the route and the hand-off share one implementation.
+- **OM-73** — `cliAuthService` now reads the login process's exit code. Claude
+  CLI v2.1.246+ finishes via a browser callback and exits 0 with no pasted code;
+  the old exit handler recorded that success as an error. `startCliLogin` reports
+  `codeEntry` so the UI shows the code field only for the older paste-code flow,
+  and a new `GET …/login/status` lets the UI poll the callback flow.
+- **OM-76 / OM-77** — `POST /api/chat` now returns `no_agents_active` (distinct
+  from `agent_unavailable`) when no orchestrator is active at all; the chat UI
+  shows a translated message linking to LLM access instead of a raw "HTTP 503"
+  and a "re-bind to default" that would 503 again.
+- **OM-80** — `LLM access` (`/admin/providers`) is now the first entry of the
+  ADMIN nav cluster.
+
 ### Fixed — The subscription-CLI agent can no longer run shell commands on the user's machine
 
 2026-09-03 — Beta test round 4, OM-81 (#991). On the subscription path the

--- a/docs/middleware-agent-handoff.md
+++ b/docs/middleware-agent-handoff.md
@@ -985,6 +985,42 @@ verschobenen Module zeigen jetzt auf `packages/harness-api-key-auth/`.
 
 ---
 
+### Subscription-CLI-Login + Provider-Hand-off (`/api/v1/admin/cli-backends`, OM-73/OM-79)
+
+`src/routes/adminCliBackends.ts` treibt `claude auth login` aus der Web-UI
+(`src/platform/cliAuthService.ts`). Auth: required.
+
+| Route | Zweck |
+|---|---|
+| `GET  /` | Erkannte CLIs (installiert / angemeldet), `?refresh=1` bustet den Cache |
+| `POST /:id/login/start` | Spawnt `claude auth login --claudeai`; Antwort `{ sessionId, verificationUrl, codeEntry, status }` |
+| `GET  /:id/login/status` | Poll-Ziel: `{ status: idle\|pending\|authorized\|invalid\|expired\|error, account?, error? }` |
+| `POST /:id/login/code` | Schreibt den eingefügten Code auf stdin (nur ältere CLIs) |
+| `POST /:id/login/cancel` | Verwirft die aktive Login-Session |
+| `POST /:id/logout` | `claude auth logout` + Cache-Bust |
+
+**Zwei CLI-Generationen, ein Flow.** Ältere CLIs (≤ 2.1.187) warten an
+`Paste code here >`; die UI zeigt das Code-Feld. Neuere (≥ 2.1.246) schließen
+den Login per localhost-Callback ab und beenden sich mit Exit 0, ohne Code.
+`startCliLogin` klassifiziert die Startausgabe (`Waiting for browser
+authorization…` / `If the browser didn't open, visit:` vs. `Paste code here`)
+und liefert `codeEntry`; die 2.1.259-Bundle druckt beides, dann gilt Callback
+mit optionalem Code (`codeEntry: false`). Der Exit-Handler liest den Exit-Code:
+0 → Detection bestätigt → `authorized`; ≠ 0 → `error` mit Output-Tail. Die UI
+pollt `login/status` in beiden Fällen.
+
+**Post-Login-Hook (OM-79).** `cliAuthService.setCliLoginAuthorizedHook(fn)`
+feuert genau einmal pro Session auf dem Übergang pending → authorized
+(`markAuthorized`, egal ob Exit-Handler oder Code-Submit zuerst kommt).
+`src/index.ts` hängt dort `autoAssignSubscriptionCli` aus
+`src/platform/providerAssignment.ts` ein: jedes installierte LLM-Plugin, das
+noch auf dem Plattform-Default (`llm_provider` unset oder `anthropic`) ohne
+Credential steht, wird auf `claude-cli` umgestellt und reaktiviert. Eine
+explizite Wahl (`openai`, OAuth, lokaler keyless Server) wird nie überschrieben.
+`applyProviderAssignment` ist dieselbe Funktion, die `POST /admin/providers/assignment`
+benutzt (Fail-closed-Regeln: tool-loser Provider vs. tool-treibendes Plugin,
+Modell/Provider-Mismatch, Routing-Disable bei Nicht-Anthropic).
+
 ### Fehlercodes für die UI: `verifyErrorCode` + `ProviderVerification.code` (issue #604)
 
 Die Middleware hat keine Request-Locale — niemand liest `Accept-Language`, und

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -168,6 +168,8 @@ import { createAdminProvidersRouter } from './routes/adminProviders.js';
 import { createAdminEmbeddingProviderRouter } from './routes/adminEmbeddingProvider.js';
 import { createAdminTranscriptionProviderRouter } from './routes/adminTranscriptionProvider.js';
 import { createAdminCliBackendsRouter } from './routes/adminCliBackends.js';
+import { setCliLoginAuthorizedHook } from './platform/cliAuthService.js';
+import { autoAssignSubscriptionCli } from './platform/providerAssignment.js';
 import { registerClaudeCliAdapter } from './platform/claudeCliAdapter.js';
 import {
   memoizeRuntimeReadinessCause,
@@ -3112,6 +3114,14 @@ async function main(): Promise<void> {
       agentResolver,
       resolveChatAgent,
       getDefaultSlug,
+      // OM-76 — "no orchestrator at all" vs "this one is gone". With a registry
+      // it is the live agent count; on a no-DB boot the legacy default bundle
+      // is the only agent there can be.
+      hasActiveAgents: () => {
+        const reg = getRegistry();
+        if (reg) return reg.size() > 0;
+        return getChatAgentBundle() !== undefined;
+      },
       getChatSessionStore,
       snapshotForAgent: (slug) => getRegistry()?.snapshotForAgent(slug),
     }),
@@ -4930,6 +4940,20 @@ async function main(): Promise<void> {
   // Read-only host-capability probe; never triggers a login or consumes quota.
   app.use('/api/v1/admin/cli-backends', requireAuth, createAdminCliBackendsRouter());
   console.log('[middleware] CLI backends endpoint ready at /api/v1/admin/cli-backends (auth: required)');
+  // OM-79 (#994) — the hand-off the subscription path was missing. A successful
+  // in-app login used to end with "signed in" while the orchestrator kept
+  // asking the vault for an Anthropic key and never published chatAgent@1.
+  // Point every credential-less LLM plugin at the CLI provider right here, so
+  // the login IS the setup; the assignment section stays for overrides.
+  setCliLoginAuthorizedHook(async () => {
+    await autoAssignSubscriptionCli({
+      installedRegistry,
+      vault: secretVault,
+      reactivate: reactivateAgent,
+      llmProviderCatalog,
+      log: (msg) => console.log(msg),
+    });
+  });
 
   // ── Agent-Builder drafts (B.0) ────────────────────────────────────────────
   // SQLite-backed draft store; persists alongside the vault so redeploys

--- a/middleware/src/platform/cliAuthService.ts
+++ b/middleware/src/platform/cliAuthService.ts
@@ -51,6 +51,10 @@ interface LoginSession {
   buffer: string;
   readonly createdAt: number;
   lifetimeTimer?: NodeJS.Timeout;
+  /** OM-79 — the post-login hook fires at most once per session, on the
+   *  pending → authorized transition, whichever path (exit handler or code
+   *  submit) gets there first. */
+  hookFired: boolean;
 }
 
 const MAX_BUFFER = 64 * 1024;
@@ -71,14 +75,17 @@ interface CliAuthDeps {
   readonly spawn: typeof spawn;
   readonly detectCliBackends: typeof detectCliBackends;
   readonly resolveCliBin: typeof resolveCliBin;
-  /** How long to watch for a "paste code" prompt after the URL appears. */
+  /** Upper bound on watching for a flow signature after the URL appears. */
   readonly codePromptProbeMs: number;
+  /** Cadence of the detection poll inside `submitCliCode`. */
+  readonly statusPollIntervalMs: number;
 }
 const DEFAULT_DEPS: CliAuthDeps = {
   spawn,
   detectCliBackends,
   resolveCliBin,
   codePromptProbeMs: CODE_PROMPT_PROBE_MS,
+  statusPollIntervalMs: STATUS_POLL_INTERVAL_MS,
 };
 let io: CliAuthDeps = DEFAULT_DEPS;
 
@@ -121,9 +128,46 @@ function fireAuthorizedHook(cliId: string): void {
   })();
 }
 
-/** Detect whether the CLI is waiting at a stdin code prompt (older flow). */
-function looksLikeCodePrompt(buf: string): boolean {
-  return /paste|enter the code|authorization code|code here/i.test(buf);
+/**
+ * Flow signatures in the CLI's opening output. Pinned against the strings the
+ * claude 2.1.259 bundle actually prints (see test fixtures):
+ *
+ *   Opening browser to sign in…
+ *   Waiting for browser authorization…
+ *   If the browser didn't open, visit: <url>
+ *   Paste code here if prompted >
+ *
+ * The newer CLI prints the callback lines AND a "Paste code here if prompted"
+ * fallback together, so the paste prompt alone proves nothing. A code entry is
+ * required only when a paste prompt appears WITHOUT any browser-callback line.
+ */
+const CALLBACK_SIGNATURE = /waiting for browser authorization|opening browser|if the browser didn.t open/i;
+const PASTE_SIGNATURE = /paste code here|enter the code|authorization code/i;
+
+function hasCallbackSignature(buf: string): boolean {
+  return CALLBACK_SIGNATURE.test(buf);
+}
+function hasPasteSignature(buf: string): boolean {
+  return PASTE_SIGNATURE.test(buf);
+}
+
+/**
+ * The one place a session becomes `authorized`. Returns `true` only on the
+ * actual pending → authorized transition; a second caller (the exit handler and
+ * `submitCliCode` can race, see OM-73) gets `false` and must not fire the hook
+ * again. `__resetCliBackendCache` runs on the transition so the next detection
+ * reads the fresh credential.
+ */
+function markAuthorized(session: LoginSession, account: string | undefined): boolean {
+  if (session.status !== 'pending') return false;
+  session.status = 'authorized';
+  if (account) session.account = account;
+  __resetCliBackendCache();
+  if (!session.hookFired) {
+    session.hookFired = true;
+    fireAuthorizedHook(session.cliId);
+  }
+  return true;
 }
 
 /** Only Claude is wired for v1 (the only confirmed subscription-billed CLI). */
@@ -205,6 +249,7 @@ export async function startCliLogin(cliId: string): Promise<StartLoginResult> {
     status: 'pending',
     buffer: '',
     createdAt: Date.now(),
+    hookFired: false,
   };
   active = session;
 
@@ -235,8 +280,10 @@ export async function startCliLogin(cliId: string): Promise<StartLoginResult> {
     //   * exit 0 while pending → the CLI completed; confirm via detection and
     //     mark `authorized` (fires the post-login hook, OM-79).
     //   * non-zero → a real failure; keep the last output for the operator.
-    // A successful submit (older flow) already flipped to `authorized` and
-    // disposed before this fires, so it is untouched.
+    // No ordering guarantee with `submitCliCode` (older flow): both may observe
+    // `pending` and both call `markAuthorized`, which only transitions once and
+    // fires the hook once. A session already `authorized`/`invalid`/`error`
+    // is left as it is.
     if (session.status === 'pending') {
       if (code === 0) {
         void confirmAuthorizedAfterExit(session);
@@ -275,18 +322,18 @@ export async function startCliLogin(cliId: string): Promise<StartLoginResult> {
   session.verificationUrl = url;
 
   // Decide which leg follows: a stdin code prompt (older CLI) or a browser
-  // callback (newer CLI). Watch briefly for the prompt; if the process finishes
-  // or a prompt never appears, this is the callback flow (codeEntry=false).
+  // callback (newer CLI). Resolve as soon as EITHER signature shows up so the
+  // start response is never held for the full probe window; the window only
+  // caps a CLI that prints the URL and nothing else. A callback line wins over
+  // a paste prompt (the 2.1.259 bundle prints both; the code is optional then).
   const promptDeadline = Date.now() + io.codePromptProbeMs;
-  let codeEntry = false;
   while (Date.now() < promptDeadline) {
     if (session.status !== 'pending') break; // exited (authorized or error)
-    if (looksLikeCodePrompt(session.buffer)) {
-      codeEntry = true;
-      break;
-    }
-    await delay(200);
+    if (hasCallbackSignature(session.buffer) || hasPasteSignature(session.buffer)) break;
+    await delay(100);
   }
+  const codeEntry =
+    hasPasteSignature(session.buffer) && !hasCallbackSignature(session.buffer);
   return {
     sessionId: session.id,
     verificationUrl: url,
@@ -303,13 +350,13 @@ export async function startCliLogin(cliId: string): Promise<StartLoginResult> {
 async function confirmAuthorizedAfterExit(session: LoginSession): Promise<void> {
   try {
     const snap = await io.detectCliBackends({ force: true });
+    // Detection is async; `submitCliCode` may have settled the session while we
+    // waited. Only a still-pending session is ours to transition.
+    if (session.status !== 'pending') return;
     const backend = snap.backends.find((b) => b.id === session.cliId);
     if (backend?.loggedIn === 'yes') {
-      session.status = 'authorized';
-      if (backend.account) session.account = backend.account;
+      markAuthorized(session, backend.account);
       session.child = undefined; // process already exited
-      __resetCliBackendCache();
-      fireAuthorizedHook(session.cliId);
       // Keep the session active (not disposed) so a UI polling getActiveLogin
       // sees `authorized`. The lifetime timer reaps it; the next login replaces
       // it. The child is already gone, so there is nothing to kill.
@@ -359,27 +406,38 @@ export async function submitCliCode(
     child.stdin.write(`${trimmed}\n`);
     const deadline = Date.now() + CODE_RESULT_WAIT_MS;
     while (Date.now() < deadline) {
-      await delay(STATUS_POLL_INTERVAL_MS);
+      await delay(io.statusPollIntervalMs);
 
-      // Authoritative success check FIRST — a confirmed login must win over any
+      // The exit handler may have confirmed the login while we slept (the CLI
+      // exits 0 after a correct code). It already fired the hook; just report.
+      if (session.status === 'authorized') {
+        const account = session.account;
+        disposeActive();
+        return account ? { status: 'authorized', account } : { status: 'authorized' };
+      }
+      if (session.status === 'error') {
+        return { status: 'error', error: session.error ?? 'The login process ended before sign-in completed. Start again.' };
+      }
+
+      // Authoritative success check — a confirmed login must win over any
       // lagging "invalid code" text (e.g. from a previous attempt).
       const snap = await io.detectCliBackends({ force: true });
       const backend = snap.backends.find((b) => b.id === session.cliId);
       if (backend?.loggedIn === 'yes') {
-        session.status = 'authorized';
-        if (backend.account) session.account = backend.account;
+        // OM-79 — `markAuthorized` fires the hook exactly once, even if the
+        // exit handler transitioned the session while detection was in flight.
+        markAuthorized(session, backend.account);
         const account = session.account;
         disposeActive();
-        __resetCliBackendCache();
-        // OM-79 — connect the orchestrator to the freshly logged-in CLI.
-        fireAuthorizedHook(session.cliId);
         return account ? { status: 'authorized', account } : { status: 'authorized' };
       }
       if (/invalid code/i.test(attemptOut)) {
         session.status = 'invalid';
         return { status: 'invalid', error: 'Invalid code. Copy the full code and try again.' };
       }
-      if (child.exitCode !== null) {
+      // exit 0 while still pending is being confirmed by the exit handler —
+      // keep waiting for it to settle. Only a non-zero exit is a failure here.
+      if (child.exitCode !== null && child.exitCode !== 0) {
         session.status = 'error';
         return { status: 'error', error: 'The login process ended before sign-in completed. Start again.' };
       }

--- a/middleware/src/platform/cliAuthService.ts
+++ b/middleware/src/platform/cliAuthService.ts
@@ -2,18 +2,24 @@
  * In-app CLI login flow (#309, Phase B) — drives `claude auth login` from the
  * Web UI so a self-hoster never needs a terminal.
  *
- * The flow is two-leg, matching how the official CLI authenticates inside a
- * container (verified empirically against claude v2.1.187):
+ * Two CLI generations, one flow (OM-73, #995):
  *
  *   1. Spawn `claude auth login --claudeai`. The CLI prints an OAuth URL
- *      ("… visit: https://claude.com/cai/oauth/authorize?…") and then waits at
- *      a "Paste code here" prompt reading stdin. We capture the URL and hand it
- *      to the browser (leg OUT).
- *   2. The operator authenticates in their own browser and gets a login code.
- *      The UI posts it back; we write it to the login process's stdin (leg IN).
- *      A wrong code returns "Invalid code" and the process stays alive to retry;
- *      a correct code writes credentials to CLAUDE_CONFIG_DIR (the persisted
- *      volume) and the session becomes authorized.
+ *      ("… visit: https://claude.com/cai/oauth/authorize?…"). We capture it and
+ *      hand it to the browser (leg OUT).
+ *   2a. OLDER CLIs (verified against v2.1.187) then wait at a "Paste code here"
+ *       stdin prompt. The operator authenticates in the browser, gets a code,
+ *       the UI posts it back and we write it to stdin (leg IN). A wrong code
+ *       returns "Invalid code" and the process stays alive to retry.
+ *   2b. NEWER CLIs (v2.1.246+) finish the login through a localhost callback in
+ *       the operator's browser and print NO code. The process exits 0 on its
+ *       own. There is nothing to paste — so `startCliLogin` reports
+ *       `codeEntry: false` and the UI polls `getActiveLogin` until the exit
+ *       handler flips the session to `authorized`.
+ *
+ * Either way, once a login succeeds the `authorized` hook fires (OM-79, #994):
+ * the subscription is connected but no orchestrator points at it yet, and the
+ * hook is where the platform re-assigns the credential-less plugins to the CLI.
  *
  * Hard rules:
  *  - **Subscription path only.** `--claudeai` (never `--console`) and the env is
@@ -52,9 +58,48 @@ const URL_WAIT_MS = 12_000;
 const SESSION_LIFETIME_MS = 5 * 60_000;
 const CODE_RESULT_WAIT_MS = 15_000;
 const STATUS_POLL_INTERVAL_MS = 1500;
+/** After the URL is captured, how long to watch for a "paste code" prompt
+ *  before concluding this CLI finishes via a browser callback (no code). */
+const CODE_PROMPT_PROBE_MS = 2500;
 
 let counter = 0;
 let active: LoginSession | undefined;
+
+/**
+ * Fired once, after a login is confirmed `authorized`. Set by the middleware
+ * bootstrap (OM-79): a fresh subscription login leaves every LLM plugin still
+ * pointing at a keyless `anthropic` provider, so this is where they get
+ * re-assigned to the CLI. Failure inside the hook must never turn a successful
+ * login into an error — the caller wraps it and logs.
+ */
+type LoginAuthorizedHook = (cliId: string) => void | Promise<void>;
+let authorizedHook: LoginAuthorizedHook | undefined;
+
+/** Register the post-login hook. Passing `undefined` clears it (tests). */
+export function setCliLoginAuthorizedHook(hook: LoginAuthorizedHook | undefined): void {
+  authorizedHook = hook;
+}
+
+function fireAuthorizedHook(cliId: string): void {
+  const hook = authorizedHook;
+  if (!hook) return;
+  // Detached: a slow or throwing hook must not block or fail the login result.
+  void (async () => {
+    try {
+      await hook(cliId);
+    } catch (err) {
+      console.warn(
+        `[cliAuth] post-login hook failed for ${cliId}:`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  })();
+}
+
+/** Detect whether the CLI is waiting at a stdin code prompt (older flow). */
+function looksLikeCodePrompt(buf: string): boolean {
+  return /paste|enter the code|authorization code|code here/i.test(buf);
+}
 
 /** Only Claude is wired for v1 (the only confirmed subscription-billed CLI). */
 function assertSupported(cliId: string): void {
@@ -95,6 +140,13 @@ function append(session: LoginSession, chunk: string): void {
 export interface StartLoginResult {
   readonly sessionId: string;
   readonly verificationUrl: string;
+  /** OM-73 — whether this CLI expects a pasted code (older flow). `false`
+   *  means it finishes via a browser callback and the UI should poll the
+   *  login status instead of showing a code field. */
+  readonly codeEntry: boolean;
+  /** The login already completed before the UI could react (very fast browser
+   *  callback). The UI can go straight to "connected". */
+  readonly status: CliLoginStatus;
 }
 
 /**
@@ -150,22 +202,99 @@ export async function startCliLogin(cliId: string): Promise<StartLoginResult> {
     session.error = err.message;
     if (active === session) disposeActive();
   });
-  child.on('exit', () => {
-    // If the process exits before authorization, mark it terminal and drop the
-    // stale session so getActiveLogin reports the truth. A successful submit has
-    // already flipped status to 'authorized' and disposed before this fires.
-    if (session.status === 'pending') session.status = 'error';
+  child.on('exit', (code) => {
+    // OM-73 — the newer CLI (v2.1.246+) finishes the login through a localhost
+    // browser callback and exits ON ITS OWN, with no code ever pasted. The old
+    // handler marked any still-`pending` session `error`, so a SUCCESSFUL login
+    // was recorded as a failure and the session dropped. Read the exit code:
+    //   * exit 0 while pending → the CLI completed; confirm via detection and
+    //     mark `authorized` (fires the post-login hook, OM-79).
+    //   * non-zero → a real failure; keep the last output for the operator.
+    // A successful submit (older flow) already flipped to `authorized` and
+    // disposed before this fires, so it is untouched.
+    if (session.status === 'pending') {
+      if (code === 0) {
+        void confirmAuthorizedAfterExit(session);
+        return;
+      }
+      session.status = 'error';
+      const tail = session.buffer.trim().split('\n').slice(-2).join(' ');
+      session.error = tail
+        ? `The login process ended without signing in: ${tail}`
+        : 'The login process ended without signing in. Start again.';
+    }
     if (active === session && session.status !== 'authorized') disposeActive();
   });
 
   const url = await waitFor(() => extractUrl(session.buffer), URL_WAIT_MS);
   if (!url) {
+    // The process may have completed a cached/instant login and exited 0 before
+    // ever printing a URL — that is a success, not a start failure.
+    if (session.status === 'authorized') {
+      return {
+        sessionId: session.id,
+        verificationUrl: '',
+        codeEntry: false,
+        status: 'authorized',
+      };
+    }
     const detail = session.buffer.trim().split('\n').slice(-2).join(' ') || 'no output';
     disposeActive();
     throw new Error(`Could not start the login flow (${detail}).`);
   }
   session.verificationUrl = url;
-  return { sessionId: session.id, verificationUrl: url };
+
+  // Decide which leg follows: a stdin code prompt (older CLI) or a browser
+  // callback (newer CLI). Watch briefly for the prompt; if the process finishes
+  // or a prompt never appears, this is the callback flow (codeEntry=false).
+  const promptDeadline = Date.now() + CODE_PROMPT_PROBE_MS;
+  let codeEntry = false;
+  while (Date.now() < promptDeadline) {
+    if (session.status !== 'pending') break; // exited (authorized or error)
+    if (looksLikeCodePrompt(session.buffer)) {
+      codeEntry = true;
+      break;
+    }
+    await delay(200);
+  }
+  return {
+    sessionId: session.id,
+    verificationUrl: url,
+    codeEntry,
+    status: session.status,
+  };
+}
+
+/**
+ * The login process exited 0 while still `pending` (newer browser-callback
+ * flow). Confirm the credential actually landed before declaring success, then
+ * flip to `authorized` and fire the post-login hook.
+ */
+async function confirmAuthorizedAfterExit(session: LoginSession): Promise<void> {
+  try {
+    const snap = await detectCliBackends({ force: true });
+    const backend = snap.backends.find((b) => b.id === session.cliId);
+    if (backend?.loggedIn === 'yes') {
+      session.status = 'authorized';
+      if (backend.account) session.account = backend.account;
+      session.child = undefined; // process already exited
+      __resetCliBackendCache();
+      fireAuthorizedHook(session.cliId);
+      // Keep the session active (not disposed) so a UI polling getActiveLogin
+      // sees `authorized`. The lifetime timer reaps it; the next login replaces
+      // it. The child is already gone, so there is nothing to kill.
+      return;
+    }
+    // Exited 0 but detection cannot confirm a login — do not claim success.
+    session.status = 'error';
+    session.error =
+      'The login process ended, but no active subscription session was found. Start again.';
+  } catch (err) {
+    session.status = 'error';
+    session.error = err instanceof Error ? err.message : String(err);
+  }
+  // Error path: drop the dead session so getActiveLogin reports the truth.
+  if (active === session) disposeActive();
 }
 
 /**
@@ -211,6 +340,8 @@ export async function submitCliCode(
         const account = session.account;
         disposeActive();
         __resetCliBackendCache();
+        // OM-79 — connect the orchestrator to the freshly logged-in CLI.
+        fireAuthorizedHook(session.cliId);
         return account ? { status: 'authorized', account } : { status: 'authorized' };
       }
       if (/invalid code/i.test(attemptOut)) {
@@ -229,12 +360,20 @@ export async function submitCliCode(
   }
 }
 
-export function getActiveLogin(): { sessionId: string; status: CliLoginStatus; verificationUrl?: string } | undefined {
+export function getActiveLogin(): {
+  sessionId: string;
+  status: CliLoginStatus;
+  verificationUrl?: string;
+  account?: string;
+  error?: string;
+} | undefined {
   if (!active) return undefined;
   return {
     sessionId: active.id,
     status: active.status,
     ...(active.verificationUrl ? { verificationUrl: active.verificationUrl } : {}),
+    ...(active.account ? { account: active.account } : {}),
+    ...(active.error ? { error: active.error } : {}),
   };
 }
 

--- a/middleware/src/platform/cliAuthService.ts
+++ b/middleware/src/platform/cliAuthService.ts
@@ -62,6 +62,31 @@ const STATUS_POLL_INTERVAL_MS = 1500;
  *  before concluding this CLI finishes via a browser callback (no code). */
 const CODE_PROMPT_PROBE_MS = 2500;
 
+/**
+ * Injection seam. Production uses the real child_process + detector; tests
+ * swap in a fake ChildProcess and a scripted detector so the exit-code paths
+ * (OM-73) are unit-testable without spawning anything.
+ */
+interface CliAuthDeps {
+  readonly spawn: typeof spawn;
+  readonly detectCliBackends: typeof detectCliBackends;
+  readonly resolveCliBin: typeof resolveCliBin;
+  /** How long to watch for a "paste code" prompt after the URL appears. */
+  readonly codePromptProbeMs: number;
+}
+const DEFAULT_DEPS: CliAuthDeps = {
+  spawn,
+  detectCliBackends,
+  resolveCliBin,
+  codePromptProbeMs: CODE_PROMPT_PROBE_MS,
+};
+let io: CliAuthDeps = DEFAULT_DEPS;
+
+/** Test seam: override any dependency; call with no argument to restore. */
+export function __setCliAuthDepsForTests(over?: Partial<CliAuthDeps>): void {
+  io = over ? { ...DEFAULT_DEPS, ...over } : DEFAULT_DEPS;
+}
+
 let counter = 0;
 let active: LoginSession | undefined;
 
@@ -157,7 +182,7 @@ export async function startCliLogin(cliId: string): Promise<StartLoginResult> {
   assertSupported(cliId);
 
   // A logged-in CLI does not need re-login; surface that to the caller.
-  const snap = await detectCliBackends({ force: true });
+  const snap = await io.detectCliBackends({ force: true });
   const backend = snap.backends.find((b) => b.id === cliId);
   if (!backend?.installed) {
     throw new Error(`${cliId} is not installed in this environment.`);
@@ -167,7 +192,7 @@ export async function startCliLogin(cliId: string): Promise<StartLoginResult> {
 
   // Resolve through the runtime install dir so a CLI installed in-app is
   // spawnable even when it is not on PATH.
-  const child = spawn(resolveCliBin(backend.bin), ['auth', 'login', '--claudeai'], {
+  const child = io.spawn(io.resolveCliBin(backend.bin), ['auth', 'login', '--claudeai'], {
     env: scrubbedEnv(),
     windowsHide: true,
   });
@@ -222,6 +247,11 @@ export async function startCliLogin(cliId: string): Promise<StartLoginResult> {
       session.error = tail
         ? `The login process ended without signing in: ${tail}`
         : 'The login process ended without signing in. Start again.';
+      // Keep the terminal session visible: a UI polling the status (callback
+      // flow) must see `error` + the message, not an `idle` that hides it. The
+      // process is gone, so there is nothing to kill; the lifetime timer reaps.
+      session.child = undefined;
+      return;
     }
     if (active === session && session.status !== 'authorized') disposeActive();
   });
@@ -247,7 +277,7 @@ export async function startCliLogin(cliId: string): Promise<StartLoginResult> {
   // Decide which leg follows: a stdin code prompt (older CLI) or a browser
   // callback (newer CLI). Watch briefly for the prompt; if the process finishes
   // or a prompt never appears, this is the callback flow (codeEntry=false).
-  const promptDeadline = Date.now() + CODE_PROMPT_PROBE_MS;
+  const promptDeadline = Date.now() + io.codePromptProbeMs;
   let codeEntry = false;
   while (Date.now() < promptDeadline) {
     if (session.status !== 'pending') break; // exited (authorized or error)
@@ -272,7 +302,7 @@ export async function startCliLogin(cliId: string): Promise<StartLoginResult> {
  */
 async function confirmAuthorizedAfterExit(session: LoginSession): Promise<void> {
   try {
-    const snap = await detectCliBackends({ force: true });
+    const snap = await io.detectCliBackends({ force: true });
     const backend = snap.backends.find((b) => b.id === session.cliId);
     if (backend?.loggedIn === 'yes') {
       session.status = 'authorized';
@@ -293,8 +323,9 @@ async function confirmAuthorizedAfterExit(session: LoginSession): Promise<void> 
     session.status = 'error';
     session.error = err instanceof Error ? err.message : String(err);
   }
-  // Error path: drop the dead session so getActiveLogin reports the truth.
-  if (active === session) disposeActive();
+  // Error path: the process is gone; keep the terminal session so a polling UI
+  // reads `error` + message (the lifetime timer or the next login reaps it).
+  session.child = undefined;
 }
 
 /**
@@ -332,7 +363,7 @@ export async function submitCliCode(
 
       // Authoritative success check FIRST — a confirmed login must win over any
       // lagging "invalid code" text (e.g. from a previous attempt).
-      const snap = await detectCliBackends({ force: true });
+      const snap = await io.detectCliBackends({ force: true });
       const backend = snap.backends.find((b) => b.id === session.cliId);
       if (backend?.loggedIn === 'yes') {
         session.status = 'authorized';
@@ -385,11 +416,11 @@ export function cancelCliLogin(): void {
 export async function cliLogout(cliId: string): Promise<{ ok: boolean }> {
   assertSupported(cliId);
   disposeActive();
-  const snap = await detectCliBackends({ force: true });
+  const snap = await io.detectCliBackends({ force: true });
   const backend = snap.backends.find((b) => b.id === cliId);
   if (!backend?.installed) return { ok: true };
   await new Promise<void>((resolve) => {
-    const c = spawn(resolveCliBin(backend.bin), ['auth', 'logout'], { env: scrubbedEnv(), windowsHide: true });
+    const c = io.spawn(io.resolveCliBin(backend.bin), ['auth', 'logout'], { env: scrubbedEnv(), windowsHide: true });
     c.on('error', () => resolve());
     c.on('exit', () => resolve());
     setTimeout(() => {

--- a/middleware/src/platform/providerAssignment.ts
+++ b/middleware/src/platform/providerAssignment.ts
@@ -159,8 +159,10 @@ export async function applyProviderAssignment(
 // publishes `chatAgent@1`. Every operator surface then answers 503.
 //
 // The hand-off flips that assignment automatically, but only where there is
-// nothing to lose: the plugin's current provider has NO credential at all.
-// A working API key or OAuth grant is never overridden — the operator chose it.
+// nothing to lose: the plugin still sits on the platform DEFAULT provider
+// (`llm_provider` unset or `anthropic`) AND that provider has no credential.
+// Anything the operator chose explicitly — another vendor, an OAuth provider, a
+// keyless local server — is never overridden, credential or not.
 // ---------------------------------------------------------------------------
 
 /** The keyless provider the in-app login connects. */
@@ -224,6 +226,16 @@ export async function autoAssignSubscriptionCli(
     const current = (readStringConfig(cfg, 'llm_provider') ?? DEFAULT_PROVIDER) as ProviderId;
     if (current === SUBSCRIPTION_CLI_PROVIDER) {
       skipped.push({ pluginId: desc.id, reason: 'already_cli' });
+      continue;
+    }
+    // Only the platform DEFAULT is ever overridden. `llm_provider` unset means
+    // the operator never chose anything, and the default `anthropic` without a
+    // key is exactly the fresh-install state OM-79 describes. An EXPLICIT choice
+    // (`openai`, an OAuth provider, a keyless local server, …) is the operator's
+    // decision — even when it currently lacks a credential — and is left alone;
+    // the subscription tab's explainer tells them where to re-point it.
+    if (readStringConfig(cfg, 'llm_provider') !== undefined && current !== DEFAULT_PROVIDER) {
+      skipped.push({ pluginId: desc.id, reason: `explicit_provider:${current}` });
       continue;
     }
     const verification = await resolveProviderVerification(current, {

--- a/middleware/src/platform/providerAssignment.ts
+++ b/middleware/src/platform/providerAssignment.ts
@@ -1,0 +1,254 @@
+/**
+ * Per-plugin LLM provider assignment, shared by the providers admin route
+ * (`POST /api/v1/admin/providers/assignment`) and the subscription-login
+ * hand-off (OM-79, #994).
+ *
+ * The rules used to live inline in the route handler. The hand-off needs the
+ * very same fail-closed checks (tool-less provider vs tool-driving plugin,
+ * model/provider mismatch, routing-disable on a non-Anthropic switch), so they
+ * moved here instead of being duplicated.
+ */
+import {
+  listModelsByProvider,
+  modelForClass,
+  resolveModelRef,
+  type ModelInfo,
+  type ProviderId,
+} from '@omadia/llm-provider';
+
+import type { InstalledRegistry } from '../plugins/installedRegistry.js';
+import type { CliBackendsSnapshot } from './cliBackendDetector.js';
+import {
+  DEFAULT_PROVIDER,
+  LLM_PLUGINS,
+  readStringConfig,
+  resolveProviderVerification,
+  type LlmProviderCatalogView,
+  type ProviderKeyVault,
+} from './pluginLlmReadiness.js';
+
+export interface ProviderAssignmentDeps {
+  readonly installedRegistry: InstalledRegistry;
+  /** Tear down + re-activate a plugin so it re-reads its config. */
+  readonly reactivate?: (pluginId: string) => Promise<void>;
+  readonly llmProviderCatalog?: LlmProviderCatalogView;
+}
+
+export interface ProviderAssignmentInput {
+  readonly pluginId: string;
+  readonly provider: string;
+  readonly model: string;
+}
+
+export type ProviderAssignmentResult =
+  | {
+      readonly ok: true;
+      readonly pluginId: string;
+      readonly provider: string;
+      /** The bare vendor model id that was persisted. */
+      readonly model: string;
+    }
+  | {
+      readonly ok: false;
+      /** HTTP status the route maps this failure to. */
+      readonly status: 400 | 404 | 500;
+      readonly code: string;
+      readonly message: string;
+    };
+
+/**
+ * Validate and persist `{ provider, model }` for an LLM-consuming plugin, then
+ * reactivate it. Pure with respect to HTTP: the route turns the result into a
+ * response, the hand-off logs it.
+ */
+export async function applyProviderAssignment(
+  deps: ProviderAssignmentDeps,
+  input: ProviderAssignmentInput,
+): Promise<ProviderAssignmentResult> {
+  const pluginId = input.pluginId;
+  const provider = input.provider.trim();
+  const model = input.model.trim();
+
+  const desc = LLM_PLUGINS.find((p) => p.id === pluginId);
+  if (desc === undefined) {
+    return {
+      ok: false,
+      status: 400,
+      code: 'providers.unknown_plugin',
+      message: `'${pluginId}' is not a selectable LLM plugin`,
+    };
+  }
+  if (provider.length === 0 || model.length === 0) {
+    return {
+      ok: false,
+      status: 400,
+      code: 'providers.invalid_request',
+      message: 'body must be { pluginId, provider, model }',
+    };
+  }
+  if (!deps.installedRegistry.has(pluginId)) {
+    return {
+      ok: false,
+      status: 404,
+      code: 'providers.not_installed',
+      message: `${pluginId} is not installed`,
+    };
+  }
+  // Fail closed: never assign a tool-less provider (the `claude-cli` Shape-2
+  // backend) to a plugin that drives a tool loop — it would silently disable
+  // tools/memory/sub-agents. Tool-less plugins (extractors/classifiers) are
+  // fine and are the intended target for the subscription CLI.
+  const providerWire = deps.llmProviderCatalog?.get(provider)?.wireFormat;
+  if (desc.requiresTools === true && providerWire === 'claude-cli') {
+    return {
+      ok: false,
+      status: 400,
+      code: 'providers.tool_incompatible',
+      message: `${desc.label} needs tool support; the subscription CLI provider is tool-less. Use it only for tool-less roles (e.g. extraction/classification).`,
+    };
+  }
+  // Resolve against the CHOSEN provider so class refs (`class:frontier`),
+  // provider-qualified ids (`openai:gpt-5.5`) and legacy aliases (`opus`) all
+  // disambiguate to it. Guard the classic mistake: a known model that belongs
+  // to a DIFFERENT provider (e.g. claude-* assigned to openai). Unknown models
+  // (custom / openai-compatible) are allowed through.
+  const known = resolveModelRef(model, { defaultProvider: provider as ProviderId });
+  if (known !== undefined && known.provider !== provider) {
+    return {
+      ok: false,
+      status: 400,
+      code: 'providers.model_provider_mismatch',
+      message: `model '${model}' belongs to provider '${known.provider}', not '${provider}'`,
+    };
+  }
+  // Persist the bare vendor id the adapter expects — normalise qualified ids /
+  // class refs / aliases to `modelId`; pass unknown custom ids through as-is.
+  const storeModel = known?.modelId ?? model;
+
+  const entry = deps.installedRegistry.get(pluginId);
+  const nextConfig: Record<string, unknown> = { ...(entry?.config ?? {}) };
+  nextConfig['llm_provider'] = provider;
+  for (const mk of desc.modelKeys) nextConfig[mk] = storeModel;
+  if (provider !== 'anthropic' && desc.extraOnNonAnthropic !== undefined) {
+    for (const [k, v] of Object.entries(desc.extraOnNonAnthropic)) {
+      nextConfig[k] = v;
+    }
+  }
+
+  try {
+    await deps.installedRegistry.updateConfig(pluginId, nextConfig);
+    if (deps.reactivate) await deps.reactivate(pluginId);
+  } catch (err) {
+    return {
+      ok: false,
+      status: 500,
+      code: 'providers.apply_failed',
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+  return { ok: true, pluginId, provider, model: storeModel };
+}
+
+// ---------------------------------------------------------------------------
+// OM-79 (#994) — subscription-login hand-off.
+//
+// After `claude auth login` succeeds, everything needed to run the orchestrator
+// on the subscription exists (keyless provider, provider factory, readiness
+// gate), except the one setting nobody names: `llm_provider` still points at
+// `anthropic`, the orchestrator asks the vault for a key, finds none and never
+// publishes `chatAgent@1`. Every operator surface then answers 503.
+//
+// The hand-off flips that assignment automatically, but only where there is
+// nothing to lose: the plugin's current provider has NO credential at all.
+// A working API key or OAuth grant is never overridden — the operator chose it.
+// ---------------------------------------------------------------------------
+
+/** The keyless provider the in-app login connects. */
+export const SUBSCRIPTION_CLI_PROVIDER: ProviderId = 'claude-cli';
+
+export interface SubscriptionAutoAssignDeps extends ProviderAssignmentDeps {
+  readonly vault?: ProviderKeyVault;
+  /** Pre-detected CLI snapshot; forwarded to the verification so the current
+   *  provider's "connected" verdict is computed the same way the admin page
+   *  computes it. */
+  readonly cliSnapshot?: CliBackendsSnapshot | undefined;
+  readonly log?: (message: string) => void;
+}
+
+export interface SubscriptionAutoAssignOutcome {
+  /** Plugins whose assignment was switched to the subscription CLI. */
+  readonly assigned: readonly string[];
+  /** Plugins left untouched, with the reason. */
+  readonly skipped: ReadonlyArray<{ readonly pluginId: string; readonly reason: string }>;
+}
+
+/** The model the hand-off assigns: the provider's balanced class default, or
+ *  its first registered model when no class default is declared. */
+export function defaultSubscriptionCliModel(): ModelInfo | undefined {
+  return (
+    modelForClass('balanced', SUBSCRIPTION_CLI_PROVIDER) ??
+    listModelsByProvider(SUBSCRIPTION_CLI_PROVIDER)[0]
+  );
+}
+
+/**
+ * Point every installed, tool-less-capable LLM plugin whose current provider
+ * has no credential at the subscription CLI. Idempotent: a plugin already on
+ * the CLI, or on a provider with a key/OAuth grant, is skipped.
+ */
+export async function autoAssignSubscriptionCli(
+  deps: SubscriptionAutoAssignDeps,
+): Promise<SubscriptionAutoAssignOutcome> {
+  const log = deps.log ?? ((): void => undefined);
+  const assigned: string[] = [];
+  const skipped: Array<{ pluginId: string; reason: string }> = [];
+
+  const model = defaultSubscriptionCliModel();
+  if (model === undefined) {
+    log(
+      `[providers] subscription hand-off skipped: provider '${SUBSCRIPTION_CLI_PROVIDER}' has no registered models`,
+    );
+    return { assigned, skipped: LLM_PLUGINS.map((p) => ({ pluginId: p.id, reason: 'no_cli_model' })) };
+  }
+
+  for (const desc of LLM_PLUGINS) {
+    if (!deps.installedRegistry.has(desc.id)) {
+      skipped.push({ pluginId: desc.id, reason: 'not_installed' });
+      continue;
+    }
+    if (desc.requiresTools === true) {
+      skipped.push({ pluginId: desc.id, reason: 'requires_tools' });
+      continue;
+    }
+    const cfg = deps.installedRegistry.get(desc.id)?.config ?? {};
+    const current = (readStringConfig(cfg, 'llm_provider') ?? DEFAULT_PROVIDER) as ProviderId;
+    if (current === SUBSCRIPTION_CLI_PROVIDER) {
+      skipped.push({ pluginId: desc.id, reason: 'already_cli' });
+      continue;
+    }
+    const verification = await resolveProviderVerification(current, {
+      vault: deps.vault,
+      llmProviderCatalog: deps.llmProviderCatalog,
+      cliSnapshot: deps.cliSnapshot,
+    });
+    if (verification.status !== 'no_key') {
+      skipped.push({ pluginId: desc.id, reason: `provider_has_credential:${verification.status}` });
+      continue;
+    }
+    const result = await applyProviderAssignment(deps, {
+      pluginId: desc.id,
+      provider: SUBSCRIPTION_CLI_PROVIDER,
+      model: model.modelId,
+    });
+    if (result.ok) {
+      assigned.push(desc.id);
+      log(
+        `[providers] subscription hand-off: ${desc.id} had no credential for '${current}', now runs on '${SUBSCRIPTION_CLI_PROVIDER}' (model=${result.model})`,
+      );
+    } else {
+      skipped.push({ pluginId: desc.id, reason: result.code });
+      log(`[providers] subscription hand-off: ${desc.id} not switched (${result.code}: ${result.message})`);
+    }
+  }
+  return { assigned, skipped };
+}

--- a/middleware/src/routes/adminCliBackends.ts
+++ b/middleware/src/routes/adminCliBackends.ts
@@ -8,7 +8,8 @@
  *  GET  /                       → { backends, generatedAt } (`?refresh=1` to bust cache)
  *  POST /:id/install            → 202 { status:'started' } | 200 { alreadyInstalled } (runtime npm install)
  *  GET  /:id/install/status     → { status: idle|running|succeeded|failed, … }
- *  POST /:id/login/start        → { sessionId, verificationUrl } (spawns `claude auth login`)
+ *  POST /:id/login/start        → { sessionId, verificationUrl, codeEntry, status } (spawns `claude auth login`)
+ *  GET  /:id/login/status       → { status, account?, error? } (poll the browser-callback flow)
  *  POST /:id/login/code         → { status, account? } (writes the pasted code to stdin)
  *  POST /:id/login/cancel       → { ok }
  *  POST /:id/logout             → { ok }
@@ -26,6 +27,7 @@ import {
   submitCliCode,
   cancelCliLogin,
   cliLogout,
+  getActiveLogin,
 } from '../platform/cliAuthService.js';
 import {
   startCliInstall,
@@ -83,6 +85,22 @@ export function createAdminCliBackendsRouter(): Router {
     } catch (err) {
       res.status(400).json({ error: 'login_start_failed', message: errMessage(err) });
     }
+  });
+
+  // OM-73 — poll target for the browser-callback flow (newer CLI prints no
+  // code, finishes on its own). Reports the live login status so the UI can
+  // wait for `authorized` / `error` without a code field.
+  router.get('/:id/login/status', (_req: Request, res: Response) => {
+    const login = getActiveLogin();
+    if (!login) {
+      res.json({ status: 'idle' });
+      return;
+    }
+    res.json({
+      status: login.status,
+      ...(login.account ? { account: login.account } : {}),
+      ...(login.error ? { error: login.error } : {}),
+    });
   });
 
   router.post('/:id/login/code', async (req: Request, res: Response) => {

--- a/middleware/src/routes/adminProviders.ts
+++ b/middleware/src/routes/adminProviders.ts
@@ -36,7 +36,6 @@ import {
   pollDeviceToken,
   primeProviderOAuthTokens,
   requestUserCode,
-  resolveModelRef,
   writeProviderOAuthTokens,
   type OAuthClientConfig,
   type OAuthTokens,
@@ -66,6 +65,7 @@ import {
   resolveProviderVerification,
   type LlmProviderCatalogView,
 } from '../platform/pluginLlmReadiness.js';
+import { applyProviderAssignment } from '../platform/providerAssignment.js';
 
 export interface AdminProvidersDeps {
   readonly installedRegistry: InstalledRegistry;
@@ -370,81 +370,17 @@ export function createAdminProvidersRouter(deps: AdminProvidersDeps): Router {
       | { pluginId?: unknown; provider?: unknown; model?: unknown }
       | null;
     const pluginId = typeof body?.pluginId === 'string' ? body.pluginId : '';
-    const provider = typeof body?.provider === 'string' ? body.provider.trim() : '';
-    const model = typeof body?.model === 'string' ? body.model.trim() : '';
+    const provider = typeof body?.provider === 'string' ? body.provider : '';
+    const model = typeof body?.model === 'string' ? body.model : '';
 
-    const desc = LLM_PLUGINS.find((p) => p.id === pluginId);
-    if (desc === undefined) {
-      res.status(400).json({
-        code: 'providers.unknown_plugin',
-        message: `'${pluginId}' is not a selectable LLM plugin`,
-      });
+    // The validation + persist rules live in `providerAssignment.ts` so the
+    // subscription-login hand-off (OM-79) applies exactly the same checks.
+    const result = await applyProviderAssignment(deps, { pluginId, provider, model });
+    if (!result.ok) {
+      res.status(result.status).json({ code: result.code, message: result.message });
       return;
     }
-    if (provider.length === 0 || model.length === 0) {
-      res.status(400).json({
-        code: 'providers.invalid_request',
-        message: 'body must be { pluginId, provider, model }',
-      });
-      return;
-    }
-    if (!deps.installedRegistry.has(pluginId)) {
-      res.status(404).json({
-        code: 'providers.not_installed',
-        message: `${pluginId} is not installed`,
-      });
-      return;
-    }
-    // Fail closed: never assign a tool-less provider (the `claude-cli` Shape-2
-    // backend) to a plugin that drives a tool loop — it would silently disable
-    // tools/memory/sub-agents. Tool-less plugins (extractors/classifiers) are
-    // fine and are the intended target for the subscription CLI.
-    const providerWire = deps.llmProviderCatalog?.get(provider)?.wireFormat;
-    if (desc.requiresTools === true && providerWire === 'claude-cli') {
-      res.status(400).json({
-        code: 'providers.tool_incompatible',
-        message: `${desc.label} needs tool support; the subscription CLI provider is tool-less. Use it only for tool-less roles (e.g. extraction/classification).`,
-      });
-      return;
-    }
-    // Resolve against the CHOSEN provider so class refs (`class:frontier`),
-    // provider-qualified ids (`openai:gpt-5.5`) and legacy aliases (`opus`) all
-    // disambiguate to it. Guard the classic mistake: a known model that belongs
-    // to a DIFFERENT provider (e.g. claude-* assigned to openai). Unknown models
-    // (custom / openai-compatible) are allowed through.
-    const known = resolveModelRef(model, { defaultProvider: provider as ProviderId });
-    if (known !== undefined && known.provider !== provider) {
-      res.status(400).json({
-        code: 'providers.model_provider_mismatch',
-        message: `model '${model}' belongs to provider '${known.provider}', not '${provider}'`,
-      });
-      return;
-    }
-    // Persist the bare vendor id the adapter expects — normalise qualified ids /
-    // class refs / aliases to `modelId`; pass unknown custom ids through as-is.
-    const storeModel = known?.modelId ?? model;
-
-    const entry = deps.installedRegistry.get(pluginId);
-    const nextConfig: Record<string, unknown> = { ...(entry?.config ?? {}) };
-    nextConfig['llm_provider'] = provider;
-    for (const mk of desc.modelKeys) nextConfig[mk] = storeModel;
-    if (provider !== 'anthropic' && desc.extraOnNonAnthropic !== undefined) {
-      for (const [k, v] of Object.entries(desc.extraOnNonAnthropic)) {
-        nextConfig[k] = v;
-      }
-    }
-
-    try {
-      await deps.installedRegistry.updateConfig(pluginId, nextConfig);
-      if (deps.reactivate) await deps.reactivate(pluginId);
-    } catch (err) {
-      res.status(500).json({
-        code: 'providers.apply_failed',
-        message: err instanceof Error ? err.message : String(err),
-      });
-      return;
-    }
-    res.json({ ok: true, pluginId, provider, model: storeModel });
+    res.json({ ok: true, pluginId: result.pluginId, provider: result.provider, model: result.model });
   });
 
   // -------------------------------------------------------------------------

--- a/middleware/src/routes/chat.ts
+++ b/middleware/src/routes/chat.ts
@@ -171,6 +171,13 @@ export interface CreateChatRouterOptions {
   /** Phase A — the no-pick default slug. Returns the platform fallback
    *  Agent's slug, or `undefined` when no fallback is configured. */
   getDefaultSlug: () => string | undefined;
+  /** OM-76 (#996) — is ANY Agent active right now? When this answers `false`
+   *  the 503 carries `no_agents_active` instead of `agent_unavailable`: the
+   *  requested slug is not "deleted or disabled", there simply is no
+   *  orchestrator running (fresh install, no LLM provider assigned). The UI
+   *  must not offer "re-bind to default" in that state — the default is the
+   *  very thing that is missing. Optional so older mounts keep the old code. */
+  hasActiveAgents?: () => boolean;
   /** Phase A — chat session store, for snapshot capture on the first
    *  turn of a session. */
   chatSessionStore?: ChatSessionStore;
@@ -232,6 +239,15 @@ async function resolveAgentForRequest(
 
   const chatAgent = options.resolveChatAgent(effectiveSlug);
   if (!chatAgent) {
+    if (options.hasActiveAgents?.() === false) {
+      res.status(503).json({
+        error: 'no_agents_active',
+        message:
+          'no orchestrator is active. Assign an LLM provider (API key or subscription CLI) under LLM access.',
+        slug: effectiveSlug,
+      });
+      return undefined;
+    }
     res.status(503).json({
       error: 'agent_unavailable',
       message: `agent "${effectiveSlug}" is not currently active`,

--- a/middleware/test/chatRouterNoAgents.test.ts
+++ b/middleware/test/chatRouterNoAgents.test.ts
@@ -1,0 +1,85 @@
+/**
+ * OM-76 (#996) — "no orchestrator at all" vs "this one is gone".
+ *
+ * When the requested slug does not resolve, the 503 must distinguish two
+ * states so the chat UI can react correctly:
+ *   - some agents ARE active, the pinned one is gone → `agent_unavailable`
+ *     (the recovery banner offers "re-bind to default").
+ *   - NO agent is active (fresh install, no LLM provider assigned) →
+ *     `no_agents_active` (the banner points at LLM access; re-binding to
+ *     "default" would just 503 again, because default is the missing thing).
+ *
+ * `hasActiveAgents` is optional; when omitted the route keeps the old
+ * `agent_unavailable` behaviour, which test 4 in chatRouterAgentRouting covers.
+ */
+import { strict as assert } from 'node:assert';
+import { after, afterEach, before, describe, it } from 'node:test';
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+
+import express from 'express';
+
+import type { ChatAgent } from '@omadia/orchestrator';
+import { createChatRouter } from '../src/routes/chat.js';
+import { listenLoopback } from './_helpers/listenLoopback.js';
+
+const SLUG = 'default';
+
+describe('createChatRouter — OM-76 no_agents_active vs agent_unavailable', () => {
+  let server: Server;
+  let baseUrl: string;
+  let activeAgents: Map<string, ChatAgent>;
+  let hasActive: boolean;
+
+  before(async () => {
+    activeAgents = new Map();
+    hasActive = true;
+    const app = express();
+    app.use(express.json());
+    app.use(
+      '/api',
+      createChatRouter({
+        resolveChatAgent: (slug) => activeAgents.get(slug),
+        getDefaultSlug: () => SLUG,
+        hasActiveAgents: () => hasActive,
+      }),
+    );
+    server = await listenLoopback(app);
+    const addr = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${String(addr.port)}/api/chat`;
+  });
+
+  after(async () => {
+    await new Promise<void>((r) => server.close(() => r()));
+  });
+
+  afterEach(() => {
+    activeAgents.clear();
+    hasActive = true;
+  });
+
+  async function post(): Promise<Response> {
+    return fetch(baseUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ message: 'hi' }),
+    });
+  }
+
+  it('no active agents at all → 503 no_agents_active', async () => {
+    hasActive = false; // registry empty, nothing published
+    const res = await post();
+    assert.equal(res.status, 503);
+    const body = (await res.json()) as { error: string; slug?: string };
+    assert.equal(body.error, 'no_agents_active');
+    assert.equal(body.slug, SLUG);
+  });
+
+  it('agents active but the requested one is gone → 503 agent_unavailable', async () => {
+    hasActive = true; // some agent exists, just not `default`
+    const res = await post();
+    assert.equal(res.status, 503);
+    const body = (await res.json()) as { error: string };
+    assert.equal(body.error, 'agent_unavailable');
+  });
+});

--- a/middleware/test/cliAuthService.test.ts
+++ b/middleware/test/cliAuthService.test.ts
@@ -1,19 +1,25 @@
 /**
- * OM-73 (#995) — `claude auth login` exit handling.
+ * OM-73 (#995) — `claude auth login` exit handling and flow detection.
  *
  * The newer Claude CLI (v2.1.246+) completes the login through a browser
- * callback and exits 0 without ever printing a paste code. The old exit
- * handler marked any still-`pending` session `error`, so a SUCCESSFUL login
- * was recorded as a failure. These tests pin the contract down:
+ * callback and exits 0 without needing a pasted code. The old exit handler
+ * marked any still-`pending` session `error`, so a SUCCESSFUL login was
+ * recorded as a failure. These tests pin the contract down:
  *
  *   - exit 0 while pending, detection confirms → `authorized`, hook fires once
  *   - exit 0 while pending, detection says no   → `error`, clear message, no hook
  *   - non-zero exit                             → `error` carrying the output tail
- *   - `codeEntry` false for browser-callback wording, true for a paste prompt
+ *   - exit handler + code submit racing         → hook fires exactly once
+ *   - `codeEntry`: false for the real 2.1.259 output (callback lines + a
+ *     "Paste code here if prompted" fallback), true for a bare paste prompt,
+ *     false for a URL with no signature at all; start resolves as soon as a
+ *     signature shows up rather than waiting out the probe window.
  *
- * A fake ChildProcess (EventEmitter + PassThrough streams) stands in for
- * `spawn`, and a scripted detector for `detectCliBackends`, through the
- * module's injection seam. Nothing is spawned.
+ * Fixture strings are the ones the claude 2.1.259 bundle prints
+ * (`~/.local/share/claude/versions/2.1.259`, extracted with `strings`, the
+ * CLI itself is never run here). A fake ChildProcess (EventEmitter +
+ * PassThrough streams) stands in for `spawn`, a scripted detector for
+ * `detectCliBackends`, both via the module's injection seam.
  */
 import { strict as assert } from 'node:assert';
 import { afterEach, beforeEach, describe, it } from 'node:test';
@@ -27,6 +33,7 @@ import {
   getActiveLogin,
   setCliLoginAuthorizedHook,
   startCliLogin,
+  submitCliCode,
 } from '../src/platform/cliAuthService.js';
 import type { CliBackendsSnapshot } from '../src/platform/cliBackendDetector.js';
 
@@ -50,9 +57,19 @@ class FakeChild extends EventEmitter {
   }
 }
 
-const URL_LINE = 'Please visit: https://claude.com/cai/oauth/authorize?code=abc\n';
-const CALLBACK_LINE = 'Waiting for the browser to complete sign-in...\n';
-const PASTE_LINE = 'Paste code here if prompted > ';
+// ── Real 2.1.259 output, verbatim ─────────────────────────────────────────────
+const URL = 'https://claude.com/cai/oauth/authorize?code=true&client_id=abc';
+const OPENING_BROWSER = 'Opening browser to sign in…\n';
+const WAITING_FOR_BROWSER = 'Waiting for browser authorization…\n';
+const IF_BROWSER_DIDNT_OPEN = `If the browser didn't open, visit: ${URL}\n`;
+const PASTE_IF_PROMPTED = 'Paste code here if prompted > ';
+/** What the 2.1.259 bundle prints for `claude auth login --claudeai`. */
+const CALLBACK_FLOW_OUTPUT =
+  OPENING_BROWSER + WAITING_FOR_BROWSER + IF_BROWSER_DIDNT_OPEN + PASTE_IF_PROMPTED;
+/** Older paste-code flow (≤ 2.1.187): URL, then a stdin prompt, no callback. */
+const PASTE_FLOW_OUTPUT = `Please visit: ${URL}\nPaste code here > `;
+/** A URL and nothing else — no flow signature at all. */
+const URL_ONLY_OUTPUT = `Please visit: ${URL}\n`;
 
 function snapshot(loggedIn: 'yes' | 'no'): CliBackendsSnapshot {
   return {
@@ -75,18 +92,13 @@ function snapshot(loggedIn: 'yes' | 'no'): CliBackendsSnapshot {
 
 const delay = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
-describe('cliAuthService — OM-73 exit-code handling', () => {
+describe('cliAuthService — OM-73 exit-code handling + flow detection', () => {
   let child: FakeChild;
   let loggedIn: 'yes' | 'no';
   let hookCalls: string[];
   let detectCalls: number;
 
-  beforeEach(() => {
-    __resetCliAuthState();
-    child = new FakeChild();
-    loggedIn = 'no';
-    hookCalls = [];
-    detectCalls = 0;
+  function install(codePromptProbeMs = 150): void {
     __setCliAuthDepsForTests({
       spawn: (() => child) as unknown as typeof spawn,
       resolveCliBin: (bin: string) => bin,
@@ -94,9 +106,18 @@ describe('cliAuthService — OM-73 exit-code handling', () => {
         detectCalls += 1;
         return snapshot(loggedIn);
       },
-      // Short probe so the callback-flow tests do not wait 2.5s.
-      codePromptProbeMs: 120,
+      codePromptProbeMs,
+      statusPollIntervalMs: 40,
     });
+  }
+
+  beforeEach(() => {
+    __resetCliAuthState();
+    child = new FakeChild();
+    loggedIn = 'no';
+    hookCalls = [];
+    detectCalls = 0;
+    install();
     setCliLoginAuthorizedHook((cliId) => {
       hookCalls.push(cliId);
     });
@@ -109,27 +130,44 @@ describe('cliAuthService — OM-73 exit-code handling', () => {
   });
 
   /** Start a login and feed the CLI's opening output shortly after spawn. */
-  async function start(afterUrl: string) {
+  async function start(output: string) {
     const pending = startCliLogin('claude');
-    setTimeout(() => child.print(URL_LINE + afterUrl), 5);
+    setTimeout(() => child.print(output), 5);
     return pending;
   }
 
-  it('reports codeEntry=false for the browser-callback wording', async () => {
-    const res = await start(CALLBACK_LINE);
+  // ── flow detection ───────────────────────────────────────────────────────
+
+  it('2.1.259 output (callback lines + "if prompted" paste) → codeEntry=false', async () => {
+    const res = await start(CALLBACK_FLOW_OUTPUT);
     assert.equal(res.codeEntry, false);
     assert.equal(res.status, 'pending');
-    assert.match(res.verificationUrl, /^https:\/\/claude\.com\//);
+    assert.equal(res.verificationUrl, URL);
   });
 
-  it('reports codeEntry=true when the CLI shows a paste-code prompt', async () => {
-    const res = await start(PASTE_LINE);
+  it('bare paste prompt without any callback line → codeEntry=true', async () => {
+    const res = await start(PASTE_FLOW_OUTPUT);
     assert.equal(res.codeEntry, true);
     assert.equal(res.status, 'pending');
   });
 
+  it('URL with no signature at all → codeEntry=false after the probe window', async () => {
+    const res = await start(URL_ONLY_OUTPUT);
+    assert.equal(res.codeEntry, false);
+  });
+
+  it('start resolves as soon as a signature appears, not after the full probe window', async () => {
+    install(1500); // long window; a signature must cut it short
+    const t0 = Date.now();
+    await start(CALLBACK_FLOW_OUTPUT);
+    const elapsed = Date.now() - t0;
+    assert.ok(elapsed < 900, `start took ${String(elapsed)}ms, should not wait out the 1500ms probe`);
+  });
+
+  // ── exit-code handling ───────────────────────────────────────────────────
+
   it('exit 0 while pending + detection confirms → authorized, hook fires once', async () => {
-    const res = await start(CALLBACK_LINE);
+    const res = await start(CALLBACK_FLOW_OUTPUT);
     assert.equal(getActiveLogin()?.status, 'pending');
 
     loggedIn = 'yes';
@@ -145,7 +183,7 @@ describe('cliAuthService — OM-73 exit-code handling', () => {
   });
 
   it('exit 0 while pending but detection says NOT logged in → error, no hook', async () => {
-    await start(CALLBACK_LINE);
+    await start(CALLBACK_FLOW_OUTPUT);
 
     loggedIn = 'no';
     child.exit(0);
@@ -158,7 +196,7 @@ describe('cliAuthService — OM-73 exit-code handling', () => {
   });
 
   it('non-zero exit → error carrying the output tail, no hook', async () => {
-    await start(CALLBACK_LINE);
+    await start(CALLBACK_FLOW_OUTPUT);
 
     child.print('Error: network unreachable while contacting the auth server\n');
     child.exit(1);
@@ -169,5 +207,39 @@ describe('cliAuthService — OM-73 exit-code handling', () => {
     assert.match(login?.error ?? '', /network unreachable/);
     assert.match(login?.error ?? '', /ended without signing in/i);
     assert.deepEqual(hookCalls, []);
+  });
+
+  // ── the race the review found ────────────────────────────────────────────
+
+  it('exit handler and code submit racing → hook fires exactly once, submit reports authorized', async () => {
+    const res = await start(PASTE_FLOW_OUTPUT);
+    assert.equal(res.codeEntry, true);
+
+    // Operator pastes the code; submit writes stdin and sleeps before its
+    // first detection poll. The CLI accepts the code and exits 0 meanwhile.
+    const submit = submitCliCode(res.sessionId, 'the-code');
+    await delay(5);
+    loggedIn = 'yes';
+    child.exit(0);
+
+    const result = await submit;
+    assert.equal(result.status, 'authorized');
+    assert.equal(result.account, 'me@firm.de');
+    // One login, one hook — never two auto-assign runs / two reactivations.
+    await delay(20);
+    assert.deepEqual(hookCalls, ['claude']);
+  });
+
+  it('a second exit event on an already-authorized session does not re-fire the hook', async () => {
+    await start(CALLBACK_FLOW_OUTPUT);
+    loggedIn = 'yes';
+    child.exit(0);
+    await delay(20);
+    assert.deepEqual(hookCalls, ['claude']);
+
+    child.emit('exit', 0, null); // defensive: a duplicate signal must be inert
+    await delay(20);
+    assert.deepEqual(hookCalls, ['claude']);
+    assert.equal(getActiveLogin()?.status, 'authorized');
   });
 });

--- a/middleware/test/cliAuthService.test.ts
+++ b/middleware/test/cliAuthService.test.ts
@@ -1,0 +1,173 @@
+/**
+ * OM-73 (#995) — `claude auth login` exit handling.
+ *
+ * The newer Claude CLI (v2.1.246+) completes the login through a browser
+ * callback and exits 0 without ever printing a paste code. The old exit
+ * handler marked any still-`pending` session `error`, so a SUCCESSFUL login
+ * was recorded as a failure. These tests pin the contract down:
+ *
+ *   - exit 0 while pending, detection confirms → `authorized`, hook fires once
+ *   - exit 0 while pending, detection says no   → `error`, clear message, no hook
+ *   - non-zero exit                             → `error` carrying the output tail
+ *   - `codeEntry` false for browser-callback wording, true for a paste prompt
+ *
+ * A fake ChildProcess (EventEmitter + PassThrough streams) stands in for
+ * `spawn`, and a scripted detector for `detectCliBackends`, through the
+ * module's injection seam. Nothing is spawned.
+ */
+import { strict as assert } from 'node:assert';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import type { spawn } from 'node:child_process';
+
+import {
+  __resetCliAuthState,
+  __setCliAuthDepsForTests,
+  getActiveLogin,
+  setCliLoginAuthorizedHook,
+  startCliLogin,
+} from '../src/platform/cliAuthService.js';
+import type { CliBackendsSnapshot } from '../src/platform/cliBackendDetector.js';
+
+class FakeChild extends EventEmitter {
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  readonly stdin = new PassThrough();
+  readonly pid = 4242;
+  exitCode: number | null = null;
+  signalCode: string | null = null;
+  kill(): boolean {
+    if (this.exitCode === null) this.exitCode = -1;
+    return true;
+  }
+  print(text: string): void {
+    this.stdout.write(text);
+  }
+  exit(code: number): void {
+    this.exitCode = code;
+    this.emit('exit', code, null);
+  }
+}
+
+const URL_LINE = 'Please visit: https://claude.com/cai/oauth/authorize?code=abc\n';
+const CALLBACK_LINE = 'Waiting for the browser to complete sign-in...\n';
+const PASTE_LINE = 'Paste code here if prompted > ';
+
+function snapshot(loggedIn: 'yes' | 'no'): CliBackendsSnapshot {
+  return {
+    backends: [
+      {
+        id: 'claude',
+        label: 'Claude',
+        bin: 'claude',
+        installed: true,
+        loggedIn,
+        billing: 'subscription',
+        detail: '',
+        ...(loggedIn === 'yes' ? { account: 'me@firm.de' } : {}),
+      },
+    ],
+    cliToolsDir: '/tmp/cli-tools',
+    generatedAt: Date.now(),
+  } as unknown as CliBackendsSnapshot;
+}
+
+const delay = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+describe('cliAuthService — OM-73 exit-code handling', () => {
+  let child: FakeChild;
+  let loggedIn: 'yes' | 'no';
+  let hookCalls: string[];
+  let detectCalls: number;
+
+  beforeEach(() => {
+    __resetCliAuthState();
+    child = new FakeChild();
+    loggedIn = 'no';
+    hookCalls = [];
+    detectCalls = 0;
+    __setCliAuthDepsForTests({
+      spawn: (() => child) as unknown as typeof spawn,
+      resolveCliBin: (bin: string) => bin,
+      detectCliBackends: async () => {
+        detectCalls += 1;
+        return snapshot(loggedIn);
+      },
+      // Short probe so the callback-flow tests do not wait 2.5s.
+      codePromptProbeMs: 120,
+    });
+    setCliLoginAuthorizedHook((cliId) => {
+      hookCalls.push(cliId);
+    });
+  });
+
+  afterEach(() => {
+    setCliLoginAuthorizedHook(undefined);
+    __resetCliAuthState();
+    __setCliAuthDepsForTests();
+  });
+
+  /** Start a login and feed the CLI's opening output shortly after spawn. */
+  async function start(afterUrl: string) {
+    const pending = startCliLogin('claude');
+    setTimeout(() => child.print(URL_LINE + afterUrl), 5);
+    return pending;
+  }
+
+  it('reports codeEntry=false for the browser-callback wording', async () => {
+    const res = await start(CALLBACK_LINE);
+    assert.equal(res.codeEntry, false);
+    assert.equal(res.status, 'pending');
+    assert.match(res.verificationUrl, /^https:\/\/claude\.com\//);
+  });
+
+  it('reports codeEntry=true when the CLI shows a paste-code prompt', async () => {
+    const res = await start(PASTE_LINE);
+    assert.equal(res.codeEntry, true);
+    assert.equal(res.status, 'pending');
+  });
+
+  it('exit 0 while pending + detection confirms → authorized, hook fires once', async () => {
+    const res = await start(CALLBACK_LINE);
+    assert.equal(getActiveLogin()?.status, 'pending');
+
+    loggedIn = 'yes';
+    child.exit(0);
+    await delay(20);
+
+    const login = getActiveLogin();
+    assert.equal(login?.sessionId, res.sessionId);
+    assert.equal(login?.status, 'authorized');
+    assert.equal(login?.account, 'me@firm.de');
+    assert.deepEqual(hookCalls, ['claude']);
+    assert.ok(detectCalls >= 2, 'exit 0 must re-run detection to confirm the credential');
+  });
+
+  it('exit 0 while pending but detection says NOT logged in → error, no hook', async () => {
+    await start(CALLBACK_LINE);
+
+    loggedIn = 'no';
+    child.exit(0);
+    await delay(20);
+
+    const login = getActiveLogin();
+    assert.equal(login?.status, 'error');
+    assert.match(login?.error ?? '', /no active subscription session/i);
+    assert.deepEqual(hookCalls, []);
+  });
+
+  it('non-zero exit → error carrying the output tail, no hook', async () => {
+    await start(CALLBACK_LINE);
+
+    child.print('Error: network unreachable while contacting the auth server\n');
+    child.exit(1);
+    await delay(20);
+
+    const login = getActiveLogin();
+    assert.equal(login?.status, 'error');
+    assert.match(login?.error ?? '', /network unreachable/);
+    assert.match(login?.error ?? '', /ended without signing in/i);
+    assert.deepEqual(hookCalls, []);
+  });
+});

--- a/middleware/test/providerAssignmentAutoAssign.test.ts
+++ b/middleware/test/providerAssignmentAutoAssign.test.ts
@@ -6,8 +6,10 @@
  * `llm_provider` still points at `anthropic`, the orchestrator asks the vault
  * for a key, finds none and never publishes chatAgent@1. `autoAssignSubscriptionCli`
  * flips that assignment to the CLI provider — but ONLY where there is nothing to
- * lose (the current provider has no credential). A working key is never
- * overridden, and a plugin already on the CLI is left alone (idempotent).
+ * lose: the plugin still sits on the platform default (`llm_provider` unset or
+ * `anthropic`) AND that default has no credential. An explicit operator choice
+ * is never overridden, credential or not; a plugin already on the CLI is left
+ * alone (idempotent); a failing reactivate is reported, not thrown.
  */
 import { strict as assert } from 'node:assert';
 import { afterEach, describe, it } from 'node:test';
@@ -28,9 +30,12 @@ import {
 } from '../src/platform/providerAssignment.js';
 
 const ORCH = '@omadia/orchestrator';
+const VERIFIER = '@omadia/verifier';
+const EXTRAS = '@omadia/orchestrator-extras';
 
 async function makeDeps(
   installed: Array<{ id: string; config?: Record<string, unknown> }>,
+  opts: { reactivateThrows?: boolean } = {},
 ) {
   const vault = new InMemorySecretVault();
   const registry = new InMemoryInstalledRegistry();
@@ -56,6 +61,7 @@ async function makeDeps(
       vault,
       llmProviderCatalog,
       reactivate: async (id: string) => {
+        if (opts.reactivateThrows) throw new Error('activation exploded');
         reactivated.push(id);
       },
     },
@@ -67,9 +73,9 @@ describe('autoAssignSubscriptionCli (OM-79)', () => {
     clearExternalModels();
   });
 
-  it('assigns the CLI when the orchestrator has no credential', async () => {
+  it('assigns the CLI when the orchestrator sits on the default provider without a credential', async () => {
     const { registry, reactivated, deps } = await makeDeps([
-      { id: ORCH, config: {} }, // defaults to anthropic, no key in the vault
+      { id: ORCH, config: {} }, // llm_provider unset → default anthropic, no key
     ]);
 
     const outcome = await autoAssignSubscriptionCli(deps);
@@ -82,10 +88,19 @@ describe('autoAssignSubscriptionCli (OM-79)', () => {
     assert.equal(cfg['orchestrator_model'], model.modelId);
     // Per-turn model routing must be forced off for a non-Anthropic provider.
     assert.equal(cfg['orchestrator_model_routing'], 'false');
-    assert.ok(reactivated.includes(ORCH), 'plugin must be reactivated');
+    assert.deepEqual(reactivated, [ORCH]);
   });
 
-  it('does NOT override an orchestrator that already has an API key', async () => {
+  it('also assigns when llm_provider is explicitly the default (anthropic) without a key', async () => {
+    const { registry, deps } = await makeDeps([
+      { id: ORCH, config: { llm_provider: 'anthropic' } },
+    ]);
+    const outcome = await autoAssignSubscriptionCli(deps);
+    assert.deepEqual(outcome.assigned, [ORCH]);
+    assert.equal(registry.get(ORCH)?.config?.['llm_provider'], SUBSCRIPTION_CLI_PROVIDER);
+  });
+
+  it('does NOT override the default provider when an API key is stored', async () => {
     const { vault, registry, reactivated, deps } = await makeDeps([
       { id: ORCH, config: { llm_provider: 'anthropic' } },
     ]);
@@ -100,20 +115,90 @@ describe('autoAssignSubscriptionCli (OM-79)', () => {
     assert.deepEqual(outcome.assigned, []);
     assert.equal(registry.get(ORCH)?.config?.['llm_provider'], 'anthropic');
     assert.equal(reactivated.length, 0);
+    assert.ok(
+      outcome.skipped.some(
+        (s) => s.pluginId === ORCH && s.reason.startsWith('provider_has_credential:'),
+      ),
+    );
   });
 
-  it('is idempotent: a plugin already on the CLI is skipped', async () => {
+  it('leaves an explicit non-default provider alone even when it has no key', async () => {
     const { registry, reactivated, deps } = await makeDeps([
-      { id: ORCH, config: { llm_provider: SUBSCRIPTION_CLI_PROVIDER } },
+      { id: ORCH, config: { llm_provider: 'openai' } }, // chosen, no key
     ]);
 
     const outcome = await autoAssignSubscriptionCli(deps);
 
     assert.deepEqual(outcome.assigned, []);
-    assert.ok(
-      outcome.skipped.some((s) => s.pluginId === ORCH && s.reason === 'already_cli'),
-    );
+    assert.equal(registry.get(ORCH)?.config?.['llm_provider'], 'openai');
     assert.equal(reactivated.length, 0);
+    assert.ok(
+      outcome.skipped.some((s) => s.pluginId === ORCH && s.reason === 'explicit_provider:openai'),
+    );
+  });
+
+  it('leaves an OAuth-connected provider alone', async () => {
+    const { registry, reactivated, deps } = await makeDeps([
+      { id: ORCH, config: { llm_provider: 'openai-chatgpt' } },
+    ]);
+    const outcome = await autoAssignSubscriptionCli(deps);
+    assert.deepEqual(outcome.assigned, []);
+    assert.equal(registry.get(ORCH)?.config?.['llm_provider'], 'openai-chatgpt');
+    assert.equal(reactivated.length, 0);
+  });
+
+  it('leaves a keyless local provider alone', async () => {
+    const { registry, reactivated, deps } = await makeDeps([
+      { id: ORCH, config: { llm_provider: 'local-ollama' } },
+    ]);
+    const outcome = await autoAssignSubscriptionCli(deps);
+    assert.deepEqual(outcome.assigned, []);
+    assert.equal(registry.get(ORCH)?.config?.['llm_provider'], 'local-ollama');
+    assert.equal(reactivated.length, 0);
+  });
+
+  it('is idempotent: a plugin already on the CLI is skipped, and a second run assigns nothing', async () => {
+    const { reactivated, deps } = await makeDeps([{ id: ORCH, config: {} }]);
+
+    const first = await autoAssignSubscriptionCli(deps);
+    assert.deepEqual(first.assigned, [ORCH]);
+
+    const second = await autoAssignSubscriptionCli(deps);
+    assert.deepEqual(second.assigned, []);
+    assert.ok(second.skipped.some((s) => s.pluginId === ORCH && s.reason === 'already_cli'));
+    assert.deepEqual(reactivated, [ORCH], 'no second reactivation');
+  });
+
+  it('switches every installed LLM plugin that is still on the credential-less default', async () => {
+    const { registry, reactivated, deps } = await makeDeps([
+      { id: ORCH, config: {} },
+      { id: VERIFIER, config: {} },
+      { id: EXTRAS, config: {} },
+    ]);
+
+    const outcome = await autoAssignSubscriptionCli(deps);
+
+    assert.deepEqual([...outcome.assigned].sort(), [EXTRAS, ORCH, VERIFIER].sort());
+    const model = defaultSubscriptionCliModel();
+    assert.ok(model);
+    for (const id of [ORCH, VERIFIER, EXTRAS]) {
+      assert.equal(registry.get(id)?.config?.['llm_provider'], SUBSCRIPTION_CLI_PROVIDER, id);
+    }
+    // Extras has two model keys; both must be set.
+    assert.equal(registry.get(EXTRAS)?.config?.['fact_extractor_model'], model.modelId);
+    assert.equal(registry.get(EXTRAS)?.config?.['topic_classifier_model'], model.modelId);
+    assert.equal(reactivated.length, 3);
+  });
+
+  it('reports a failing reactivate as apply_failed and does not throw', async () => {
+    const { deps } = await makeDeps([{ id: ORCH, config: {} }], { reactivateThrows: true });
+
+    const outcome = await autoAssignSubscriptionCli(deps);
+
+    assert.deepEqual(outcome.assigned, []);
+    assert.ok(
+      outcome.skipped.some((s) => s.pluginId === ORCH && s.reason === 'providers.apply_failed'),
+    );
   });
 
   it('skips a plugin that is not installed', async () => {

--- a/middleware/test/providerAssignmentAutoAssign.test.ts
+++ b/middleware/test/providerAssignmentAutoAssign.test.ts
@@ -1,0 +1,126 @@
+/**
+ * OM-79 (#994) — subscription-login hand-off.
+ *
+ * After a successful `claude auth login`, everything needed to run the
+ * orchestrator on the subscription already exists except the assignment:
+ * `llm_provider` still points at `anthropic`, the orchestrator asks the vault
+ * for a key, finds none and never publishes chatAgent@1. `autoAssignSubscriptionCli`
+ * flips that assignment to the CLI provider — but ONLY where there is nothing to
+ * lose (the current provider has no credential). A working key is never
+ * overridden, and a plugin already on the CLI is left alone (idempotent).
+ */
+import { strict as assert } from 'node:assert';
+import { afterEach, describe, it } from 'node:test';
+
+import {
+  LlmProviderCatalog,
+  clearExternalModels,
+  providerApiKeyVaultKey,
+} from '@omadia/llm-provider';
+
+import { InMemoryInstalledRegistry } from '../src/plugins/installedRegistry.js';
+import { InMemorySecretVault } from '../src/secrets/vault.js';
+import { registerBuiltinLlmProviders } from '../src/platform/builtinLlmProviders.js';
+import {
+  autoAssignSubscriptionCli,
+  SUBSCRIPTION_CLI_PROVIDER,
+  defaultSubscriptionCliModel,
+} from '../src/platform/providerAssignment.js';
+
+const ORCH = '@omadia/orchestrator';
+
+async function makeDeps(
+  installed: Array<{ id: string; config?: Record<string, unknown> }>,
+) {
+  const vault = new InMemorySecretVault();
+  const registry = new InMemoryInstalledRegistry();
+  for (const p of installed) {
+    await registry.register({
+      id: p.id,
+      installed_version: '0.1.0',
+      installed_at: new Date().toISOString(),
+      status: 'active',
+      config: p.config ?? {},
+    });
+  }
+  clearExternalModels();
+  const llmProviderCatalog = new LlmProviderCatalog();
+  registerBuiltinLlmProviders(llmProviderCatalog);
+  const reactivated: string[] = [];
+  return {
+    vault,
+    registry,
+    reactivated,
+    deps: {
+      installedRegistry: registry,
+      vault,
+      llmProviderCatalog,
+      reactivate: async (id: string) => {
+        reactivated.push(id);
+      },
+    },
+  };
+}
+
+describe('autoAssignSubscriptionCli (OM-79)', () => {
+  afterEach(() => {
+    clearExternalModels();
+  });
+
+  it('assigns the CLI when the orchestrator has no credential', async () => {
+    const { registry, reactivated, deps } = await makeDeps([
+      { id: ORCH, config: {} }, // defaults to anthropic, no key in the vault
+    ]);
+
+    const outcome = await autoAssignSubscriptionCli(deps);
+
+    assert.deepEqual(outcome.assigned, [ORCH]);
+    const cfg = registry.get(ORCH)?.config ?? {};
+    assert.equal(cfg['llm_provider'], SUBSCRIPTION_CLI_PROVIDER);
+    const model = defaultSubscriptionCliModel();
+    assert.ok(model, 'expected a default CLI model to exist');
+    assert.equal(cfg['orchestrator_model'], model.modelId);
+    // Per-turn model routing must be forced off for a non-Anthropic provider.
+    assert.equal(cfg['orchestrator_model_routing'], 'false');
+    assert.ok(reactivated.includes(ORCH), 'plugin must be reactivated');
+  });
+
+  it('does NOT override an orchestrator that already has an API key', async () => {
+    const { vault, registry, reactivated, deps } = await makeDeps([
+      { id: ORCH, config: { llm_provider: 'anthropic' } },
+    ]);
+    // A present key makes the verification `unverified` (not `no_key`), which
+    // counts as "has a credential the operator chose" — leave it alone.
+    await vault.setMany(ORCH, {
+      [providerApiKeyVaultKey('anthropic')]: 'sk-ant-test-key',
+    });
+
+    const outcome = await autoAssignSubscriptionCli(deps);
+
+    assert.deepEqual(outcome.assigned, []);
+    assert.equal(registry.get(ORCH)?.config?.['llm_provider'], 'anthropic');
+    assert.equal(reactivated.length, 0);
+  });
+
+  it('is idempotent: a plugin already on the CLI is skipped', async () => {
+    const { registry, reactivated, deps } = await makeDeps([
+      { id: ORCH, config: { llm_provider: SUBSCRIPTION_CLI_PROVIDER } },
+    ]);
+
+    const outcome = await autoAssignSubscriptionCli(deps);
+
+    assert.deepEqual(outcome.assigned, []);
+    assert.ok(
+      outcome.skipped.some((s) => s.pluginId === ORCH && s.reason === 'already_cli'),
+    );
+    assert.equal(reactivated.length, 0);
+  });
+
+  it('skips a plugin that is not installed', async () => {
+    const { reactivated, deps } = await makeDeps([]); // nothing installed
+    const outcome = await autoAssignSubscriptionCli(deps);
+    assert.deepEqual(outcome.assigned, []);
+    assert.ok(outcome.skipped.every((s) => s.reason === 'not_installed'));
+    assert.equal(reactivated.length, 0);
+  });
+});

--- a/web-ui/app/_components/AgentUnavailableBanner.tsx
+++ b/web-ui/app/_components/AgentUnavailableBanner.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 
 /**
@@ -14,6 +15,11 @@ import { useTranslations } from 'next-intl';
  *     current registry — typically the fallback Agent).
  *   - Delete session: DELETE /bot-api/chat/sessions/:id (drops the
  *     session entirely).
+ *
+ * OM-76 — a SECOND cause reuses this banner: `no_agents_active`. There is no
+ * orchestrator at all (fresh install, no LLM provider assigned). "Re-bind to
+ * default" would rebind to the very thing that is missing and 503 again, so
+ * that state hides both actions and links to LLM access instead.
  */
 
 export interface AgentUnavailableBannerProps {
@@ -21,6 +27,8 @@ export interface AgentUnavailableBannerProps {
   unavailableSlug: string;
   onRecovered: () => void;
   onDeleted: () => void;
+  /** OM-76 — default `agent_unavailable` keeps the original two-action UI. */
+  reason?: 'agent_unavailable' | 'no_agents_active';
 }
 
 export function AgentUnavailableBanner(
@@ -29,6 +37,24 @@ export function AgentUnavailableBanner(
   const t = useTranslations('agentPicker');
   const [busy, setBusy] = useState<'re-snapshot' | 'delete' | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  // OM-76 — "there is no orchestrator": no re-bind, just a route to the fix.
+  if (props.reason === 'no_agents_active') {
+    return (
+      <div className="mx-auto mt-4 max-w-4xl rounded border border-[color:var(--warning)] bg-[color:var(--warning)]/10 p-4 text-sm text-[color:var(--warning)]">
+        <p className="font-medium">{t('noAgentsTitle')}</p>
+        <p className="mt-1 text-[color:var(--warning)]">{t('noAgentsBody')}</p>
+        <div className="mt-3">
+          <Link
+            href="/admin/providers"
+            className="inline-block rounded border border-[color:var(--warning)] bg-[color:var(--bg-elevated)] px-3 py-1 text-xs font-medium text-[color:var(--warning)] hover:bg-[color:var(--warning)]/10"
+          >
+            {t('actionOpenLlmAccess')}
+          </Link>
+        </div>
+      </div>
+    );
+  }
 
   async function reSnapshot(): Promise<void> {
     setBusy('re-snapshot');

--- a/web-ui/app/_components/Nav.tsx
+++ b/web-ui/app/_components/Nav.tsx
@@ -67,6 +67,10 @@ const NAV: readonly NavItem[] = [
     kind: 'cluster',
     key: 'adminCluster',
     children: [
+      // OM-80 — LLM access holds the orchestrator↔provider assignment without
+      // which no agent runs, yet it had no menu entry (reachable only via the
+      // dashboard status card). First position: it is the setup prerequisite.
+      { kind: 'link', href: '/admin/providers', key: 'llmAccess' },
       { kind: 'link', href: '/admin', key: 'admin' },
       { kind: 'link', href: '/system', key: 'system' },
       // Orchestrators and Conductor moved here from the top level — they're

--- a/web-ui/app/_components/StreamRunner.tsx
+++ b/web-ui/app/_components/StreamRunner.tsx
@@ -198,13 +198,23 @@ export async function runOneTurn(
             slug?: string;
           };
           msg = parsed.message ?? parsed.error ?? `HTTP ${String(res.status)}`;
-          // Phase A / TA08 — flag the recovery banner.
-          if (
-            res.status === 503 &&
-            parsed.error === 'agent_unavailable' &&
-            parsed.slug
-          ) {
-            store.patch(sessionId, { agentUnavailableSlug: parsed.slug });
+          // Phase A / TA08 + OM-76/77 — flag the recovery banner and give the
+          // bubble a translated sentence, never a raw "HTTP 503".
+          if (res.status === 503 && parsed.error === 'agent_unavailable' && parsed.slug) {
+            store.patch(sessionId, {
+              agentUnavailableSlug: parsed.slug,
+              agentUnavailableReason: 'agent_unavailable',
+            });
+            msg = t('errorAgentUnavailable');
+          } else if (res.status === 503 && parsed.error === 'no_agents_active') {
+            // OM-76 — there is no orchestrator at all (fresh install / no LLM
+            // provider assigned). Distinct from "this one is gone": the banner
+            // must not offer "re-bind to default", it must point at LLM access.
+            store.patch(sessionId, {
+              agentUnavailableSlug: parsed.slug ?? '',
+              agentUnavailableReason: 'no_agents_active',
+            });
+            msg = t('errorNoAgentsActive');
           }
         } catch {
           msg = fallback || `HTTP ${String(res.status)}`;

--- a/web-ui/app/_components/__tests__/AgentUnavailableBanner.test.tsx
+++ b/web-ui/app/_components/__tests__/AgentUnavailableBanner.test.tsx
@@ -1,0 +1,57 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { renderWithIntl } from '../../_lib/test-utils';
+import { AgentUnavailableBanner } from '../AgentUnavailableBanner';
+
+/**
+ * OM-76 (#996) — the banner has two causes.
+ *
+ * `agent_unavailable`: this session's pinned orchestrator is gone → offer the
+ * re-bind + delete actions (the original behaviour).
+ *
+ * `no_agents_active`: there is NO orchestrator at all. "Re-bind to default"
+ * would rebind to the missing thing and 503 again, so the banner must instead
+ * link to LLM access and hide the re-bind action.
+ */
+vi.mock('next/link', () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+describe('<AgentUnavailableBanner />', () => {
+  const noop = (): void => {};
+
+  it('agent_unavailable → offers re-bind and delete', () => {
+    renderWithIntl(
+      <AgentUnavailableBanner
+        sessionId="s1"
+        unavailableSlug="myagent"
+        reason="agent_unavailable"
+        onRecovered={noop}
+        onDeleted={noop}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /re-bind to standard/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /delete session/i })).toBeTruthy();
+  });
+
+  it('no_agents_active → no re-bind, links to LLM access', () => {
+    renderWithIntl(
+      <AgentUnavailableBanner
+        sessionId="s1"
+        unavailableSlug=""
+        reason="no_agents_active"
+        onRecovered={noop}
+        onDeleted={noop}
+      />,
+    );
+    // The dangerous "re-bind to the missing default" action is gone.
+    expect(screen.queryByRole('button', { name: /re-bind to standard/i })).toBeNull();
+    // The way out is a link to LLM access.
+    const link = screen.getByRole('link', { name: /open llm access/i });
+    expect(link.getAttribute('href')).toBe('/admin/providers');
+    expect(screen.getByText(/no orchestrator is running/i)).toBeTruthy();
+  });
+});

--- a/web-ui/app/_components/__tests__/Nav.test.tsx
+++ b/web-ui/app/_components/__tests__/Nav.test.tsx
@@ -138,6 +138,21 @@ describe('<Nav /> cluster dropdown', () => {
     expect(menuVisible()).toBe(false);
   });
 
+  // OM-80 (#998) — LLM access holds the orchestrator↔provider assignment
+  // without which no agent runs, yet it had no menu entry. It must be the first
+  // child of the ADMIN cluster.
+  it('admin cluster lists LLM access first, linking to /admin/providers', () => {
+    renderWithIntl(<Nav />);
+    const button = openerFor('admin');
+    fireEvent.mouseEnter(wrapperOf(button));
+
+    const link = screen.getByRole('menuitem', { name: /llm access/i });
+    expect(link.getAttribute('href')).toBe('/admin/providers');
+
+    const items = screen.getAllByRole('menuitem');
+    expect(items[0]).toBe(link);
+  });
+
   it('opens on keyboard focus and on Enter (no pointer involved)', () => {
     renderWithIntl(<Nav />);
     const button = openerFor('admin');

--- a/web-ui/app/_components/__tests__/StreamRunner.test.tsx
+++ b/web-ui/app/_components/__tests__/StreamRunner.test.tsx
@@ -231,6 +231,63 @@ describe('runOneTurn — in-band error on a 200 stream (#403)', () => {
 });
 
 /**
+ * OM-76 / OM-77 (#996, #997) — a 503 from the chat route used to reach the
+ * bubble as the server's English sentence (`agent "default" is not currently
+ * active`) or, worse, as a bare "HTTP 503". Both codes now map to a catalogue
+ * key and flag the recovery banner with the cause.
+ */
+describe('runOneTurn — 503 agent codes are translated, never raw (OM-76/77)', () => {
+  function json503(body: Record<string, unknown>): Response {
+    return new Response(JSON.stringify(body), {
+      status: 503,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  it('no_agents_active → errorNoAgentsActive + banner reason', async () => {
+    const { latest } = captureStore();
+    const store = latest();
+
+    const sessionId = await drive(
+      store,
+      json503({
+        error: 'no_agents_active',
+        message: 'no orchestrator is active. Assign an LLM provider under LLM access.',
+        slug: 'default',
+      }),
+    );
+
+    const record = latest().get(sessionId);
+    expect(record?.phase).toBe('error');
+    expect(record?.error).toBe('errorNoAgentsActive');
+    expect(record?.error).not.toMatch(/HTTP 503|is not currently active|no orchestrator is active/);
+    expect(record?.agentUnavailableReason).toBe('no_agents_active');
+    expect(record?.agentUnavailableSlug).toBe('default');
+  });
+
+  it('agent_unavailable → errorAgentUnavailable + banner reason', async () => {
+    const { latest } = captureStore();
+    const store = latest();
+
+    const sessionId = await drive(
+      store,
+      json503({
+        error: 'agent_unavailable',
+        message: 'agent "sales" is not currently active',
+        slug: 'sales',
+      }),
+    );
+
+    const record = latest().get(sessionId);
+    expect(record?.phase).toBe('error');
+    expect(record?.error).toBe('errorAgentUnavailable');
+    expect(record?.error).not.toMatch(/HTTP 503|is not currently active/);
+    expect(record?.agentUnavailableReason).toBe('agent_unavailable');
+    expect(record?.agentUnavailableSlug).toBe('sales');
+  });
+});
+
+/**
  * #617 — a turn whose session is NOT the active one used to write into the
  * void: every store write went through the active-session mutator, so the
  * answer arrived in the tab marker but never in the transcript. These tests drive a real

--- a/web-ui/app/_lib/__tests__/errorHelpCoverage.test.ts
+++ b/web-ui/app/_lib/__tests__/errorHelpCoverage.test.ts
@@ -128,6 +128,21 @@ const FORWARDED_CODE_SOURCES = [
     literal: /:\s*'(runtime\.json_file_[a-z_]+)'/g,
     minCodes: 7,
   },
+  {
+    /**
+     * OM-79 (#994) — `POST /admin/providers/assignment` used to hold the
+     * assignment rules inline; they moved to `platform/providerAssignment.ts`
+     * so the subscription-login hand-off applies the same fail-closed checks.
+     * The route now forwards `result.code` wholesale; the literals live in
+     * `applyProviderAssignment`'s failure returns (`code: 'providers.…'`).
+     */
+    route: 'adminProviders.ts',
+    forwards: 'code: result.code',
+    source: ['middleware', 'src', 'platform', 'providerAssignment.ts'],
+    /** `code: 'providers.tool_incompatible',` */
+    literal: /code:\s*'(providers\.[a-z_]+)'/g,
+    minCodes: 6,
+  },
 ] as const;
 
 /**
@@ -152,6 +167,12 @@ const ACKNOWLEDGED_NON_LITERAL_CODE: Readonly<
     {
       expr: 'code: err.code',
       why: 'a thrown InstallError — followed via FORWARDED_CODE_SOURCES',
+    },
+  ],
+  'adminProviders.ts': [
+    {
+      expr: 'code: result.code',
+      why: 'an applyProviderAssignment failure (OM-79) — followed via FORWARDED_CODE_SOURCES',
     },
   ],
   'runtime.ts': [

--- a/web-ui/app/_lib/api.ts
+++ b/web-ui/app/_lib/api.ts
@@ -543,9 +543,21 @@ export async function getCliBackends(force = false): Promise<CliBackendsResponse
 export interface CliLoginStart {
   sessionId: string;
   verificationUrl: string;
+  /** OM-73 — `false` when the CLI finishes via a browser callback and prints no
+   *  code; the UI then polls the login status instead of showing a code field.
+   *  Absent on pre-OM-73 middleware — treat `undefined` as `true` (old flow). */
+  codeEntry?: boolean;
+  /** The login may already be authorized by the time start returns. */
+  status?: CliLoginStatus;
 }
 
-export type CliLoginStatus = 'pending' | 'authorized' | 'invalid' | 'expired' | 'error';
+export type CliLoginStatus =
+  | 'idle'
+  | 'pending'
+  | 'authorized'
+  | 'invalid'
+  | 'expired'
+  | 'error';
 
 export interface CliCodeResult {
   status: CliLoginStatus;
@@ -556,6 +568,13 @@ export interface CliCodeResult {
 /** Start the in-app CLI login flow (spawns `claude auth login`, returns the URL). */
 export async function startCliLogin(id: string): Promise<CliLoginStart> {
   return postJson<CliLoginStart>(`/v1/admin/cli-backends/${encodeURIComponent(id)}/login/start`, {});
+}
+
+/** OM-73 — poll the login status (browser-callback flow, no pasted code). */
+export async function getCliLoginStatus(id: string): Promise<CliCodeResult> {
+  return getJson<CliCodeResult>(
+    `/v1/admin/cli-backends/${encodeURIComponent(id)}/login/status`,
+  );
 }
 
 /** Submit the login code the operator's browser returned. */

--- a/web-ui/app/_lib/streamStore.tsx
+++ b/web-ui/app/_lib/streamStore.tsx
@@ -70,6 +70,10 @@ export interface StreamRecord {
    *  HTTP 503 agent_unavailable. The recovery banner reads this
    *  to decide whether to offer the re-snapshot / delete actions. */
   agentUnavailableSlug?: string;
+  /** OM-76 — which 503 cause it was. `agent_unavailable` = this session's
+   *  pinned agent is gone (offer re-bind); `no_agents_active` = there is no
+   *  orchestrator at all (offer a link to LLM access, no re-bind). */
+  agentUnavailableReason?: 'agent_unavailable' | 'no_agents_active';
 }
 
 /** Payload the UI hands the store to ask <StreamRunner /> to do the work. */

--- a/web-ui/app/admin/providers/_components/__tests__/LlmAccessTabs.test.tsx
+++ b/web-ui/app/admin/providers/_components/__tests__/LlmAccessTabs.test.tsx
@@ -71,8 +71,11 @@ describe('<LlmAccessTabs /> cross-panel navigation', () => {
     });
     expect(mockGetProviders).not.toHaveBeenCalled();
 
+    // OM-79 (#994): the explainer link is now an instruction ("assign the
+    // orchestrator to this CLI under LLM access"), no longer an aside about
+    // selecting a model. It is still the in-page switch to the API-keys panel.
     const switchControl = screen.getByRole('button', {
-      name: /select a CLI model/i,
+      name: /assign the orchestrator to this CLI/i,
     });
     fireEvent.click(switchControl);
 

--- a/web-ui/app/admin/subscription-clis/_components/SubscriptionClisPanel.tsx
+++ b/web-ui/app/admin/subscription-clis/_components/SubscriptionClisPanel.tsx
@@ -17,6 +17,7 @@ import {
   getCliBackends,
   startCliLogin,
   submitCliLoginCode,
+  getCliLoginStatus,
   cancelCliLogin,
   cliLogout,
   type CliBackendsResponse,
@@ -205,7 +206,15 @@ type LoginPhase =
   | { phase: 'starting' }
   | { phase: 'awaiting'; sessionId: string; url: string }
   | { phase: 'submitting'; sessionId: string; url: string }
+  // OM-73 — the newer CLI finishes through a browser callback with no code to
+  // paste; we show the link and poll the login status until it resolves.
+  | { phase: 'polling'; url: string }
   | { phase: 'error'; message: string; sessionId?: string; url?: string };
+
+/** Poll cap for the browser-callback login (OM-73): 40 tries × 3s = 2 min,
+ *  matching the backend session lifetime. */
+const LOGIN_POLL_TRIES = 40;
+const LOGIN_POLL_INTERVAL_MS = 3000;
 
 function CliRow({
   b,
@@ -232,12 +241,54 @@ function CliRow({
         ? t('status.installedNotLoggedIn')
         : t('status.installedUnknown');
 
+  /** OM-73 — poll the login status until it resolves (browser-callback flow). */
+  const pollUntilResolved = useCallback(
+    async (url: string): Promise<void> => {
+      for (let i = 0; i < LOGIN_POLL_TRIES; i++) {
+        await new Promise((r) => setTimeout(r, LOGIN_POLL_INTERVAL_MS));
+        let snap;
+        try {
+          snap = await getCliLoginStatus(b.id);
+        } catch {
+          continue; // transient; keep polling
+        }
+        if (snap.status === 'authorized') {
+          setLogin({ phase: 'idle' });
+          setCode('');
+          onChanged();
+          return;
+        }
+        if (snap.status === 'error' || snap.status === 'expired' || snap.status === 'invalid') {
+          setLogin({ phase: 'error', message: snap.error ?? t('connect.failed'), url });
+          return;
+        }
+      }
+      setLogin({ phase: 'error', message: t('connect.stillPending'), url });
+    },
+    [b.id, onChanged, t],
+  );
+
   const onConnect = async (): Promise<void> => {
     setLogin({ phase: 'starting' });
     setCode('');
     try {
-      const { sessionId, verificationUrl } = await startCliLogin(b.id);
-      setLogin({ phase: 'awaiting', sessionId, url: verificationUrl });
+      const start = await startCliLogin(b.id);
+      // The login may already be complete (a cached/instant browser callback).
+      if (start.status === 'authorized') {
+        setLogin({ phase: 'idle' });
+        onChanged();
+        return;
+      }
+      // `codeEntry === false` ⇒ the newer CLI finishes via a browser callback
+      // and prints no code (OM-73). Show the link and poll instead of asking
+      // for a code that will never appear. `undefined` ⇒ old middleware ⇒ old
+      // paste-code flow.
+      if (start.codeEntry === false) {
+        setLogin({ phase: 'polling', url: start.verificationUrl });
+        void pollUntilResolved(start.verificationUrl);
+        return;
+      }
+      setLogin({ phase: 'awaiting', sessionId: start.sessionId, url: start.verificationUrl });
     } catch (err) {
       setLogin({ phase: 'error', message: err instanceof Error ? err.message : String(err) });
     }
@@ -368,6 +419,34 @@ function CliRow({
 
           {login.phase === 'starting' && (
             <p className="text-sm text-[color:var(--fg-muted)]">{t('connect.starting')}</p>
+          )}
+
+          {/* OM-73 — browser-callback flow: open the link, then we wait. No code. */}
+          {login.phase === 'polling' && (
+            <div>
+              <div className="text-[12px] font-semibold uppercase tracking-[0.16em] text-[color:var(--fg-muted)]">
+                {t('connect.heading')}
+              </div>
+              <ol className="mt-2 list-decimal space-y-2 pl-5 text-sm text-[color:var(--fg-muted)]">
+                <li>
+                  {t('connect.openHint')}{' '}
+                  <a
+                    href={login.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="break-all text-[color:var(--accent)] underline"
+                  >
+                    {t('connect.openLink')}
+                  </a>
+                </li>
+                <li>{t('connect.callbackWait')}</li>
+              </ol>
+              <div className="mt-3">
+                <Button variant="ghost" size="sm" onClick={onCancel}>
+                  {t('connect.cancel')}
+                </Button>
+              </div>
+            </div>
           )}
 
           {(login.phase === 'awaiting' || login.phase === 'submitting' || (login.phase === 'error' && login.url)) && (

--- a/web-ui/app/admin/subscription-clis/_components/SubscriptionClisPanel.tsx
+++ b/web-ui/app/admin/subscription-clis/_components/SubscriptionClisPanel.tsx
@@ -211,9 +211,10 @@ type LoginPhase =
   | { phase: 'polling'; url: string }
   | { phase: 'error'; message: string; sessionId?: string; url?: string };
 
-/** Poll cap for the browser-callback login (OM-73): 40 tries × 3s = 2 min,
- *  matching the backend session lifetime. */
-const LOGIN_POLL_TRIES = 40;
+/** Poll budget for the login status (OM-73): 100 tries × 3s = 5 min, matching
+ *  the backend's SESSION_LIFETIME_MS (cliAuthService.ts) so the UI never gives
+ *  up before the server does. */
+const LOGIN_POLL_TRIES = 100;
 const LOGIN_POLL_INTERVAL_MS = 3000;
 
 function CliRow({
@@ -230,6 +231,17 @@ function CliRow({
   const [login, setLogin] = useState<LoginPhase>({ phase: 'idle' });
   const [code, setCode] = useState('');
   const [busyLogout, setBusyLogout] = useState(false);
+  /**
+   * OM-73 — cancellation token for the status poll. Every new login start,
+   * cancel, resolved submit and unmount bumps it; a running loop compares its
+   * own token per tick and stops when it no longer matches, so no stale loop
+   * ever writes into a row that moved on.
+   */
+  const pollToken = useRef(0);
+  const stopPolling = useCallback((): void => {
+    pollToken.current += 1;
+  }, []);
+  useEffect(() => stopPolling, [stopPolling]);
 
   const statusLine = !b.installed
     ? t('status.notInstalled')
@@ -241,34 +253,54 @@ function CliRow({
         ? t('status.installedNotLoggedIn')
         : t('status.installedUnknown');
 
-  /** OM-73 — poll the login status until it resolves (browser-callback flow). */
+  /**
+   * OM-73 — poll the login status until it resolves. Runs for BOTH flows: the
+   * browser-callback flow has nothing else to wait on, and in the paste-code
+   * flow the 2.1.259 CLI may still finish via the callback before the operator
+   * pastes anything — so the row resolves regardless of the `codeEntry` guess.
+   */
   const pollUntilResolved = useCallback(
     async (url: string): Promise<void> => {
+      const token = ++pollToken.current;
+      const alive = (): boolean => pollToken.current === token;
       for (let i = 0; i < LOGIN_POLL_TRIES; i++) {
         await new Promise((r) => setTimeout(r, LOGIN_POLL_INTERVAL_MS));
+        if (!alive()) return;
         let snap;
         try {
           snap = await getCliLoginStatus(b.id);
         } catch {
           continue; // transient; keep polling
         }
+        if (!alive()) return;
         if (snap.status === 'authorized') {
+          stopPolling();
           setLogin({ phase: 'idle' });
           setCode('');
           onChanged();
           return;
         }
         if (snap.status === 'error' || snap.status === 'expired' || snap.status === 'invalid') {
+          stopPolling();
           setLogin({ phase: 'error', message: snap.error ?? t('connect.failed'), url });
           return;
         }
+        // `idle` is terminal too: the server no longer has our session (reaped
+        // or replaced), so nothing we wait for can still arrive.
+        if (snap.status === 'idle') {
+          stopPolling();
+          setLogin({ phase: 'error', message: t('connect.callbackTimedOut'), url });
+          return;
+        }
       }
-      setLogin({ phase: 'error', message: t('connect.stillPending'), url });
+      if (!alive()) return;
+      setLogin({ phase: 'error', message: t('connect.callbackTimedOut'), url });
     },
-    [b.id, onChanged, t],
+    [b.id, onChanged, stopPolling, t],
   );
 
   const onConnect = async (): Promise<void> => {
+    stopPolling(); // a fresh start supersedes any loop from a previous attempt
     setLogin({ phase: 'starting' });
     setCode('');
     try {
@@ -289,6 +321,9 @@ function CliRow({
         return;
       }
       setLogin({ phase: 'awaiting', sessionId: start.sessionId, url: start.verificationUrl });
+      // Poll here as well — the heuristic may be wrong, or the CLI may finish
+      // through the browser callback while the code field is still showing.
+      void pollUntilResolved(start.verificationUrl);
     } catch (err) {
       setLogin({ phase: 'error', message: err instanceof Error ? err.message : String(err) });
     }
@@ -297,8 +332,13 @@ function CliRow({
   const onSubmitCode = async (sessionId: string, url: string): Promise<void> => {
     if (!code.trim()) return;
     setLogin({ phase: 'submitting', sessionId, url });
+    const tokenAtSubmit = pollToken.current;
     try {
       const res = await submitCliLoginCode(b.id, sessionId, code.trim());
+      // The status poll may have resolved the row while the submit was in
+      // flight (callback finished first). Its outcome wins; drop ours.
+      if (pollToken.current !== tokenAtSubmit) return;
+      stopPolling();
       if (res.status === 'authorized') {
         setLogin({ phase: 'idle' });
         setCode('');
@@ -327,6 +367,7 @@ function CliRow({
   };
 
   const onCancel = (): void => {
+    stopPolling();
     void cancelCliLogin(b.id);
     setLogin({ phase: 'idle' });
     setCode('');

--- a/web-ui/app/admin/subscription-clis/_components/__tests__/SubscriptionClisPanel.test.tsx
+++ b/web-ui/app/admin/subscription-clis/_components/__tests__/SubscriptionClisPanel.test.tsx
@@ -125,17 +125,17 @@ describe('<SubscriptionClisPanel />', () => {
     });
 
     // The connect box renders; the install steps stay collapsed behind the
-    // existing <details>, exactly as before.
-    await waitFor(() => {
-      expect(screen.queryByText(/CLI installieren/)).toBeNull();
-    });
+    // existing <details>, exactly as before. Wait for the READY render (the
+    // manual-install steps) before asserting — the earlier `waitFor(null)` was
+    // satisfied by the loading state and made this test flake under load.
     expect(
-      screen.getByText(
+      await screen.findByText(
         new RegExp(
           `npm install -g @anthropic-ai/claude-code --prefix ${CLI_TOOLS_DIR}`,
         ),
       ),
     ).toBeTruthy();
+    expect(screen.queryByText(/CLI installieren/)).toBeNull();
   });
 
   it('an uninstalled installable CLI offers the in-app install button (manual steps collapsed)', async () => {

--- a/web-ui/app/admin/subscription-clis/_components/__tests__/SubscriptionClisPanel.test.tsx
+++ b/web-ui/app/admin/subscription-clis/_components/__tests__/SubscriptionClisPanel.test.tsx
@@ -18,18 +18,27 @@ import type { CliBackendStatus } from '../../../../_lib/api';
  * the wire and had zero render sites.
  */
 
-const { mockGetCliBackends, mockStartCliInstall, mockGetCliInstallStatus } = vi.hoisted(() => ({
+const {
+  mockGetCliBackends,
+  mockStartCliInstall,
+  mockGetCliInstallStatus,
+  mockStartCliLogin,
+  mockGetCliLoginStatus,
+} = vi.hoisted(() => ({
   mockGetCliBackends: vi.fn(),
   mockStartCliInstall: vi.fn(),
   mockGetCliInstallStatus: vi.fn(),
+  mockStartCliLogin: vi.fn(),
+  mockGetCliLoginStatus: vi.fn(),
 }));
 
 const CLI_TOOLS_DIR = '/var/lib/omadia/cli-tools';
 
 vi.mock('../../../../_lib/api', () => ({
   getCliBackends: mockGetCliBackends,
-  startCliLogin: vi.fn(),
+  startCliLogin: mockStartCliLogin,
   submitCliLoginCode: vi.fn(),
+  getCliLoginStatus: mockGetCliLoginStatus,
   cancelCliLogin: vi.fn(),
   cliLogout: vi.fn(),
   startCliInstall: mockStartCliInstall,
@@ -262,4 +271,53 @@ describe('<SubscriptionClisPanel />', () => {
       expect(screen.getByText(/^Abrechnung: Abo$/)).toBeTruthy();
     });
   });
+
+  /**
+   * OM-73 (#995) — the newer Claude CLI (v2.1.246+) finishes the login through
+   * a browser callback and prints NO code. The old UI still showed a "paste the
+   * code" field that never got a code, and the backend recorded the successful
+   * login as an error. With `codeEntry: false` the panel must NOT show a code
+   * field; it shows the callback-wait copy and polls the login status.
+   */
+  it('OM-73: a browser-callback login shows no code field and polls to success', async () => {
+    mockGetCliBackends
+      .mockResolvedValueOnce({
+        backends: [backend({ installed: true, loggedIn: 'no' })],
+        cliToolsDir: CLI_TOOLS_DIR,
+        generatedAt: Date.now(),
+      })
+      // After the login resolves, onChanged re-loads and the CLI is logged in.
+      .mockResolvedValue({
+        backends: [backend({ installed: true, loggedIn: 'yes', account: 'me@firm.de' })],
+        cliToolsDir: CLI_TOOLS_DIR,
+        generatedAt: Date.now(),
+      });
+    mockStartCliLogin.mockResolvedValue({
+      sessionId: 'login-1',
+      verificationUrl: 'https://claude.com/oauth/authorize?x=1',
+      codeEntry: false,
+      status: 'pending',
+    });
+    mockGetCliLoginStatus.mockResolvedValue({ status: 'authorized', account: 'me@firm.de' });
+
+    renderWithIntl(<SubscriptionClisPanel onSwitchToProviders={() => {}} />, {
+      locale: 'de',
+    });
+
+    const connect = await screen.findByRole('button', { name: /Abo verbinden/i });
+    fireEvent.click(connect);
+
+    // The callback-wait copy appears; the code entry field never does.
+    await screen.findByText(/schließt die Anmeldung selbst ab/i);
+    expect(screen.queryByPlaceholderText(/Login-Code einfügen/i)).toBeNull();
+    expect(mockStartCliLogin).toHaveBeenCalledWith('claude');
+
+    // Polling reaches `authorized` and the panel re-loads the backends.
+    await waitFor(
+      () => {
+        expect(mockGetCliLoginStatus).toHaveBeenCalledWith('claude');
+      },
+      { timeout: 6000 },
+    );
+  }, 10000);
 });

--- a/web-ui/app/admin/subscription-clis/_components/__tests__/SubscriptionClisPanel.test.tsx
+++ b/web-ui/app/admin/subscription-clis/_components/__tests__/SubscriptionClisPanel.test.tsx
@@ -277,16 +277,20 @@ describe('<SubscriptionClisPanel />', () => {
    * a browser callback and prints NO code. The old UI still showed a "paste the
    * code" field that never got a code, and the backend recorded the successful
    * login as an error. With `codeEntry: false` the panel must NOT show a code
-   * field; it shows the callback-wait copy and polls the login status.
+   * field; it shows the callback-wait copy and polls the login status until the
+   * row is connected.
+   *
+   * Real timers on purpose (see the install-poll test above): the status poll
+   * runs on a 3s cadence and vitest's fake timers deadlock against waitFor.
    */
-  it('OM-73: a browser-callback login shows no code field and polls to success', async () => {
+  it('OM-73: a browser-callback login shows no code field and reaches connected via polling', async () => {
     mockGetCliBackends
       .mockResolvedValueOnce({
         backends: [backend({ installed: true, loggedIn: 'no' })],
         cliToolsDir: CLI_TOOLS_DIR,
         generatedAt: Date.now(),
       })
-      // After the login resolves, onChanged re-loads and the CLI is logged in.
+      // After the poll reports `authorized`, onChanged re-loads: now logged in.
       .mockResolvedValue({
         backends: [backend({ installed: true, loggedIn: 'yes', account: 'me@firm.de' })],
         cliToolsDir: CLI_TOOLS_DIR,
@@ -312,12 +316,45 @@ describe('<SubscriptionClisPanel />', () => {
     expect(screen.queryByPlaceholderText(/Login-Code einfügen/i)).toBeNull();
     expect(mockStartCliLogin).toHaveBeenCalledWith('claude');
 
-    // Polling reaches `authorized` and the panel re-loads the backends.
+    // One poll tick later the row is CONNECTED — no code was ever pasted.
     await waitFor(
       () => {
         expect(mockGetCliLoginStatus).toHaveBeenCalledWith('claude');
+        expect(screen.getByText(/Angemeldet als me@firm\.de/)).toBeTruthy();
       },
       { timeout: 6000 },
     );
+    expect(screen.queryByText(/schließt die Anmeldung selbst ab/i)).toBeNull();
+  }, 10000);
+
+  it('OM-73: cancelling the callback login stops the status poll', async () => {
+    mockGetCliBackends.mockResolvedValue({
+      backends: [backend({ installed: true, loggedIn: 'no' })],
+      cliToolsDir: CLI_TOOLS_DIR,
+      generatedAt: Date.now(),
+    });
+    mockStartCliLogin.mockResolvedValue({
+      sessionId: 'login-2',
+      verificationUrl: 'https://claude.com/oauth/authorize?x=2',
+      codeEntry: false,
+      status: 'pending',
+    });
+    mockGetCliLoginStatus.mockResolvedValue({ status: 'pending' });
+
+    renderWithIntl(<SubscriptionClisPanel onSwitchToProviders={() => {}} />, {
+      locale: 'de',
+    });
+
+    fireEvent.click(await screen.findByRole('button', { name: /Abo verbinden/i }));
+    await screen.findByText(/schließt die Anmeldung selbst ab/i);
+
+    fireEvent.click(screen.getByRole('button', { name: /^Abbrechen$/ }));
+    // Back to the idle row immediately …
+    expect(await screen.findByRole('button', { name: /Abo verbinden/i })).toBeTruthy();
+
+    // … and the loop must not fire a single status request after the cancel,
+    // not even the tick that was already scheduled.
+    await new Promise((r) => setTimeout(r, 3500));
+    expect(mockGetCliLoginStatus).not.toHaveBeenCalled();
   }, 10000);
 });

--- a/web-ui/app/chat/page.tsx
+++ b/web-ui/app/chat/page.tsx
@@ -593,6 +593,7 @@ export default function ChatPage(): React.ReactElement {
           <AgentUnavailableBanner
             sessionId={activeId}
             unavailableSlug={rec.agentUnavailableSlug}
+            reason={rec.agentUnavailableReason}
             onRecovered={() => {
               streamStore.patch(activeId, { agentUnavailableSlug: undefined });
               // Drop the pinned snapshot in the local session so the

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -3646,6 +3646,7 @@
       "failed": "Anmeldung fehlgeschlagen. Bitte erneut versuchen.",
       "stillPending": "Noch nicht angemeldet. Öffne den Link, bestätige den Zugriff und sende den Code erneut.",
       "callbackWait": "Bestätige den Zugriff im Browser. Diese CLI schließt die Anmeldung selbst ab, kein Code zum Einfügen — diese Seite aktualisiert sich, sobald es fertig ist.",
+      "callbackTimedOut": "Die Anmeldung wurde nicht rechtzeitig abgeschlossen. Starte erneut, bestätige den Zugriff im Browser und lass diese Seite offen.",
       "manualSummary": "Lieber das Terminal?",
       "step1": "Stelle sicher, dass die CLI installiert ist (im omadia-Image enthalten oder selbst installieren):",
       "installCmd": "npm install -g @anthropic-ai/claude-code --prefix {prefix}",

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -458,7 +458,8 @@
     "pluginsCluster": "Plugins",
     "adminCluster": "Admin",
     "help": "Hilfe",
-    "teamsSignIn": "Teams-Anmeldung"
+    "teamsSignIn": "Teams-Anmeldung",
+    "llmAccess": "LLM-Zugang"
   },
   "conductor": {
     "title": "Conductor",
@@ -1373,6 +1374,8 @@
   },
   "chat": {
     "errorProxyFailure": "Proxy-Fehler (HTTP {status}). Prüf die Middleware-Logs.",
+    "errorAgentUnavailable": "Der Orchestrator dieser Session ist nicht mehr aktiv. Binde ihn unten neu, oder wähle einen anderen.",
+    "errorNoAgentsActive": "Es läuft noch kein Orchestrator. Ordne unter LLM-Zugang einen LLM-Anbieter zu und versuche es erneut.",
     "errorAborted": "Abgebrochen.",
     "errorProviderGeneric": "Beim Zugriff auf den KI-Anbieter ist etwas schiefgelaufen. Bitte versuch es erneut.",
     "errorProviderAuth": "Der KI-Anbieter hat den hinterlegten API-Schlüssel abgelehnt. Prüfe ihn unter Admin → LLM-Zugang mit „Schlüssel testen“ und hinterlege ggf. einen neuen.",
@@ -1671,7 +1674,10 @@
     "unavailableTitle": "Der Orchestrator dieser Session ist nicht mehr verfügbar",
     "unavailableBody": "Der Orchestrator „{slug}\" wurde gelöscht oder deaktiviert. Wie soll diese Session weiterlaufen?",
     "actionReSnapshot": "Auf Standard umbinden",
-    "actionDelete": "Session löschen"
+    "actionDelete": "Session löschen",
+    "noAgentsTitle": "Es läuft kein Orchestrator",
+    "noAgentsBody": "Es ist noch kein LLM-Anbieter einem Orchestrator zugeordnet, daher kann kein Agent antworten. Öffne den LLM-Zugang und hinterlege einen API-Schlüssel oder eine Abo-CLI.",
+    "actionOpenLlmAccess": "LLM-Zugang öffnen"
   },
   "skills": {
     "metaTitle": "Skills · omadia",
@@ -3611,7 +3617,7 @@
     },
     "loading": "Lädt …",
     "loadError": "Laden fehlgeschlagen: {message}",
-    "selectModelLink": "Nach der Anmeldung ein CLI-Modell für einen Agenten unter LLM-Provider auswählen",
+    "selectModelLink": "Ordne nach der Anmeldung den Orchestrator unter LLM-Zugang dieser CLI zu — sonst läuft kein Agent. omadia setzt das automatisch, wenn kein anderer Anbieter konfiguriert ist",
     "detected": {
       "heading": "Erkannte CLIs"
     },
@@ -3639,6 +3645,7 @@
       "retry": "Erneut versuchen",
       "failed": "Anmeldung fehlgeschlagen. Bitte erneut versuchen.",
       "stillPending": "Noch nicht angemeldet. Öffne den Link, bestätige den Zugriff und sende den Code erneut.",
+      "callbackWait": "Bestätige den Zugriff im Browser. Diese CLI schließt die Anmeldung selbst ab, kein Code zum Einfügen — diese Seite aktualisiert sich, sobald es fertig ist.",
       "manualSummary": "Lieber das Terminal?",
       "step1": "Stelle sicher, dass die CLI installiert ist (im omadia-Image enthalten oder selbst installieren):",
       "installCmd": "npm install -g @anthropic-ai/claude-code --prefix {prefix}",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -3646,6 +3646,7 @@
       "failed": "Sign-in failed. Try again.",
       "stillPending": "Not signed in yet. Open the link, approve access, then submit the code again.",
       "callbackWait": "Approve access in the browser. This CLI finishes the sign-in on its own, no code to paste — this page updates when it is done.",
+      "callbackTimedOut": "The sign-in did not complete in time. Start again, approve access in the browser, and keep this page open.",
       "manualSummary": "Prefer the terminal?",
       "step1": "Make sure the CLI is installed (bundled in the omadia image, or install it):",
       "installCmd": "npm install -g @anthropic-ai/claude-code --prefix {prefix}",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -458,7 +458,8 @@
     "pluginsCluster": "Plugins",
     "adminCluster": "Admin",
     "help": "Help",
-    "teamsSignIn": "Teams sign-in"
+    "teamsSignIn": "Teams sign-in",
+    "llmAccess": "LLM access"
   },
   "conductor": {
     "title": "Conductor",
@@ -1373,6 +1374,8 @@
   },
   "chat": {
     "errorProxyFailure": "Proxy error (HTTP {status}). Check the middleware logs.",
+    "errorAgentUnavailable": "This session's orchestrator is no longer active. Re-bind it below, or pick another.",
+    "errorNoAgentsActive": "No orchestrator is running yet. Assign an LLM provider under LLM access, then try again.",
     "errorAborted": "Aborted.",
     "errorProviderGeneric": "Something went wrong while talking to the AI provider. Please try again.",
     "errorProviderAuth": "The AI provider rejected the stored API key. Check it under Admin → LLM access with “Test key” and store a new one if needed.",
@@ -1671,7 +1674,10 @@
     "unavailableTitle": "This session's Orchestrator is no longer available",
     "unavailableBody": "The Orchestrator \"{slug}\" was deleted or disabled. Pick how to recover this session.",
     "actionReSnapshot": "Re-bind to standard",
-    "actionDelete": "Delete session"
+    "actionDelete": "Delete session",
+    "noAgentsTitle": "No orchestrator is running",
+    "noAgentsBody": "No LLM provider is assigned to an orchestrator yet, so no agent can answer. Open LLM access and assign an API key or a subscription CLI.",
+    "actionOpenLlmAccess": "Open LLM access"
   },
   "skills": {
     "metaTitle": "Skills · omadia",
@@ -3611,7 +3617,7 @@
     },
     "loading": "Loading …",
     "loadError": "Failed to load: {message}",
-    "selectModelLink": "Once logged in, select a CLI model for an agent in LLM providers",
+    "selectModelLink": "After you sign in, assign the orchestrator to this CLI under LLM access — otherwise no agent runs. omadia sets this for you automatically when no other provider is configured",
     "detected": {
       "heading": "Detected CLIs"
     },
@@ -3639,6 +3645,7 @@
       "retry": "Try again",
       "failed": "Sign-in failed. Try again.",
       "stillPending": "Not signed in yet. Open the link, approve access, then submit the code again.",
+      "callbackWait": "Approve access in the browser. This CLI finishes the sign-in on its own, no code to paste — this page updates when it is done.",
       "manualSummary": "Prefer the terminal?",
       "step1": "Make sure the CLI is installed (bundled in the omadia image, or install it):",
       "installCmd": "npm install -g @anthropic-ai/claude-code --prefix {prefix}",


### PR DESCRIPTION
Beta test round 4 (TE Printline, 03.09.2026), cluster B. Umbrella #1006.

Closes #994
Closes #995
Closes #996
Closes #997
Closes #998

## What

The subscription path was fully built, but nothing connected a successful CLI login to the orchestrator, and the newer CLI's login flow was recorded as an error.

- **OM-79** New `platform/providerAssignment.ts`: `applyProviderAssignment` (shared with `POST /admin/providers/assignment`, same fail-closed rules) and `autoAssignSubscriptionCli`, fired once after a successful CLI login. It assigns `claude-cli` only when `llm_provider` is unset or the platform default and has no usable credential; explicit choices, OAuth-connected and keyless local providers are left alone. Reactivates each assigned plugin once, never throws into the login flow. The subscription tab's explainer is now an instruction.
- **OM-73** `cliAuthService.ts` reads the exit code: 0 while pending confirms via detection and marks `authorized` through a single `markAuthorized()` transition (hook fires once, also across the exit+submit race); non-zero is `error` with the output tail. `codeEntry` tells the UI whether the CLI wants a paste code (signatures pinned from the 2.1.259 bundle; callback wins over "if prompted"). New `GET /admin/cli-backends/:id/login/status`; the panel polls it in both phases with a cancel token, `idle` terminal, 5 min budget.
- **OM-76** `routes/chat.ts` returns `no_agents_active` (503) when the registry has zero active agents, `agent_unavailable` otherwise; `AgentUnavailableBanner` hides "Rebind to default" in that case and links to LLM access.
- **OM-77** `StreamRunner` maps both codes to translated messages; no bare "HTTP 503".
- **OM-80** "LLM access" is the first entry of the ADMIN nav cluster.
- Docs: CHANGELOG (API changes listed), handoff §3 block for the cli-backends router and the post-login hook.

## Test plan

- [x] middleware: cliAuthService (exit 0 / non-zero / race / codeEntry signatures), providerAssignmentAutoAssign (10 cases), chatRouterNoAgents, chatRouterAgentRouting, adminProvidersRoute: 52 pass; `tsc`, `lint`, ratchet clean for touched files
- [x] web-ui: Nav, AgentUnavailableBanner, SubscriptionClisPanel (polling to connected, cancel stops loop), StreamRunner (503 mapping), i18n parity: 39 pass; `i18n:check` 4401 keys; tsc, lint clean
- [x] Reviewed by omadia-reviewer; all blocking findings fixed in f63b726a
- [ ] Manual: fresh install, subscription login on CLI >= 2.1.246 ends in "signed in" without a code field and the orchestrator publishes chatAgent@1 without visiting the assignment section

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/1013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791033448&installation_model_id=428086&pr_number=1013&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F1013&signature=bfa7b74652f73f9039ab0d1687895f513f2cd524c4ed3b572fb5eedbb289e7ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->