### PR TITLE
fix: scope routine actions, unify the sandbox-listen guard

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,36 @@ changelog.
 
 ## [Unreleased]
 
+### Fixed — routine card buttons keep working, and say when they run unscoped (#1029)
+
+2026-09-04 — follow-up to #1025, which scoped the routine smart-card handler
+from the per-turn context and refused when it was absent. That would have
+broken Pausieren, Aktivieren, Löschen and Jetzt auslösen for every user: the
+Teams adapter dispatches card clicks out-of-band, returning before the
+orchestrator turn, so the context is never captured on that path and every
+click would have answered "routines are unavailable in this session".
+
+`handleRoutineAction` now takes an optional `actor` from the channel, with
+documented precedence — explicit `actor`, then the turn context, then
+unscoped exactly as before #1025. The unscoped case is counted and logged at
+error level naming the action and routine id, because a hole you can see is
+better than silently scoping to nobody. Once the Teams adapter passes the
+tenant and `from.aadObjectId` it already holds on the activity, the fallback
+can be deleted.
+
+Two guards from #1024 and #1025 were also proving less than they claimed. The
+routine store's recording-pool assertions bound `tenant` and `user_id` but not
+`id`, so rewriting the scoped delete to drop the row predicate — deleting
+every routine that user owns — left the suite green; `id` is now bound too.
+And the sandbox-listen scan was name-and-literal shaped: a copy called
+anything, comparing `errno === -1`, using double quotes or `.includes`, or
+living in a `.js` file, passed it. Detection is behaviour-shaped now, with a
+test that proves each spelling is matched and that correct usage is not, plus
+a written note on what it still cannot see. Its directory scan also used
+`new URL(...).pathname`, which leaves percent-encoding intact — a checkout
+path needing decoding made the scan walk nothing and report zero offenders,
+failing open.
+
 ### Fixed — knowing a routine id is no longer enough to pause, resume or delete it (#1025)
 
 2026-09-04 — `manage_routine` resolved the channel turn context for `create`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,35 @@ changelog.
 
 ## [Unreleased]
 
+### Fixed — knowing a routine id is no longer enough to pause, resume or delete it (#1025)
+
+2026-09-04 — `manage_routine` resolved the channel turn context for `create`
+and `list`, but `pause`, `resume` and `delete` passed a bare `id` to a runner
+whose store filtered on `WHERE id = $1` alone. Knowing an id was therefore
+enough to act on any tenant's routine. Ids are uuids and `list` is scoped, so
+an id had to leak rather than be enumerated, which is obscurity rather than
+authorization.
+
+All five actions now resolve the context and refuse without it, and the
+mutating ones carry the caller's `(tenant, userId)` into the SQL predicate, so
+another tenant's id reports not-found instead of acting — with the same error
+a genuinely absent id produces, so the failure is not an existence oracle. The
+scope is a required discriminated argument on the runner rather than an
+optional `owner?`: an optional scope is one a caller can forget, and forgetting
+it is exactly how this gap arose. Cross-tenant access is now a greppable
+`{ kind: 'operator' }` literal, used by the operators-only HTTP router.
+
+Two neighbours had the same gap and are fixed with it: the routine smart-card
+buttons are a second door onto the same mutations, and `triggerRoutineNow`
+delivers into the routine's own conversation, so an unscoped trigger let one
+principal push messages into another tenant's conversation. A related ordering
+bug also surfaced — `delete` unregistered the scheduler before deleting, so a
+cross-tenant id silently disarmed someone else's cron while the row survived,
+leaving a routine that looks active in `list` and never fires again.
+
+This also widens #1016's "absent context passes" rationale, which was
+documented as true for two of five actions and now holds for all five.
+
 ### Fixed — a stale turn context on the CLI path refuses instead of substituting a principal (#1016)
 
 2026-09-04 — closes the open half of #1016. The capture-timing bug was fixed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,40 @@ changelog.
 
 ## [Unreleased]
 
+### Fixed — a privacy and an auth suite can no longer delete themselves and report success (#1024)
+
+2026-09-04 — follow-up to #1017, which fixed one copy of this and revealed how
+far it had spread.
+
+Seven places in `middleware/test` had grown their own version of "the sandbox
+refused a loopback listener, so skip this test": three named
+`isSandboxListenDenied`, two named `isSandboxListenError`, two written inline.
+They did not agree. #1017 taught only the `cliBridge` copy to respect
+`OMADIA_EXPECT_LOOPBACK`, so on a runner where `bind(127.0.0.1:0)` returns
+`EPERM` the rest still swallowed the failure — including
+`publicMcpPrivacy.e2e`, `publicMcpMaskingAssertion` and
+`devEndpointsAuth.e2e`. A privacy-masking assertion and an auth e2e passing
+green while asserting nothing is the failure family `ci.yml` cites #640 and
+#752 for.
+
+All seven now call one helper in `test/_helpers/listenLoopback.ts`, next to the
+`listenLoopback` they already shared. It honours `OMADIA_EXPECT_LOOPBACK` (the
+CI signal from #1017) and `CI` (the signal the two `test/auth/**` suites had
+grown independently), so no site is weakened and a runner that sets either one
+gets the strict behaviour. `isDeniedListenError` exposes the error shape alone,
+for the two suites that raise a better diagnostic than a bare `EPERM`.
+
+The naming was the second half of the trap: same-named functions with different
+behaviour, while `.env.example` documents a flag that only one of them read.
+
+Guarded against regrowth by `test/sandboxListenGuard.test.ts`: unit cases for
+the helper's four outcomes, plus two greps over the whole test tree asserting
+that nothing else defines the predicate or compares an error code to `EPERM`
+inline. Proven by reverting one call site to its local copy — two assertions go
+red — rather than by observing a green run. The exemption list is two files and
+each is justified in place, because an exclusion list is where a guard goes
+blind. Two guards in this repo have already turned out to prove nothing.
+
 ### Fixed — a stale turn context on the CLI path refuses instead of substituting a principal (#1016)
 
 2026-09-04 — closes the open half of #1016. The capture-timing bug was fixed

--- a/docs/security-architecture.md
+++ b/docs/security-architecture.md
@@ -261,7 +261,31 @@ working across it:
   `triggerRoutineNow` delivers into the routine's *own* `conversationRef`, so
   an unscoped trigger let one principal push messages into another tenant's
   conversation on demand. The operator HTTP router stays deliberately
-  cross-tenant behind `requireAuth`, stated once as `OPERATOR_SCOPE`.
+  cross-tenant, stated once as `OPERATOR_SCOPE`. Precisely: it sits behind
+  `requireAuth`, which verifies the session JWT and, for Entra sessions, the
+  `ADMIN_ALLOWED_EMAILS` whitelist — it checks neither role nor tenant, so
+  the gate is "any valid operator session", not "operators-only" as an
+  earlier draft of this entry claimed.
+
+  **The card path needed a different answer (#1029).** Scoping the smart-card
+  handler from the turn context alone would have broken all four buttons in
+  production. The Teams adapter dispatches card clicks out-of-band —
+  `handleMessage` takes the routine branch and returns before
+  `runOrchestratorTurn`, so `captureRoutineTurn` never fires and the context
+  is always absent there. Refusing on absence is an outage, not a safe
+  default. The contract therefore takes an optional `actor` from the channel,
+  with documented precedence: explicit `actor`, then the turn context, then
+  UNSCOPED as before #1025 — counted by `unscopedActionMetrics` and logged at
+  error level naming the action and id. A hole you can see beats scoping to
+  nobody, and the counter is what tells an operator the adapter-side fix has
+  shipped: the count stops rising and the fallback can be deleted. Teams
+  already holds both fields on the activity (tenant id and
+  `from.aadObjectId`); passing them is the adapter-side follow-up.
+
+  The test for that path deliberately does NOT wrap the call in
+  `routineTurnContext.run`. That wrapper is what made the first version pass
+  while production would have answered "routines are unavailable in this
+  session" on every click.
 
   One ordering bug surfaced while scoping `delete`: the runner unregistered
   the scheduler *before* deleting, so a cross-tenant id silently disarmed

--- a/docs/security-architecture.md
+++ b/docs/security-architecture.md
@@ -217,13 +217,12 @@ working across it:
   both are the same channel-native id written by the same adapter, so they agree
   for a turn that owns its context and disagree exactly when the chain is stale.
   Context present but the turn names no owner ⇒ refuse, that being the stale
-  shape; mismatch ⇒ refuse; no context ⇒ pass. That last row is narrower than
-  the obvious phrasing: `manage_routine` refuses a missing context in `create`
-  and `list` only, while `pause`, `resume` and `delete` never resolve context
-  and pass a bare id to a runner that does no tenant scoping. Passing here
-  neither creates nor closes that hole — it is tracked separately — and the
-  reason to pass is that throwing would harden every context-free HTTP turn,
-  this guard's job being staleness rather than authorization. The refusal names
+  shape; mismatch ⇒ refuse; no context ⇒ pass. When this guard landed, that
+  last row was narrower than the obvious phrasing: `manage_routine` refused a
+  missing context in `create` and `list` only. #1025 closed the rest, so all
+  five actions now resolve context and refuse without it. The reason to pass
+  is still that throwing would harden every context-free HTTP turn, this
+  guard's job being staleness rather than authorization. The refusal names
   neither principal (it reaches the model) and carries a short correlation ref
   that also appears in the server log, so a user's report can be matched to a
   log line without either side naming anyone.
@@ -237,6 +236,47 @@ working across it:
   drift there would look exactly like the supported "no provider installed"
   state. `pluginServiceGrantCoverage.test.ts` catches the undeclared half
   repo-wide.
+- **A routine id is not an authorization (#1025).** `manage_routine` resolved
+  the turn context for `create` and `list` but not for `pause`, `resume` and
+  `delete`, which passed a bare `args.id` to a runner whose store filtered on
+  `WHERE id = $1` alone. Knowing an id was therefore enough to pause, resume
+  or delete any tenant's routine. Ids are uuids and `list` is scoped, so an id
+  had to leak rather than be enumerated — obscurity, not authorization.
+
+  Three things changed. The scope is a required, discriminated argument on the
+  runner (`{ kind: 'channel-user', tenant, userId }` or `{ kind: 'operator' }`)
+  rather than an optional `owner?`, because an optional scope is one a caller
+  can forget and forgetting it is how this arose; a cross-tenant operation is
+  now a greppable `operator` literal instead of an omission. The predicate
+  itself lives in the SQL (`AND tenant = $n AND user_id = $n`), so it cannot
+  be raced by a read-then-act caller and cannot be bypassed by a caller that
+  never supplied a scope. And a scoped miss raises the same
+  `RoutineNotFoundError` as a genuinely absent id, so the error channel is not
+  an existence oracle.
+
+  Two neighbours were the same class of gap and are fixed with it. The
+  smart-card actions in `integration.ts` are a second door onto the same
+  mutations and were equally unscoped — the card carries the id, so a replayed
+  payload reached pause/resume/trigger/delete for any row. And
+  `triggerRoutineNow` delivers into the routine's *own* `conversationRef`, so
+  an unscoped trigger let one principal push messages into another tenant's
+  conversation on demand. The operator HTTP router stays deliberately
+  cross-tenant behind `requireAuth`, stated once as `OPERATOR_SCOPE`.
+
+  One ordering bug surfaced while scoping `delete`: the runner unregistered
+  the scheduler *before* deleting, so a cross-tenant id silently disarmed
+  someone else's cron while the row survived — a routine that still looks
+  active in `list` and never fires again, which is harder to notice than a
+  deleted row. Unregistration now happens only after the scoped delete
+  reports a row was removed.
+
+  Reviewer note: the layer tests stub the store, so they prove the callers
+  *pass* a scope, not that the store *uses* it. Measured — with the SQL
+  predicate removed, all 14 layer tests stayed green. `routineScoping.test.ts`
+  therefore also drives the real `RoutineStore` against a recording pool and
+  follows each `$n` the SQL names into its bound value, which is what makes a
+  dropped predicate fail. Planted-omission results: tool scope dropped 2 red,
+  store predicate dropped 1 red, delete ordering flipped 1 red.
 - **Only advertised tools are dispatchable (#1015).** `tools/call` used to
   forward any name into `dispatch()`. The dispatchable set is wider than the
   advertised one — handler-only registrations stay dispatchable but

--- a/middleware/packages/plugin-api/api-snapshot/plugin-api.d.ts.snap
+++ b/middleware/packages/plugin-api/api-snapshot/plugin-api.d.ts.snap
@@ -2224,6 +2224,10 @@ cron: string;
 handleRoutineAction(input: {
 action: 'pause' | 'resume' | 'trigger_now' | 'delete';
 id: string;
+actor?: {
+tenant: string;
+userId: string;
+};
 }): Promise<string>;
 buildRoutineSmartCardAttachment(input: {
 routine: {

--- a/middleware/packages/plugin-api/package.json
+++ b/middleware/packages/plugin-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omadia/plugin-api",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/middleware/packages/plugin-api/src/routinesIntegration.ts
+++ b/middleware/packages/plugin-api/src/routinesIntegration.ts
@@ -118,10 +118,41 @@ export interface RoutinesIntegration {
    * Handle a button-click from a routine smart-card (Pause / Resume /
    * Trigger-now / Delete). Returns a short German confirmation string
    * the channel renders back into the chat.
+   *
+   * SCOPING (#1025, #1029)
+   * ----------------------
+   * The card carries only the routine id, so without a principal this
+   * entry point can act on any tenant's routine. Precedence for deciding
+   * whose routine may be touched:
+   *
+   *   1. `actor` when supplied — the channel knows who clicked and says so.
+   *   2. the per-turn routine context, when the click happens to arrive
+   *      inside a captured turn.
+   *   3. neither ⇒ the call proceeds UNSCOPED, exactly as it did before
+   *      #1025, and the kernel records an error-level log plus a counter
+   *      naming the action and id.
+   *
+   * Case 3 is deliberate and temporary. Card clicks are dispatched
+   * out-of-band by the Teams adapter (`handleMessage` returns before
+   * `runOrchestratorTurn`, so `captureRoutineTurn` never fires), which
+   * means refusing here would break Pausieren, Aktivieren, Löschen and
+   * Jetzt auslösen for every user today. Silently scoping to nobody would
+   * be worse than an observable hole, so the hole is counted instead.
+   *
+   * Channel adapters SHOULD pass `actor`; Teams already holds both fields
+   * on the activity (tenant id and `from.aadObjectId`). Once it does, the
+   * unscoped fallback can be deleted — tracked as the adapter-side
+   * follow-up to #1025.
    */
   handleRoutineAction(input: {
     action: 'pause' | 'resume' | 'trigger_now' | 'delete';
     id: string;
+    /**
+     * Who clicked. Same (tenant, userId) pair `captureRoutineTurn`
+     * carries, and the same pair the routine row is scoped by, so the
+     * two sources cannot disagree about what "mine" means.
+     */
+    actor?: { tenant: string; userId: string };
   }): Promise<string>;
 
   /**

--- a/middleware/src/plugins/routines/integration.ts
+++ b/middleware/src/plugins/routines/integration.ts
@@ -6,6 +6,10 @@ import {
 import type { RoutinesHandle } from './initRoutines.js';
 import { createProactiveSender } from './genericProactiveSender.js';
 import {
+  actorScope,
+  ROUTINE_NO_CONTEXT_ERROR,
+} from './manageRoutineTool.js';
+import {
   ADAPTIVE_CARD_CONTENT_TYPE,
   buildRoutineListSmartCard,
   buildRoutineSmartCard,
@@ -64,23 +68,35 @@ export function createRoutinesIntegration(
       );
     },
 
+    /**
+     * #1025 — the smart-card buttons are the SECOND door onto the same
+     * mutations as `manage_routine`, and they were equally unscoped: the
+     * card carries the routine id, so a replayed or hand-crafted action
+     * payload reached pause/resume/trigger/delete for any id. Scoped to
+     * the turn's own (tenant, user), and refused outright when the card
+     * fires outside a channel turn, where there is no principal to scope
+     * to and acting anyway would mean acting as nobody.
+     */
     async handleRoutineAction({ action, id }) {
+      const ctx = routineTurnContext.current();
+      if (!ctx) return ROUTINE_NO_CONTEXT_ERROR;
+      const scope = actorScope(ctx);
       if (action === 'pause') {
-        const updated = await handle.runner.pauseRoutine(id);
+        const updated = await handle.runner.pauseRoutine(id, scope);
         return `Routine "${updated.name}" pausiert.`;
       }
       if (action === 'resume') {
-        const updated = await handle.runner.resumeRoutine(id);
+        const updated = await handle.runner.resumeRoutine(id, scope);
         return `Routine "${updated.name}" wieder aktiv.`;
       }
       if (action === 'trigger_now') {
-        const updated = await handle.runner.triggerRoutineNow(id);
+        const updated = await handle.runner.triggerRoutineNow(id, scope);
         const status = updated.lastRunStatus ?? 'ok';
         return status === 'ok'
           ? `Routine "${updated.name}" wurde manuell ausgelöst — Antwort kommt gleich.`
           : `Routine "${updated.name}" lief manuell, aber mit Status "${status}" — siehe Operator-UI für Details.`;
       }
-      const ok = await handle.runner.deleteRoutine(id);
+      const ok = await handle.runner.deleteRoutine(id, scope);
       return ok
         ? 'Routine gelöscht.'
         : 'Routine wurde bereits gelöscht oder nicht gefunden.';

--- a/middleware/src/plugins/routines/integration.ts
+++ b/middleware/src/plugins/routines/integration.ts
@@ -5,10 +5,9 @@ import {
 
 import type { RoutinesHandle } from './initRoutines.js';
 import { createProactiveSender } from './genericProactiveSender.js';
-import {
-  actorScope,
-  ROUTINE_NO_CONTEXT_ERROR,
-} from './manageRoutineTool.js';
+import { actorScope } from './manageRoutineTool.js';
+import type { RoutineActorScope } from './routineRunner.js';
+import { recordUnscopedRoutineAction } from './unscopedActionMetrics.js';
 import {
   ADAPTIVE_CARD_CONTENT_TYPE,
   buildRoutineListSmartCard,
@@ -72,15 +71,37 @@ export function createRoutinesIntegration(
      * #1025 — the smart-card buttons are the SECOND door onto the same
      * mutations as `manage_routine`, and they were equally unscoped: the
      * card carries the routine id, so a replayed or hand-crafted action
-     * payload reached pause/resume/trigger/delete for any id. Scoped to
-     * the turn's own (tenant, user), and refused outright when the card
-     * fires outside a channel turn, where there is no principal to scope
-     * to and acting anyway would mean acting as nobody.
+     * payload reached pause/resume/trigger/delete for any id.
+     *
+     * #1029 — the first version of this refused when no turn context was
+     * present, which would have broken all four buttons in production.
+     * The Teams adapter dispatches card clicks out-of-band: `handleMessage`
+     * takes the routine branch and returns before `runOrchestratorTurn`,
+     * so `captureRoutineTurn` never fires and `current()` is always
+     * undefined on this path. Refusing there is not a safe default, it is
+     * an outage.
+     *
+     * Precedence, documented in the contract next to the `actor` field:
+     *   1. `actor` from the channel — the only source that is correct on
+     *      the out-of-band path, because the adapter holds the activity.
+     *   2. the per-turn context, for clicks that do arrive inside a
+     *      captured turn.
+     *   3. neither ⇒ proceed UNSCOPED as before #1025, and record it.
+     *
+     * Case 3 keeps a known hole open on purpose, and counts every use so
+     * it is observable rather than silent. It disappears the moment the
+     * adapter passes `actor`.
      */
-    async handleRoutineAction({ action, id }) {
+    async handleRoutineAction({ action, id, actor }) {
       const ctx = routineTurnContext.current();
-      if (!ctx) return ROUTINE_NO_CONTEXT_ERROR;
-      const scope = actorScope(ctx);
+      const scope: RoutineActorScope = actor
+        ? { kind: 'channel-user', tenant: actor.tenant, userId: actor.userId }
+        : ctx
+          ? actorScope(ctx)
+          : { kind: 'operator' };
+      if (!actor && !ctx) {
+        recordUnscopedRoutineAction(action, id);
+      }
       if (action === 'pause') {
         const updated = await handle.runner.pauseRoutine(id, scope);
         return `Routine "${updated.name}" pausiert.`;

--- a/middleware/src/plugins/routines/manageRoutineTool.ts
+++ b/middleware/src/plugins/routines/manageRoutineTool.ts
@@ -9,6 +9,7 @@ import {
   RoutineNotFoundError,
   RoutineQuotaExceededError,
   UnknownChannelError,
+  type RoutineActorScope,
   type RoutineRunner,
 } from './routineRunner.js';
 
@@ -281,7 +282,9 @@ export class ManageRoutineTool {
 
   private async handlePause(args: ManageRoutineInput): Promise<string> {
     if (!args.id) return 'Error: `pause` requires `id`.';
-    const updated = await this.runner.pauseRoutine(args.id);
+    const ctx = this.resolveContext();
+    if (!ctx) return ROUTINE_NO_CONTEXT_ERROR;
+    const updated = await this.runner.pauseRoutine(args.id, actorScope(ctx));
     return JSON.stringify({
       action: 'paused',
       routine: summariseRoutine(updated),
@@ -290,7 +293,9 @@ export class ManageRoutineTool {
 
   private async handleResume(args: ManageRoutineInput): Promise<string> {
     if (!args.id) return 'Error: `resume` requires `id`.';
-    const updated = await this.runner.resumeRoutine(args.id);
+    const ctx = this.resolveContext();
+    if (!ctx) return ROUTINE_NO_CONTEXT_ERROR;
+    const updated = await this.runner.resumeRoutine(args.id, actorScope(ctx));
     return JSON.stringify({
       action: 'resumed',
       routine: summariseRoutine(updated),
@@ -299,12 +304,26 @@ export class ManageRoutineTool {
 
   private async handleDelete(args: ManageRoutineInput): Promise<string> {
     if (!args.id) return 'Error: `delete` requires `id`.';
-    const ok = await this.runner.deleteRoutine(args.id);
+    const ctx = this.resolveContext();
+    if (!ctx) return ROUTINE_NO_CONTEXT_ERROR;
+    const ok = await this.runner.deleteRoutine(args.id, actorScope(ctx));
     return JSON.stringify({
       action: ok ? 'deleted' : 'not_found',
       id: args.id,
     });
   }
+}
+
+/**
+ * #1025 — the scope every mutating action runs under. `create` and `list`
+ * always resolved the turn context; `pause`, `resume` and `delete` did not,
+ * and passed a bare id to a runner that filtered on nothing, so knowing an
+ * id was enough to act on another tenant's routine. Every action now
+ * derives its scope from the same context, which is why this helper exists
+ * rather than three inline literals that could drift.
+ */
+export function actorScope(ctx: ManageRoutineContext): RoutineActorScope {
+  return { kind: 'channel-user', tenant: ctx.tenant, userId: ctx.userId };
 }
 
 interface SummarisedRoutine {

--- a/middleware/src/plugins/routines/migrations/0004_routines_output_template.sql
+++ b/middleware/src/plugins/routines/migrations/0004_routines_output_template.sql
@@ -19,8 +19,11 @@
 -- to. JSONB keeps the migration cost low and the routine row
 -- self-contained.
 --
--- See docs/harness-platform/PHASE-C-DESIGN-server-side-templates.md
--- for the type shape (`RoutineOutputTemplate`).
+-- For the type shape see `RoutineOutputTemplate` in
+-- src/plugins/routines/routineOutputTemplate.ts, which validates it and is
+-- therefore the contract. (The former citation pointed into
+-- docs/harness-platform/, a gitignored local tree that resolves for nobody
+-- else.)
 
 ALTER TABLE routines
   ADD COLUMN IF NOT EXISTS output_template JSONB NULL;

--- a/middleware/src/plugins/routines/routineOutputTemplate.ts
+++ b/middleware/src/plugins/routines/routineOutputTemplate.ts
@@ -21,7 +21,10 @@
  * `applyEgressFilter` + Phase A.2 final-scrub for spontaneous-PII
  * protection — same safety net the legacy path enjoys.
  *
- * See docs/harness-platform/PHASE-C-DESIGN-server-side-templates.md
+ * Phase C design note: `docs/harness-platform/` is a gitignored local
+ * tree, so the original citation resolved for nobody else. The shape this
+ * module validates IS the contract — see `parseRoutineOutputTemplate`
+ * below and `routineTemplateRenderer.ts` for how each section renders.
  * for the full architecture, schema migration, and slice plan.
  */
 

--- a/middleware/src/plugins/routines/routineRunner.ts
+++ b/middleware/src/plugins/routines/routineRunner.ts
@@ -52,6 +52,7 @@ import {
   RoutineNameConflictError,
   type CreateRoutineInput,
   type Routine,
+  type RoutineOwner,
   type RoutineRunStatus,
   type RoutineStore,
 } from './routineStore.js';
@@ -69,6 +70,46 @@ export const DEFAULT_MAX_ACTIVE_PER_USER = 50;
 /** Minimum wall-clock interval between two firings. Enforced at create()
  *  time after deriving an estimated period from the cron expression. */
 export const MIN_RUN_INTERVAL_MS = 60_000;
+
+/**
+ * #1025 — who is asking for a routine mutation.
+ *
+ * A discriminated union rather than an optional `owner?` parameter, on
+ * purpose: an optional scope is one a caller can forget, and forgetting it
+ * is exactly how `pause`/`resume`/`delete` came to accept a bare id from
+ * any principal. Here TypeScript makes every call site state which case it
+ * is, so a cross-tenant operation is a deliberate, greppable
+ * `{ kind: 'operator' }` instead of an omission that reads like an
+ * oversight.
+ *
+ *   - `channel-user` — an end user acting through a channel turn. Scoped to
+ *     the (tenant, userId) the turn context carries.
+ *   - `operator`     — the authenticated operator surface, deliberately
+ *     cross-tenant (see the routes' own `requireAuth` rationale).
+ */
+export type RoutineActorScope =
+  | ({ kind: 'channel-user' } & RoutineOwner)
+  | { kind: 'operator' };
+
+/** The store-level owner filter for a scope, or undefined for an operator. */
+function ownerFilter(scope: RoutineActorScope): RoutineOwner | undefined {
+  return scope.kind === 'channel-user'
+    ? { tenant: scope.tenant, userId: scope.userId }
+    : undefined;
+}
+
+/**
+ * Whether an already-loaded row is within a scope. Used where the scope
+ * cannot be pushed into the SQL because the operation reads first and acts
+ * second (`triggerRoutineNow`). Prefer `ownerFilter` and a scoped
+ * statement wherever a single statement can do the job.
+ */
+function ownedBy(routine: Routine, scope: RoutineActorScope): boolean {
+  return (
+    scope.kind === 'operator' ||
+    (routine.tenant === scope.tenant && routine.userId === scope.userId)
+  );
+}
 
 export class RoutineQuotaExceededError extends Error {
   constructor(public readonly limit: number) {
@@ -256,9 +297,18 @@ export class RoutineRunner {
    * complete (or the run errored). Caller (`handleRoutineAction`)
    * surfaces a confirmation back into the chat.
    */
-  async triggerRoutineNow(id: string): Promise<Routine> {
+  async triggerRoutineNow(
+    id: string,
+    scope: RoutineActorScope,
+  ): Promise<Routine> {
     const routine = await this.store.get(id);
-    if (!routine) throw new RoutineNotFoundError(id);
+    // #1025 — scoped for the same reason as delete, and with a sharper
+    // consequence: a run delivers to the routine's OWN conversationRef, so
+    // an unscoped trigger let one principal push messages into another
+    // tenant's conversation on demand.
+    if (!routine || !ownedBy(routine, scope)) {
+      throw new RoutineNotFoundError(id);
+    }
     const controller = new AbortController();
     await this.runOnce(routine, controller.signal, 'manual');
     // Re-read so caller gets the updated last_run_* fields.
@@ -405,15 +455,26 @@ export class RoutineRunner {
     return this.store.listForUser(tenant, userId);
   }
 
-  async pauseRoutine(id: string): Promise<Routine> {
-    const updated = await this.store.setStatus(id, 'paused');
+  async pauseRoutine(id: string, scope: RoutineActorScope): Promise<Routine> {
+    const updated = await this.store.setStatus(
+      id,
+      'paused',
+      ownerFilter(scope),
+    );
+    // A scoped miss and a genuinely missing id both land here, and both
+    // raise the same error: telling a caller "exists, but not yours" would
+    // confirm the id.
     if (!updated) throw new RoutineNotFoundError(id);
     this.unregisterFromScheduler(id);
     return updated;
   }
 
-  async resumeRoutine(id: string): Promise<Routine> {
-    const updated = await this.store.setStatus(id, 'active');
+  async resumeRoutine(id: string, scope: RoutineActorScope): Promise<Routine> {
+    const updated = await this.store.setStatus(
+      id,
+      'active',
+      ownerFilter(scope),
+    );
     if (!updated) throw new RoutineNotFoundError(id);
     if (!this.senders.get(updated.channel)) {
       // Resume the row but report the misconfiguration; trigger will
@@ -426,9 +487,17 @@ export class RoutineRunner {
     return updated;
   }
 
-  async deleteRoutine(id: string): Promise<boolean> {
-    this.unregisterFromScheduler(id);
-    return this.store.delete(id);
+  /**
+   * #1025 — the scheduler is unregistered only AFTER the scoped delete
+   * reports a row was actually removed. The previous order unregistered
+   * first, so a cross-tenant id silently disarmed someone else's cron
+   * while the row survived: the routine then looked active in `list` and
+   * never fired again, which is harder to notice than a deleted row.
+   */
+  async deleteRoutine(id: string, scope: RoutineActorScope): Promise<boolean> {
+    const deleted = await this.store.delete(id, ownerFilter(scope));
+    if (deleted) this.unregisterFromScheduler(id);
+    return deleted;
   }
 
   /**

--- a/middleware/src/plugins/routines/routineStore.ts
+++ b/middleware/src/plugins/routines/routineStore.ts
@@ -53,6 +53,17 @@ export interface RecordRunInput {
   error?: string | null;
 }
 
+/**
+ * #1025 — the (tenant, user_id) pair a scoped mutation must match. Same
+ * pair `listForUser` filters on and `create` enforces uniqueness within,
+ * so "the rows this principal can see" and "the rows it can act on" are
+ * one definition rather than two that can drift apart.
+ */
+export interface RoutineOwner {
+  tenant: string;
+  userId: string;
+}
+
 export interface RoutineStoreOptions {
   pool: Pool;
   log?: (msg: string) => void;
@@ -353,24 +364,49 @@ export class RoutineStore {
    * was not found. The RoutineRunner mirrors the change into the
    * JobScheduler (register on resume, dispose on pause).
    */
-  async setStatus(id: string, status: RoutineStatus): Promise<Routine | null> {
-    const result = await this.pool.query<RoutineRow>(
-      `UPDATE routines
-          SET status = $2, updated_at = now()
-        WHERE id = $1
-        RETURNING ${SELECT_COLUMNS}`,
-      [id, status],
-    );
+  async setStatus(
+    id: string,
+    status: RoutineStatus,
+    owner?: RoutineOwner,
+  ): Promise<Routine | null> {
+    // #1025 — an `owner` narrows the WHERE clause to that (tenant, user_id),
+    // so a row belonging to someone else returns null exactly like a
+    // non-existent id. The predicate lives HERE rather than as a
+    // read-then-act check in the caller: a single statement cannot be
+    // raced, and a caller that forgets the check cannot bypass a scope it
+    // never supplied.
+    const result = owner
+      ? await this.pool.query<RoutineRow>(
+          `UPDATE routines
+              SET status = $2, updated_at = now()
+            WHERE id = $1 AND tenant = $3 AND user_id = $4
+            RETURNING ${SELECT_COLUMNS}`,
+          [id, status, owner.tenant, owner.userId],
+        )
+      : await this.pool.query<RoutineRow>(
+          `UPDATE routines
+              SET status = $2, updated_at = now()
+            WHERE id = $1
+            RETURNING ${SELECT_COLUMNS}`,
+          [id, status],
+        );
     const row = result.rows[0];
     return row ? rowToRoutine(row) : null;
   }
 
-  /** Returns true if a row was deleted. */
-  async delete(id: string): Promise<boolean> {
-    const result = await this.pool.query(
-      'DELETE FROM routines WHERE id = $1',
-      [id],
-    );
+  /**
+   * Returns true if a row was deleted.
+   *
+   * #1025 — see `setStatus`: an `owner` scopes the delete, so another
+   * tenant's id reports false instead of removing the row.
+   */
+  async delete(id: string, owner?: RoutineOwner): Promise<boolean> {
+    const result = owner
+      ? await this.pool.query(
+          'DELETE FROM routines WHERE id = $1 AND tenant = $2 AND user_id = $3',
+          [id, owner.tenant, owner.userId],
+        )
+      : await this.pool.query('DELETE FROM routines WHERE id = $1', [id]);
     return (result.rowCount ?? 0) > 0;
   }
 

--- a/middleware/src/plugins/routines/turnOwnerGuard.ts
+++ b/middleware/src/plugins/routines/turnOwnerGuard.ts
@@ -101,16 +101,18 @@ function idOrUndefined(value: string | undefined): string | undefined {
  * | present | differs  | REFUSE — the bug this issue is about |
  * | present | matches  | pass |
  *
- * On the "absent ⇒ pass" row, stated precisely because the obvious phrasing
- * overclaims: `manage_routine` refuses a missing context in `handleCreate` and
- * `handleList` only. `handlePause`, `handleResume` and `handleDelete` never
- * call `resolveContext` at all — they pass a bare `args.id` to the runner,
- * which does no tenant scoping. So for two of five actions the absent-context
- * case is genuinely covered downstream; for the other three nothing checks,
- * and passing here neither creates nor closes that hole. The reason to pass is
- * narrower than "the tool handles it": throwing on absence would harden every
- * context-free HTTP turn into an error, and this guard's job is staleness, not
- * authorization. The pause/resume/delete scoping gap is tracked separately.
+ * On the "absent ⇒ pass" row: as of #1025 all five `manage_routine` actions
+ * resolve the turn context and refuse without it, and `pause`/`resume`/
+ * `delete`/`trigger` additionally scope the row to the caller's
+ * (tenant, userId) in SQL. So the absent-context case is now genuinely
+ * covered downstream for every action, not just `create` and `list` as it
+ * was when this guard landed.
+ *
+ * Passing here is still the right call, and for a reason narrower than "the
+ * tool handles it": throwing on absence would harden every context-free HTTP
+ * turn into an error, and this guard's job is staleness — a chain carrying
+ * the PREVIOUS turn's principal — not authorization, which is #1025's SQL
+ * predicate.
  */
 export function createRoutineTurnOwnerGuard(
   deps: RoutineTurnOwnerGuardDeps = {},

--- a/middleware/src/plugins/routines/unscopedActionMetrics.ts
+++ b/middleware/src/plugins/routines/unscopedActionMetrics.ts
@@ -1,0 +1,122 @@
+/**
+ * #1025 / #1029 — counters for routine card actions that ran UNSCOPED.
+ *
+ * WHY A FOURTH MODULE OF THIS SHAPE
+ * ---------------------------------
+ * `brokerMetrics` (#578), `securityScreenMetrics` (#749) and
+ * `foreignToolMetrics` (#1008) are three parallel modules with the same
+ * shape and no shared factory. Neither of the existing two fits
+ * semantically — one counts credential-broker denials, the other counts
+ * foreign CLI tool calls — and widening either to carry routine actions
+ * would make its name lie. So this follows the established shape rather
+ * than inventing a pattern, which is the part worth reusing.
+ *
+ * WHAT IT COUNTS
+ * --------------
+ * A smart-card click that reached pause/resume/trigger/delete with no
+ * principal to scope it: no `actor` from the channel and no captured turn
+ * context. Those calls act cross-tenant, exactly as they did before
+ * #1025.
+ *
+ * The expected value is NOT zero, unlike `foreignToolMetrics`. Today the
+ * Teams adapter dispatches card clicks out-of-band and passes no `actor`,
+ * so every click lands here. That is the point: refusing would break all
+ * four buttons in production, and scoping to nobody would be worse than a
+ * hole you can see. The counter is what makes it visible, and what tells
+ * an operator the adapter-side fix has actually shipped — the count stops
+ * rising and the fallback can be deleted.
+ *
+ * Process-scoped and in-memory, same trade as the three modules above:
+ * this answers "is anything still acting unscoped RIGHT NOW", which has to
+ * survive a deployment with no Postgres and no telemetry pool.
+ */
+
+export type UnscopedRoutineAction =
+  | 'pause'
+  | 'resume'
+  | 'trigger_now'
+  | 'delete';
+
+export interface UnscopedRoutineActionMetrics {
+  /** Unscoped card actions since process start. */
+  readonly calls: number;
+  /** Per-action counts, so an operator can see WHICH button is unscoped. */
+  readonly byAction: Readonly<Record<string, number>>;
+  /** Epoch ms of the first occurrence, or undefined while the count is 0. */
+  readonly firstSeenAt: number | undefined;
+  /** Epoch ms of the most recent occurrence, or undefined while 0. */
+  readonly lastSeenAt: number | undefined;
+}
+
+interface MutableState {
+  calls: number;
+  byAction: Record<string, number>;
+  firstSeenAt: number | undefined;
+  lastSeenAt: number | undefined;
+}
+
+function emptyState(): MutableState {
+  return {
+    calls: 0,
+    byAction: {},
+    firstSeenAt: undefined,
+    lastSeenAt: undefined,
+  };
+}
+
+let state: MutableState = emptyState();
+
+function defaultAlert(
+  action: UnscopedRoutineAction,
+  routineId: string,
+  calls: number,
+): void {
+  console.error(
+    `[security] UNSCOPED routine card action "${action}" on routine ` +
+      `"${routineId}" — no actor was supplied and no turn context was ` +
+      'captured, so this ran cross-tenant (#1025). The channel adapter ' +
+      'should pass `actor` on handleRoutineAction. ' +
+      `unscopedRoutineActionsThisProcess=${String(calls)}`,
+  );
+}
+
+/**
+ * Count one unscoped card action and announce it. Never throws: this is
+ * evidence, and evidence must not be able to break the action it is
+ * evidence about — the same contract `recordForeignToolCall` keeps.
+ */
+export function recordUnscopedRoutineAction(
+  action: UnscopedRoutineAction,
+  routineId: string,
+  onAlert: (
+    action: UnscopedRoutineAction,
+    routineId: string,
+    calls: number,
+  ) => void = defaultAlert,
+): void {
+  try {
+    const now = Date.now();
+    state.calls += 1;
+    state.byAction[action] = (state.byAction[action] ?? 0) + 1;
+    state.firstSeenAt ??= now;
+    state.lastSeenAt = now;
+    onAlert(action, routineId, state.calls);
+  } catch {
+    /* counters are best-effort */
+  }
+}
+
+/** An immutable snapshot. Callers cannot mutate the counters through it. */
+export function getUnscopedRoutineActionMetrics(): UnscopedRoutineActionMetrics {
+  return {
+    calls: state.calls,
+    byAction: { ...state.byAction },
+    firstSeenAt: state.firstSeenAt,
+    lastSeenAt: state.lastSeenAt,
+  };
+}
+
+/** Test-only reset. Module state would otherwise leak between test files. */
+export function resetUnscopedRoutineActionMetrics(): void {
+  state = emptyState();
+}

--- a/middleware/src/routes/routines.ts
+++ b/middleware/src/routes/routines.ts
@@ -7,6 +7,7 @@ import {
 } from '../plugins/routines/routineOutputTemplate.js';
 import {
   RoutineNotFoundError,
+  type RoutineActorScope,
   type RoutineRunner,
 } from '../plugins/routines/routineRunner.js';
 import type {
@@ -15,6 +16,15 @@ import type {
 } from '../plugins/routines/routineRunsStore.js';
 import type { Routine, RoutineStore } from '../plugins/routines/routineStore.js';
 import { renderRoutineTemplate } from '../plugins/routines/routineTemplateRenderer.js';
+
+/**
+ * #1025 — every mutation on this router runs cross-tenant, which is a
+ * decision rather than an omission: the whole router is operators-only
+ * behind `requireAuth`, and an operator managing one tenant's routines
+ * from the Operator UI is the feature. Named once so the intent is
+ * greppable and a future non-operator route cannot inherit it by accident.
+ */
+const OPERATOR_SCOPE: RoutineActorScope = { kind: 'operator' };
 
 export interface RoutinesRouterDeps {
   store: RoutineStore;
@@ -210,10 +220,13 @@ export function createRoutinesRouter(deps: RoutinesRouterDeps): Router {
         return;
       }
       try {
+        // #1025 — cross-tenant on purpose, same rationale as the list
+        // above: this router is operators-only behind requireAuth. The
+        // scope is stated rather than omitted so it reads as a decision.
         const updated =
           status === 'paused'
-            ? await deps.runner.pauseRoutine(id)
-            : await deps.runner.resumeRoutine(id);
+            ? await deps.runner.pauseRoutine(id, OPERATOR_SCOPE)
+            : await deps.runner.resumeRoutine(id, OPERATOR_SCOPE);
         const body: RoutineResponse = { routine: toDto(updated) };
         res.json(body);
       } catch (err) {
@@ -275,7 +288,7 @@ export function createRoutinesRouter(deps: RoutinesRouterDeps): Router {
       // arrives via the proactive sender. Return 202 immediately;
       // the run's outcome is observable via `GET /:id/runs`.
       void deps.runner
-        .triggerRoutineNow(id)
+        .triggerRoutineNow(id, OPERATOR_SCOPE)
         .catch((err: unknown) => {
           log(
             `[routines/route] background trigger run for ${id} failed: ${errMsg(err)}`,
@@ -458,7 +471,8 @@ export function createRoutinesRouter(deps: RoutinesRouterDeps): Router {
     const idRaw = req.params['id'];
     const id = typeof idRaw === 'string' ? idRaw : '';
     try {
-      const ok = await deps.runner.deleteRoutine(id);
+      // #1025 — operators-only router, cross-tenant by design (see PATCH).
+      const ok = await deps.runner.deleteRoutine(id, OPERATOR_SCOPE);
       if (!ok) {
         res.status(404).json({
           code: 'routines.not_found',

--- a/middleware/src/routes/routines.ts
+++ b/middleware/src/routes/routines.ts
@@ -19,7 +19,7 @@ import { renderRoutineTemplate } from '../plugins/routines/routineTemplateRender
 
 /**
  * #1025 — every mutation on this router runs cross-tenant, which is a
- * decision rather than an omission: the whole router is operators-only
+ * decision rather than an omission: the whole router sits behind
  * behind `requireAuth`, and an operator managing one tenant's routines
  * from the Operator UI is the feature. Named once so the intent is
  * greppable and a future non-operator route cannot inherit it by accident.
@@ -193,7 +193,7 @@ export function createRoutinesRouter(deps: RoutinesRouterDeps): Router {
     try {
       // Operator view: include paused rows alongside active.
       // Cross-tenant list is acceptable here because the route is behind
-      // requireAuth (operators-only).
+      // requireAuth — any valid operator session, see OPERATOR_SCOPE.
       const rows = await deps.store.listAll();
       const body: ListRoutinesResponse = {
         routines: rows.map(toDto),
@@ -221,7 +221,7 @@ export function createRoutinesRouter(deps: RoutinesRouterDeps): Router {
       }
       try {
         // #1025 — cross-tenant on purpose, same rationale as the list
-        // above: this router is operators-only behind requireAuth. The
+        // above: this router sits behind requireAuth. The
         // scope is stated rather than omitted so it reads as a decision.
         const updated =
           status === 'paused'
@@ -471,7 +471,7 @@ export function createRoutinesRouter(deps: RoutinesRouterDeps): Router {
     const idRaw = req.params['id'];
     const id = typeof idRaw === 'string' ? idRaw : '';
     try {
-      // #1025 — operators-only router, cross-tenant by design (see PATCH).
+      // #1025 — cross-tenant by design on this router (see PATCH).
       const ok = await deps.runner.deleteRoutine(id, OPERATOR_SCOPE);
       if (!ok) {
         res.status(404).json({

--- a/middleware/test/_helpers/listenLoopback.ts
+++ b/middleware/test/_helpers/listenLoopback.ts
@@ -39,3 +39,65 @@ export function listenLoopback(target: {
     server.once('error', reject);
   });
 }
+
+/**
+ * True when the environment is one where a loopback listener MUST work, so a
+ * bind failure is a real defect rather than a sandbox restriction.
+ *
+ * Two signals, because the repo grew two independently:
+ *   - `OMADIA_EXPECT_LOOPBACK=1` — set on the middleware test step in
+ *     `.github/workflows/ci.yml` (#1017).
+ *   - `CI` — the signal the two `test/auth/**` suites already used to turn an
+ *     `EPERM` into a descriptive failure (#640, #752).
+ *
+ * Honouring both means one helper covers every site without weakening any of
+ * them, and a runner that sets only one still gets the strict behaviour.
+ */
+export function loopbackRequired(): boolean {
+  return process.env.OMADIA_EXPECT_LOOPBACK === '1' || Boolean(process.env.CI);
+}
+
+/**
+ * True when the sandbox refused a loopback listener AND this environment
+ * tolerates that, so the caller may self-skip.
+ *
+ * WHY THIS IS SHARED (#1024)
+ * --------------------------
+ * Seven places grew their own copy of this check — three named
+ * `isSandboxListenDenied`, two named `isSandboxListenError`, two written inline
+ * — and they did not agree. #1017 taught the `cliBridge` copy to respect
+ * `OMADIA_EXPECT_LOOPBACK`; the `publicMcp`, `devEndpoints`, `mcpClient` and
+ * `mcpWriteIdempotency` copies kept swallowing the failure, so on a runner
+ * where `bind(127.0.0.1:0)` returns `EPERM` a privacy-masking assertion and an
+ * auth e2e passed green while asserting nothing. That is the failure family
+ * `ci.yml` cites #640 and #752 for: a suite that deletes itself and reports
+ * success.
+ *
+ * Same-named functions with different behaviour were the second half of the
+ * trap — anyone who found `OMADIA_EXPECT_LOOPBACK` documented in
+ * `middleware/.env.example` would reasonably assume it covered all of them.
+ *
+ * Callers that can produce a better diagnostic than a bare `EPERM` should ask
+ * `loopbackRequired()` and throw their own message; the rest can rely on this
+ * returning `false` so their `throw error` path runs.
+ */
+export function isSandboxListenDenied(error: unknown): boolean {
+  if (loopbackRequired()) {
+    return false;
+  }
+  return isDeniedListenError(error);
+}
+
+/**
+ * The error SHAPE only: "this is a refused-listener error", with no opinion on
+ * whether the environment tolerates it.
+ *
+ * Split out because a caller that wants to raise a better diagnostic than a
+ * bare `EPERM` needs both halves separately — `loopbackRequired()` to decide,
+ * and this to confirm the failure is the one it means to explain. Without it
+ * those callers had to re-derive `code === 'EPERM'` inline, which is how two of
+ * the seven #1024 copies came to exist in the first place.
+ */
+export function isDeniedListenError(error: unknown): boolean {
+  return error instanceof Error && 'code' in error && error.code === 'EPERM';
+}

--- a/middleware/test/auth/staticPublicPathsClosedSet.test.ts
+++ b/middleware/test/auth/staticPublicPathsClosedSet.test.ts
@@ -12,6 +12,11 @@ import { EmailWhitelist } from '../../src/auth/whitelist.js';
 import { CIMD_METADATA_PATH } from '../../src/services/mcpCimd.js';
 import { PUBLIC_MCP_PATH } from '../../src/mcp/publicMcpPath.js';
 import { teamsBotMessagingPath } from '../../src/platform/teamsMessagingPath.js';
+import {
+  isDeniedListenError,
+  isSandboxListenDenied,
+  loopbackRequired,
+} from '../_helpers/listenLoopback.js';
 
 /**
  * Epic #470 C12 — `STATIC_PUBLIC_PATHS` is a CLOSED set of CORE-owned entries.
@@ -193,17 +198,21 @@ describe('publicPaths — a path off the closed set 401s before routing (#470 C1
       // Some sandboxes refuse loopback listeners. Locally we self-skip so the
       // rest of the file still runs, but in CI that would silently delete the
       // entire 401 half of this closed-set guard while the job stayed green.
-      if (err instanceof Error && 'code' in err && err.code === 'EPERM') {
-        if (process.env.CI) {
-          throw new Error(
-            'CI must allow a loopback listener for staticPublicPathsClosedSet.test.ts. ' +
-              'Without bind(127.0.0.1:0) the five unauthenticated 401 assertions ' +
-              'would be skipped, which would hide a regression in the closed public-path set.',
-            { cause: err },
-          );
-        }
+      //
+      // #1024 — the EPERM check and the "is loopback required here" decision
+      // now come from the one shared helper, so this suite cannot drift away
+      // from the six others that make the same call.
+      if (isSandboxListenDenied(err)) {
         sandboxDeniedListen = true;
         return;
+      }
+      if (loopbackRequired() && isDeniedListenError(err)) {
+        throw new Error(
+          'CI must allow a loopback listener for staticPublicPathsClosedSet.test.ts. ' +
+            'Without bind(127.0.0.1:0) the five unauthenticated 401 assertions ' +
+            'would be skipped, which would hide a regression in the closed public-path set.',
+          { cause: err },
+        );
       }
       throw err;
     }

--- a/middleware/test/auth/teamsMessagingPublicPath.test.ts
+++ b/middleware/test/auth/teamsMessagingPublicPath.test.ts
@@ -36,6 +36,11 @@ import { createRequireAuth } from '../../src/auth/requireAuth.js';
 import { EmailWhitelist } from '../../src/auth/whitelist.js';
 import { buildTeamsBotMessagingEndpoint } from '../../src/platform/teamsProvisionerService.js';
 import {
+  isDeniedListenError,
+  isSandboxListenDenied,
+  loopbackRequired,
+} from '../_helpers/listenLoopback.js';
+import {
   TEAMS_DEFAULT_MESSAGING_PATH,
   teamsBotMessagingPath,
 } from '../../src/platform/teamsMessagingPath.js';
@@ -106,17 +111,20 @@ describe('the Teams messaging webhook is reachable without a session', () => {
       // loopback listeners, but skipping in CI would delete this whole suite
       // while the job stayed green — the failure mode that let the original bug
       // ship in the first place.
-      if (err instanceof Error && 'code' in err && err.code === 'EPERM') {
-        if (process.env.CI) {
-          throw new Error(
-            'CI must allow a loopback listener for teamsMessagingPublicPath.test.ts. ' +
-              'Without bind(127.0.0.1:0) both halves of this guard — the webhook ' +
-              'being reachable and its siblings staying closed — would be skipped.',
-            { cause: err },
-          );
-        }
+      //
+      // #1024 — both halves of that decision now come from the one shared
+      // helper, so this suite and the six others cannot drift apart.
+      if (isSandboxListenDenied(err)) {
         sandboxDeniedListen = true;
         return;
+      }
+      if (loopbackRequired() && isDeniedListenError(err)) {
+        throw new Error(
+          'CI must allow a loopback listener for teamsMessagingPublicPath.test.ts. ' +
+            'Without bind(127.0.0.1:0) both halves of this guard — the webhook ' +
+            'being reachable and its siblings staying closed — would be skipped.',
+          { cause: err },
+        );
       }
       throw err;
     }

--- a/middleware/test/cliBridge/loopbackMcpServer.test.ts
+++ b/middleware/test/cliBridge/loopbackMcpServer.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, it } from 'node:test';
 
 import { LoopbackMcpServer } from '../../packages/harness-orchestrator/src/loopbackMcpServer.js';
 import type { ToolDispatchService } from '../../packages/harness-orchestrator/src/toolDispatchService.js';
+import { isSandboxListenDenied } from '../_helpers/listenLoopback.js';
 
 function parseMcpJson(text: string): unknown {
   const trimmed = text.trim();
@@ -22,21 +23,9 @@ function parseMcpJson(text: string): unknown {
 
 const MCP_ACCEPT = 'application/json, text/event-stream';
 
-/**
- * True when the sandbox refuses loopback listeners, so the test self-skips.
- *
- * #1017 — every behavioural test in this file, including the OM-82 context
- * test, hangs off this guard. On a runner where listening is denied the whole
- * file therefore passed green while asserting nothing. Setting
- * `OMADIA_EXPECT_LOOPBACK=1` (CI does) makes the guard return false, so the
- * caller rethrows and the suite fails loudly instead of silently skipping.
- */
-function isSandboxListenDenied(error: unknown): boolean {
-  if (process.env.OMADIA_EXPECT_LOOPBACK === '1') {
-    return false;
-  }
-  return error instanceof Error && 'code' in error && error.code === 'EPERM';
-}
+// #1017 gave this file's local guard the `OMADIA_EXPECT_LOOPBACK` behaviour;
+// #1024 moved it to `test/_helpers/listenLoopback.ts` so the six other sites
+// that had grown their own copy share it instead of diverging.
 
 describe('LoopbackMcpServer', () => {
   let server: LoopbackMcpServer | undefined;

--- a/middleware/test/devEndpoints/harness.ts
+++ b/middleware/test/devEndpoints/harness.ts
@@ -68,10 +68,13 @@ export const LEGACY_DEV_PUBLIC_PATH = /^\/api\/dev(?:\/|$|\?)/;
 const SESSION_KEY = new Uint8Array(64).fill(9);
 const OPERATOR_EMAIL = 'operator@example.com';
 
-/** True when the sandbox refuses loopback listeners, so callers can self-skip. */
-export function isSandboxListenDenied(error: unknown): boolean {
-  return error instanceof Error && 'code' in error && error.code === 'EPERM';
-}
+/**
+ * Re-exported so `devEndpointsAuth.e2e`'s six call sites keep their import,
+ * while the behaviour lives in ONE place (#1024). The local copy this replaces
+ * ignored `OMADIA_EXPECT_LOOPBACK`, so on a listener-denied runner the whole
+ * auth e2e passed green without asserting a single 401.
+ */
+export { isSandboxListenDenied } from '../_helpers/listenLoopback.js';
 
 /**
  * A `LifecycleService` that records every call.

--- a/middleware/test/mcpClient.test.ts
+++ b/middleware/test/mcpClient.test.ts
@@ -15,6 +15,7 @@ import {
   type McpServerConfig,
 } from '@omadia/orchestrator';
 import type { ToolDispatchService } from '../packages/harness-orchestrator/src/toolDispatchService.js';
+import { isSandboxListenDenied } from './_helpers/listenLoopback.js';
 
 /**
  * W0-5 — the first REAL `McpManager` → MCP-server round trip in the repo.
@@ -54,11 +55,9 @@ function fakeDispatch(seen: Array<{ name: string; input: unknown }>): ToolDispat
   } as unknown as ToolDispatchService;
 }
 
-function isSandboxListenError(error: unknown): boolean {
-  return (
-    error instanceof Error && 'code' in error && (error as { code?: string }).code === 'EPERM'
-  );
-}
+// #1024 — the local `isSandboxListenError` this replaces ignored
+// `OMADIA_EXPECT_LOOPBACK`, so a listener-denied runner skipped the repo's only
+// real McpManager round trip and still reported success.
 
 /** Count how many times the manager dropped a pooled connection. `close` is the
  *  single invalidation point (connect failure, call failure, stale token). */
@@ -320,7 +319,7 @@ describe('McpManager against a live MCP server (W0-5)', () => {
       servers.push(server);
       return handle.url;
     } catch (error) {
-      if (isSandboxListenError(error)) {
+      if (isSandboxListenDenied(error)) {
         t.skip('sandbox blocks loopback listeners on 127.0.0.1');
         return undefined;
       }

--- a/middleware/test/mcpWriteIdempotency.test.ts
+++ b/middleware/test/mcpWriteIdempotency.test.ts
@@ -25,6 +25,7 @@ import { NativeToolRegistry } from '../packages/harness-orchestrator/src/nativeT
 import { ToolDispatchService } from '../packages/harness-orchestrator/src/toolDispatchService.js';
 import { ToolIdempotencyStore } from '../packages/harness-orchestrator/src/toolIdempotency.js';
 import type { WriteCapability } from '../packages/plugin-api/src/writeCapabilities.js';
+import { isSandboxListenDenied } from './_helpers/listenLoopback.js';
 
 /**
  * #542 prerequisite — duplicate-write protection across the MCP transport retry.
@@ -67,11 +68,9 @@ function forwardableHeaders(headers: IncomingHttpHeaders): Record<string, string
   return out;
 }
 
-function isSandboxListenError(error: unknown): boolean {
-  return (
-    error instanceof Error && 'code' in error && (error as { code?: string }).code === 'EPERM'
-  );
-}
+// #1024 — the local `isSandboxListenError` this replaces ignored
+// `OMADIA_EXPECT_LOOPBACK`, so a listener-denied runner skipped the
+// duplicate-write protection proof and still reported success.
 
 function serverConfig(url: string): McpServerConfig {
   return {
@@ -234,7 +233,7 @@ describe('write-capable MCP tool — duplicate-write protection (#542 prerequisi
       servers.push(server);
       return handle.url;
     } catch (error) {
-      if (isSandboxListenError(error)) {
+      if (isSandboxListenDenied(error)) {
         t.skip('sandbox blocks loopback listeners on 127.0.0.1');
         return undefined;
       }

--- a/middleware/test/publicMcp/harness.ts
+++ b/middleware/test/publicMcp/harness.ts
@@ -78,10 +78,14 @@ export function parseMcpJson(text: string): Record<string, unknown> {
   return JSON.parse(data.join('\n')) as Record<string, unknown>;
 }
 
-/** True when the sandbox refuses loopback listeners, so callers can self-skip. */
-export function isSandboxListenDenied(error: unknown): boolean {
-  return error instanceof Error && 'code' in error && error.code === 'EPERM';
-}
+/**
+ * Re-exported so this harness's five consumers keep their import site, while
+ * the behaviour lives in ONE place (#1024). The local copy this replaces
+ * ignored `OMADIA_EXPECT_LOOPBACK`, so on a listener-denied runner
+ * `publicMcpPrivacy.e2e` and `publicMcpMaskingAssertion` passed green while
+ * asserting nothing about masking.
+ */
+export { isSandboxListenDenied } from '../_helpers/listenLoopback.js';
 
 export interface FakeKey {
   readonly token: string;

--- a/middleware/test/routineRunner.test.ts
+++ b/middleware/test/routineRunner.test.ts
@@ -25,6 +25,7 @@ import {
   UnknownChannelError,
   type JobSchedulerLike,
   type OrchestratorLike,
+  type RoutineActorScope,
 } from '../src/plugins/routines/routineRunner.js';
 import { RoutineNameConflictError } from '../src/plugins/routines/routineStore.js';
 import { routineTurnContext } from '../src/plugins/routines/routineTurnContext.js';
@@ -34,6 +35,7 @@ import type {
   CreateRoutineInput,
   RecordRunInput,
   Routine,
+  RoutineOwner,
   RoutineStatus,
   RoutineStore,
 } from '../src/plugins/routines/routineStore.js';
@@ -165,16 +167,33 @@ class InMemoryRoutineStore implements RoutineStore {
     ).length;
   }
 
-  async setStatus(id: string, status: RoutineStatus): Promise<Routine | null> {
+  async setStatus(
+    id: string,
+    status: RoutineStatus,
+    owner?: RoutineOwner,
+  ): Promise<Routine | null> {
     const existing = this.rows.get(id);
     if (!existing) return null;
+    // #1025 — mirror the SQL predicate: an owner that does not match makes
+    // the row invisible, exactly as `WHERE id = $1 AND tenant = $3 AND
+    // user_id = $4` would. A stub that ignored `owner` would let a scoping
+    // regression pass every runner test.
+    if (owner && (existing.tenant !== owner.tenant || existing.userId !== owner.userId)) {
+      return null;
+    }
     const updated: Routine = { ...existing, status, updatedAt: new Date() };
     this.rows.set(id, updated);
     return updated;
   }
 
-  async delete(id: string): Promise<boolean> {
+  async delete(id: string, owner?: RoutineOwner): Promise<boolean> {
     this.deleteCalls += 1;
+    const existing = this.rows.get(id);
+    if (!existing) return false;
+    // #1025 — same owner predicate as setStatus, see the note there.
+    if (owner && (existing.tenant !== owner.tenant || existing.userId !== owner.userId)) {
+      return false;
+    }
     return this.rows.delete(id);
   }
 
@@ -284,6 +303,17 @@ class StubSender implements ProactiveSender {
 const VALID_CRON = '*/30 * * * *';
 const TENANT = 'tenant-A';
 const USER = 'user-1';
+
+/**
+ * #1025 — the scope every routine mutation now requires. These tests own
+ * their rows as (TENANT, USER), so scoping as that channel user exercises
+ * the same predicate production uses instead of the operator bypass.
+ */
+const OWNER_SCOPE: RoutineActorScope = {
+  kind: 'channel-user',
+  tenant: TENANT,
+  userId: USER,
+};
 
 interface Harness {
   store: InMemoryRoutineStore;
@@ -621,7 +651,7 @@ describe('RoutineRunner — createRoutine', () => {
   it('still reports a conflict when the existing same-name routine is paused', async () => {
     const h = makeHarness();
     const first = await h.runner.createRoutine(baseInput);
-    await h.runner.pauseRoutine(first.id);
+    await h.runner.pauseRoutine(first.id, OWNER_SCOPE);
 
     await assert.rejects(
       () => h.runner.createRoutine(baseInput),
@@ -671,7 +701,7 @@ describe('RoutineRunner — pause / resume / delete', () => {
     const r = await h.runner.createRoutine(baseInput);
     assert.equal(h.scheduler.list().length, 1);
 
-    const updated = await h.runner.pauseRoutine(r.id);
+    const updated = await h.runner.pauseRoutine(r.id, OWNER_SCOPE);
     assert.equal(updated.status, 'paused');
     assert.equal(h.scheduler.list().length, 0);
     assert.equal(h.store.rows.size, 1);
@@ -680,9 +710,9 @@ describe('RoutineRunner — pause / resume / delete', () => {
   it('resume re-registers a paused routine', async () => {
     const h = makeHarness();
     const r = await h.runner.createRoutine(baseInput);
-    await h.runner.pauseRoutine(r.id);
+    await h.runner.pauseRoutine(r.id, OWNER_SCOPE);
 
-    const resumed = await h.runner.resumeRoutine(r.id);
+    const resumed = await h.runner.resumeRoutine(r.id, OWNER_SCOPE);
     assert.equal(resumed.status, 'active');
     assert.equal(h.scheduler.list().length, 1);
   });
@@ -690,11 +720,11 @@ describe('RoutineRunner — pause / resume / delete', () => {
   it('pause / resume / delete throw RoutineNotFoundError on unknown id', async () => {
     const h = makeHarness();
     await assert.rejects(
-      () => h.runner.pauseRoutine('missing'),
+      () => h.runner.pauseRoutine('missing', OWNER_SCOPE),
       RoutineNotFoundError,
     );
     await assert.rejects(
-      () => h.runner.resumeRoutine('missing'),
+      () => h.runner.resumeRoutine('missing', OWNER_SCOPE),
       RoutineNotFoundError,
     );
   });
@@ -702,7 +732,7 @@ describe('RoutineRunner — pause / resume / delete', () => {
   it('delete clears both the row and the scheduler entry', async () => {
     const h = makeHarness();
     const r = await h.runner.createRoutine(baseInput);
-    const ok = await h.runner.deleteRoutine(r.id);
+    const ok = await h.runner.deleteRoutine(r.id, OWNER_SCOPE);
     assert.equal(ok, true);
     assert.equal(h.store.rows.size, 0);
     assert.equal(h.scheduler.list().length, 0);
@@ -830,7 +860,7 @@ describe('RoutineRunner — run-once delivery path', () => {
     });
     const routine = await h.runner.createRoutine(baseInput);
 
-    await h.runner.triggerRoutineNow(routine.id);
+    await h.runner.triggerRoutineNow(routine.id, OWNER_SCOPE);
 
     assert.equal(stub.calls.length, 1);
     assert.equal(sender.calls.length, 1);
@@ -1349,7 +1379,7 @@ describe('live chat-agent resolution (issue #473)', () => {
     // and let resumeRoutine do the scheduler registration (it only warns
     // on a missing sender).
     const row = await h.store.create(baseInput);
-    await h.runner.resumeRoutine(row.id);
+    await h.runner.resumeRoutine(row.id, OWNER_SCOPE);
 
     await h.scheduler.fire(row.id);
 

--- a/middleware/test/routineScoping.test.ts
+++ b/middleware/test/routineScoping.test.ts
@@ -27,6 +27,10 @@ import type {
 } from '../src/plugins/routines/routineStore.js';
 import type { RoutineRunsStore } from '../src/plugins/routines/routineRunsStore.js';
 import { routineTurnContext } from '../src/plugins/routines/routineTurnContext.js';
+import {
+  getUnscopedRoutineActionMetrics,
+  resetUnscopedRoutineActionMetrics,
+} from '../src/plugins/routines/unscopedActionMetrics.js';
 
 /**
  * #1025 — `manage_routine` resolved the turn context for `create` and
@@ -387,6 +391,16 @@ describe('#1025 routineStore — the owner predicate is in the SQL, not just the
 
   const flat = (sql: string): string => sql.replace(/\s+/g, ' ');
 
+  /**
+   * Matches the standalone `id` column only. `/id = \$(\d+)/` would also
+   * match the tail of `user_id = $4`, so on a statement scoped by owner but
+   * NOT by row it reads user_id's placeholder and the assertion passes for
+   * the wrong column — measured, it even matches
+   * `WHERE tenant = $1 AND user_id = $2`, which is precisely the regression
+   * this assertion exists to catch.
+   */
+  const ID_BOUND = /(?:^|[\s(])id = \$(\d+)/;
+
   /** The value the driver substitutes for the `$n` this pattern captures. */
   function boundTo(stmt: Recorded, pattern: RegExp): unknown {
     const match = pattern.exec(flat(stmt.text));
@@ -394,24 +408,33 @@ describe('#1025 routineStore — the owner predicate is in the SQL, not just the
     return stmt.values[Number(match[1]) - 1];
   }
 
-  it('setStatus binds the owner tenant and user_id into its WHERE clause', async () => {
+  /**
+   * #1029 — asserting only tenant and user_id proves the owner predicate is
+   * PRESENT, not that the statement is still row-scoped. Measured: rewriting
+   * the scoped delete to `WHERE tenant = $1 AND user_id = $2` — which deletes
+   * every routine that user owns — left the whole file green. Binding `id`
+   * too is what makes the statement's target part of the contract.
+   */
+  it('setStatus binds id, tenant and user_id into its WHERE clause', async () => {
     const { store, stmts } = recordingStore();
 
     await store.setStatus('r1', 'paused', OWNER);
 
     const stmt = stmts[0];
     assert.ok(stmt);
+    assert.equal(boundTo(stmt, ID_BOUND), 'r1');
     assert.equal(boundTo(stmt, /tenant = \$(\d+)/), OWNER.tenant);
     assert.equal(boundTo(stmt, /user_id = \$(\d+)/), OWNER.userId);
   });
 
-  it('delete binds the owner tenant and user_id into its WHERE clause', async () => {
+  it('delete binds id, tenant and user_id into its WHERE clause', async () => {
     const { store, stmts } = recordingStore();
 
     await store.delete('r1', OWNER);
 
     const stmt = stmts[0];
     assert.ok(stmt);
+    assert.equal(boundTo(stmt, ID_BOUND), 'r1');
     assert.equal(boundTo(stmt, /tenant = \$(\d+)/), OWNER.tenant);
     assert.equal(boundTo(stmt, /user_id = \$(\d+)/), OWNER.userId);
   });
@@ -437,7 +460,7 @@ describe('#1025 smart-card actions — the second door is scoped as well', () =>
     } as unknown as RoutinesHandle);
   }
 
-  it('refuses a foreign id even though the card carries it', async () => {
+  it('scopes from the turn context when the click lands inside a captured turn', async () => {
     const h = makeHarness();
     const foreign = h.store.seed(OTHER);
     const integ = integrationFor(h);
@@ -451,21 +474,80 @@ describe('#1025 smart-card actions — the second door is scoped as well', () =>
     assert.equal(h.store.rows.get(foreign.id)?.status, 'active');
   });
 
-  it('refuses outside a channel turn, where there is no principal to scope to', async () => {
+  /**
+   * #1029 — THE CARD PATH. Deliberately NOT wrapped in
+   * `routineTurnContext.run`: the Teams adapter dispatches card clicks
+   * out-of-band (`handleMessage` returns before `runOrchestratorTurn`, so
+   * `captureRoutineTurn` never fires), which means production always
+   * arrives here with no context and no actor. The wrapper is exactly what
+   * made the first version of this suite pass while all four buttons would
+   * have answered "routines are unavailable in this session".
+   */
+  it('proceeds UNSCOPED and records it when the card supplies neither actor nor context', async () => {
     const h = makeHarness();
     const own = h.store.seed(OWNER);
     const integ = integrationFor(h);
+    resetUnscopedRoutineActionMetrics();
+    // Honest precondition: `enter()` uses `enterWith`, which has no scope
+    // exit, so a leaked value from another test would silently turn this
+    // into the ALS case and prove nothing.
+    assert.equal(routineTurnContext.current(), undefined);
+
+    const out = await integ.handleRoutineAction({
+      action: 'pause',
+      id: own.id,
+    });
+
+    // The action goes through — refusing here is an outage, not a default.
+    assert.match(out, /pausiert/);
+    assert.equal(h.store.rows.get(own.id)?.status, 'paused');
+    // And the hole is observable rather than silent.
+    const metrics = getUnscopedRoutineActionMetrics();
+    assert.equal(metrics.calls, 1);
+    assert.equal(metrics.byAction['pause'], 1);
+  });
+
+  it('scopes from an explicit actor, with no turn context in play', async () => {
+    const h = makeHarness();
+    const foreign = h.store.seed(OTHER);
+    const integ = integrationFor(h);
+    resetUnscopedRoutineActionMetrics();
+    assert.equal(routineTurnContext.current(), undefined);
+
+    // OWNER clicks a card carrying ANOTHER tenant's routine id.
+    await assert.rejects(
+      () =>
+        integ.handleRoutineAction({
+          action: 'pause',
+          id: foreign.id,
+          actor: { tenant: OWNER.tenant, userId: OWNER.userId },
+        }),
+      RoutineNotFoundError,
+    );
+
+    assert.equal(h.store.rows.get(foreign.id)?.status, 'active');
+    // Scoped, so nothing was recorded as unscoped.
+    assert.equal(getUnscopedRoutineActionMetrics().calls, 0);
+  });
+
+  it('lets an explicit actor act on their own routine', async () => {
+    const h = makeHarness();
+    const own = h.store.seed(OWNER);
+    const integ = integrationFor(h);
+    resetUnscopedRoutineActionMetrics();
 
     const out = await integ.handleRoutineAction({
       action: 'delete',
       id: own.id,
+      actor: { tenant: OWNER.tenant, userId: OWNER.userId },
     });
 
-    assert.equal(out, ROUTINE_NO_CONTEXT_ERROR);
-    assert.equal(h.store.rows.has(own.id), true);
+    assert.equal(out, 'Routine gelöscht.');
+    assert.equal(h.store.rows.has(own.id), false);
+    assert.equal(getUnscopedRoutineActionMetrics().calls, 0);
   });
 
-  it('still works for the turn owner', async () => {
+  it('lets the turn owner act on their own routine via the context', async () => {
     const h = makeHarness();
     const own = h.store.seed(OWNER);
     const integ = integrationFor(h);

--- a/middleware/test/routineScoping.test.ts
+++ b/middleware/test/routineScoping.test.ts
@@ -1,0 +1,480 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import type { Pool } from 'pg';
+
+import { InMemoryProactiveSenderRegistry } from '../src/plugins/routines/proactiveSender.js';
+import { createRoutinesIntegration } from '../src/plugins/routines/integration.js';
+import type { RoutinesHandle } from '../src/plugins/routines/initRoutines.js';
+import {
+  ManageRoutineTool,
+  ROUTINE_NO_CONTEXT_ERROR,
+  type ManageRoutineContext,
+} from '../src/plugins/routines/manageRoutineTool.js';
+import {
+  RoutineNotFoundError,
+  RoutineRunner,
+  type JobSchedulerLike,
+  type OrchestratorLike,
+  type RoutineActorScope,
+} from '../src/plugins/routines/routineRunner.js';
+import { RoutineStore } from '../src/plugins/routines/routineStore.js';
+import type {
+  CreateRoutineInput,
+  Routine,
+  RoutineOwner,
+  RoutineStatus,
+} from '../src/plugins/routines/routineStore.js';
+import type { RoutineRunsStore } from '../src/plugins/routines/routineRunsStore.js';
+import { routineTurnContext } from '../src/plugins/routines/routineTurnContext.js';
+
+/**
+ * #1025 — `manage_routine` resolved the turn context for `create` and
+ * `list` but not for `pause`, `resume` and `delete`. Those three passed a
+ * bare id to a runner that filtered on nothing, so knowing an id was
+ * enough to act on another tenant's routine. Routine ids are uuids and
+ * `list` is scoped, so the barrier was that an id had to leak — obscurity,
+ * not authorization.
+ *
+ * These tests drive the REAL tool, the REAL runner and the REAL smart-card
+ * integration. The only stub is the store, and it mirrors the SQL owner
+ * predicate rather than ignoring it — a stub that ignored `owner` would let
+ * the whole scoping change be reverted with every test still green, which
+ * is the failure mode this file exists to rule out.
+ */
+
+const OWNER: RoutineOwner = { tenant: 'tenant-A', userId: 'user-1' };
+const OTHER: RoutineOwner = { tenant: 'tenant-B', userId: 'user-9' };
+
+const OWNER_CTX: ManageRoutineContext = {
+  tenant: OWNER.tenant,
+  userId: OWNER.userId,
+  channel: 'teams',
+  conversationRef: { conversation: { id: 'conv-1' } },
+};
+
+/** The scope a channel turn for OWNER produces. */
+const OWNER_SCOPE: RoutineActorScope = {
+  kind: 'channel-user',
+  tenant: OWNER.tenant,
+  userId: OWNER.userId,
+};
+
+/** A deterministic, schema-valid v4 uuid for the nth seeded row. */
+function uuidForSeq(n: number): string {
+  const tail = String(n).padStart(12, '0');
+  return `00000000-0000-4000-8000-${tail}`;
+}
+
+function matchesOwner(row: Routine, owner?: RoutineOwner): boolean {
+  return (
+    owner === undefined ||
+    (row.tenant === owner.tenant && row.userId === owner.userId)
+  );
+}
+
+/** Store stub whose owner predicate mirrors the scoped SQL. */
+class ScopedStoreStub {
+  readonly rows = new Map<string, Routine>();
+  private seq = 1;
+
+  /**
+   * `manage_routine` validates `id` as a uuid, so a readable stub id like
+   * `routine-1` fails input validation before any scoping runs and every
+   * assertion below would pass for the wrong reason.
+   */
+  seed(owner: RoutineOwner, over: Partial<Routine> = {}): Routine {
+    const id = over.id ?? uuidForSeq(this.seq++);
+    const now = new Date();
+    const row: Routine = {
+      id,
+      tenant: owner.tenant,
+      userId: owner.userId,
+      name: `routine-${id}`,
+      cron: '*/30 * * * *',
+      prompt: 'Sag hallo',
+      channel: 'teams',
+      conversationRef: { conversation: { id: `conv-${id}` } },
+      status: 'active',
+      timeoutMs: 600_000,
+      createdAt: now,
+      updatedAt: now,
+      lastRunAt: null,
+      lastRunStatus: null,
+      lastRunError: null,
+      outputTemplate: null,
+      ...over,
+    };
+    this.rows.set(row.id, row);
+    return row;
+  }
+
+  async create(input: CreateRoutineInput): Promise<Routine> {
+    return this.seed(
+      { tenant: input.tenant, userId: input.userId },
+      { name: input.name, cron: input.cron, prompt: input.prompt },
+    );
+  }
+
+  async get(id: string): Promise<Routine | null> {
+    return this.rows.get(id) ?? null;
+  }
+
+  async getByName(): Promise<Routine | null> {
+    return null;
+  }
+
+  async listForUser(tenant: string, userId: string): Promise<Routine[]> {
+    return [...this.rows.values()].filter(
+      (r) => r.tenant === tenant && r.userId === userId,
+    );
+  }
+
+  async listAllActive(): Promise<Routine[]> {
+    return [...this.rows.values()].filter((r) => r.status === 'active');
+  }
+
+  async listAll(): Promise<Routine[]> {
+    return [...this.rows.values()];
+  }
+
+  async countActiveForUser(): Promise<number> {
+    return 0;
+  }
+
+  async setStatus(
+    id: string,
+    status: RoutineStatus,
+    owner?: RoutineOwner,
+  ): Promise<Routine | null> {
+    const row = this.rows.get(id);
+    if (!row || !matchesOwner(row, owner)) return null;
+    const updated: Routine = { ...row, status, updatedAt: new Date() };
+    this.rows.set(id, updated);
+    return updated;
+  }
+
+  async delete(id: string, owner?: RoutineOwner): Promise<boolean> {
+    const row = this.rows.get(id);
+    if (!row || !matchesOwner(row, owner)) return false;
+    return this.rows.delete(id);
+  }
+
+  async recordRun(): Promise<void> {}
+}
+
+/** Scheduler stub that records which routine ids were unregistered. */
+class TrackingScheduler implements JobSchedulerLike {
+  readonly registered = new Set<string>();
+  readonly unregistered: string[] = [];
+
+  register(_agentId: string, spec: { name: string }): () => void {
+    this.registered.add(spec.name);
+    return () => {
+      this.registered.delete(spec.name);
+      this.unregistered.push(spec.name);
+    };
+  }
+
+  stopForPlugin(): void {}
+
+  list(): ReadonlyArray<{ agentId: string; name: string }> {
+    return [];
+  }
+}
+
+interface Harness {
+  store: ScopedStoreStub;
+  scheduler: TrackingScheduler;
+  runner: RoutineRunner;
+  tool: ManageRoutineTool;
+  runs: string[];
+}
+
+function makeHarness(
+  resolveContext: () => ManageRoutineContext | undefined = () => OWNER_CTX,
+): Harness {
+  const store = new ScopedStoreStub();
+  const scheduler = new TrackingScheduler();
+  const runs: string[] = [];
+  const orchestrator: OrchestratorLike = {
+    async runTurn(input: { userMessage: string }) {
+      runs.push(input.userMessage);
+      return { text: 'ok' };
+    },
+  } as unknown as OrchestratorLike;
+  const senderRegistry = new InMemoryProactiveSenderRegistry();
+  senderRegistry.register({
+    channel: 'teams',
+    async send() {},
+  } as never);
+  const runner = new RoutineRunner({
+    store: store as unknown as RoutineStore,
+    runsStore: {
+      async insert() {
+        return null;
+      },
+      async listForRoutine() {
+        return [];
+      },
+      async get() {
+        return null;
+      },
+    } as unknown as RoutineRunsStore,
+    scheduler,
+    getOrchestrator: () => orchestrator,
+    senderRegistry,
+    log: () => {},
+  });
+  const tool = new ManageRoutineTool({ runner, resolveContext });
+  return { store, scheduler, runner, tool, runs };
+}
+
+describe('#1025 manage_routine — pause/resume/delete refuse without a turn context', () => {
+  for (const action of ['pause', 'resume', 'delete'] as const) {
+    it(`${action} returns the no-context error instead of acting on a bare id`, async () => {
+      const h = makeHarness(() => undefined);
+      const row = h.store.seed(OWNER);
+
+      const out = await h.tool.handle({ action, id: row.id });
+
+      assert.equal(out, ROUTINE_NO_CONTEXT_ERROR);
+      // The row is untouched: still present, still active.
+      assert.equal(h.store.rows.get(row.id)?.status, 'active');
+      assert.equal(h.store.rows.size, 1);
+    });
+  }
+});
+
+describe('#1025 manage_routine — another tenant\'s id is not actionable', () => {
+  it('pause reports not-found and leaves the foreign routine active', async () => {
+    const h = makeHarness();
+    const foreign = h.store.seed(OTHER);
+
+    const out = await h.tool.handle({ action: 'pause', id: foreign.id });
+
+    assert.match(out, /^Error: /);
+    assert.equal(h.store.rows.get(foreign.id)?.status, 'active');
+  });
+
+  it('resume reports not-found and leaves the foreign routine paused', async () => {
+    const h = makeHarness();
+    const foreign = h.store.seed(OTHER, { status: 'paused' });
+
+    const out = await h.tool.handle({ action: 'resume', id: foreign.id });
+
+    assert.match(out, /^Error: /);
+    assert.equal(h.store.rows.get(foreign.id)?.status, 'paused');
+  });
+
+  it('delete reports not_found and the foreign routine survives', async () => {
+    const h = makeHarness();
+    const foreign = h.store.seed(OTHER);
+
+    const out = await h.tool.handle({ action: 'delete', id: foreign.id });
+
+    assert.equal(JSON.parse(out).action, 'not_found');
+    assert.equal(h.store.rows.has(foreign.id), true);
+  });
+
+  it('the refusal does not disclose that the id exists', async () => {
+    const h = makeHarness();
+    const foreign = h.store.seed(OTHER);
+
+    const onForeign = await h.tool.handle({ action: 'pause', id: foreign.id });
+    const onAbsent = await h.tool.handle({
+      action: 'pause',
+      id: '11111111-1111-4111-8111-111111111111',
+    });
+
+    // Same shape for "exists but not yours" and "does not exist": anything
+    // else turns the error channel into an existence oracle.
+    assert.equal(
+      onForeign.replace(foreign.id, 'ID'),
+      onAbsent.replace('11111111-1111-4111-8111-111111111111', 'ID'),
+    );
+  });
+});
+
+describe('#1025 manage_routine — the owner still acts on their own routines', () => {
+  it('pause, resume and delete all succeed for the caller\'s own row', async () => {
+    const h = makeHarness();
+    const own = h.store.seed(OWNER);
+
+    const paused = await h.tool.handle({ action: 'pause', id: own.id });
+    assert.equal(JSON.parse(paused).action, 'paused');
+    assert.equal(h.store.rows.get(own.id)?.status, 'paused');
+
+    const resumed = await h.tool.handle({ action: 'resume', id: own.id });
+    assert.equal(JSON.parse(resumed).action, 'resumed');
+    assert.equal(h.store.rows.get(own.id)?.status, 'active');
+
+    const deleted = await h.tool.handle({ action: 'delete', id: own.id });
+    assert.equal(JSON.parse(deleted).action, 'deleted');
+    assert.equal(h.store.rows.has(own.id), false);
+  });
+});
+
+describe('#1025 runner — trigger and delete are scoped too', () => {
+  it('triggerRoutineNow refuses a foreign id and never runs the turn', async () => {
+    const h = makeHarness();
+    const foreign = h.store.seed(OTHER);
+
+    await assert.rejects(
+      () => h.runner.triggerRoutineNow(foreign.id, OWNER_SCOPE),
+      RoutineNotFoundError,
+    );
+    // The decisive assertion: a run would have delivered into the OTHER
+    // tenant's conversationRef.
+    assert.equal(h.runs.length, 0);
+  });
+
+  it('a refused delete does not disarm the foreign routine\'s schedule', async () => {
+    const h = makeHarness();
+    const foreign = h.store.seed(OTHER);
+    await h.runner.resumeRoutine(foreign.id, { kind: 'operator' });
+    assert.equal(h.scheduler.registered.has(foreign.id), true);
+
+    const ok = await h.runner.deleteRoutine(foreign.id, OWNER_SCOPE);
+
+    assert.equal(ok, false);
+    // The old order unregistered BEFORE deleting, so a cross-tenant id
+    // silently stopped someone else's cron while the row survived — a
+    // routine that looks active in `list` and never fires again.
+    assert.deepEqual(h.scheduler.unregistered, []);
+    assert.equal(h.scheduler.registered.has(foreign.id), true);
+  });
+
+  it('an operator scope still reaches across tenants, by design', async () => {
+    const h = makeHarness();
+    const foreign = h.store.seed(OTHER);
+
+    const paused = await h.runner.pauseRoutine(foreign.id, {
+      kind: 'operator',
+    });
+
+    assert.equal(paused.status, 'paused');
+  });
+});
+
+/**
+ * The suites above stub the store, so they prove the tool/runner/integration
+ * layers PASS a scope. They cannot prove the store USES it: a stub that
+ * mirrors the owner predicate stays green even if the real SQL drops it.
+ * (Measured: removing the predicate from `routineStore` left all 14 green.)
+ *
+ * This suite closes that hole without Postgres, using the recording-pool
+ * pattern from `publicMcpKeyBindingsAdmin.test.ts`: capture the statement,
+ * then follow each `$n` the SQL names into the parameter array, so a swap
+ * on either side is caught by the other.
+ */
+describe('#1025 routineStore — the owner predicate is in the SQL, not just the caller', () => {
+  interface Recorded {
+    text: string;
+    values: unknown[];
+  }
+
+  function recordingStore(): { store: RoutineStore; stmts: Recorded[] } {
+    const stmts: Recorded[] = [];
+    const pool = {
+      async query(text: string, values?: unknown[]) {
+        stmts.push({ text, values: values ?? [] });
+        return { rows: [], rowCount: 0 };
+      },
+    } as unknown as Pool;
+    return { store: new RoutineStore({ pool, log: () => {} }), stmts };
+  }
+
+  const flat = (sql: string): string => sql.replace(/\s+/g, ' ');
+
+  /** The value the driver substitutes for the `$n` this pattern captures. */
+  function boundTo(stmt: Recorded, pattern: RegExp): unknown {
+    const match = pattern.exec(flat(stmt.text));
+    assert.ok(match, `SQL does not match ${pattern}: ${flat(stmt.text)}`);
+    return stmt.values[Number(match[1]) - 1];
+  }
+
+  it('setStatus binds the owner tenant and user_id into its WHERE clause', async () => {
+    const { store, stmts } = recordingStore();
+
+    await store.setStatus('r1', 'paused', OWNER);
+
+    const stmt = stmts[0];
+    assert.ok(stmt);
+    assert.equal(boundTo(stmt, /tenant = \$(\d+)/), OWNER.tenant);
+    assert.equal(boundTo(stmt, /user_id = \$(\d+)/), OWNER.userId);
+  });
+
+  it('delete binds the owner tenant and user_id into its WHERE clause', async () => {
+    const { store, stmts } = recordingStore();
+
+    await store.delete('r1', OWNER);
+
+    const stmt = stmts[0];
+    assert.ok(stmt);
+    assert.equal(boundTo(stmt, /tenant = \$(\d+)/), OWNER.tenant);
+    assert.equal(boundTo(stmt, /user_id = \$(\d+)/), OWNER.userId);
+  });
+
+  it('omits the predicate entirely for an unscoped (operator) call', async () => {
+    const { store, stmts } = recordingStore();
+
+    await store.setStatus('r1', 'paused');
+    await store.delete('r1');
+
+    for (const stmt of stmts) {
+      assert.doesNotMatch(flat(stmt.text), /tenant = \$/);
+      assert.doesNotMatch(flat(stmt.text), /user_id = \$/);
+    }
+  });
+});
+
+describe('#1025 smart-card actions — the second door is scoped as well', () => {
+  function integrationFor(h: Harness) {
+    return createRoutinesIntegration({
+      store: h.store as unknown as RoutineStore,
+      runner: h.runner,
+    } as unknown as RoutinesHandle);
+  }
+
+  it('refuses a foreign id even though the card carries it', async () => {
+    const h = makeHarness();
+    const foreign = h.store.seed(OTHER);
+    const integ = integrationFor(h);
+
+    await routineTurnContext.run(OWNER_CTX, async () => {
+      await assert.rejects(
+        () => integ.handleRoutineAction({ action: 'pause', id: foreign.id }),
+        RoutineNotFoundError,
+      );
+    });
+    assert.equal(h.store.rows.get(foreign.id)?.status, 'active');
+  });
+
+  it('refuses outside a channel turn, where there is no principal to scope to', async () => {
+    const h = makeHarness();
+    const own = h.store.seed(OWNER);
+    const integ = integrationFor(h);
+
+    const out = await integ.handleRoutineAction({
+      action: 'delete',
+      id: own.id,
+    });
+
+    assert.equal(out, ROUTINE_NO_CONTEXT_ERROR);
+    assert.equal(h.store.rows.has(own.id), true);
+  });
+
+  it('still works for the turn owner', async () => {
+    const h = makeHarness();
+    const own = h.store.seed(OWNER);
+    const integ = integrationFor(h);
+
+    const out = await routineTurnContext.run(OWNER_CTX, () =>
+      integ.handleRoutineAction({ action: 'pause', id: own.id }),
+    );
+
+    assert.match(out, /pausiert/);
+    assert.equal(h.store.rows.get(own.id)?.status, 'paused');
+  });
+});

--- a/middleware/test/sandboxListenGuard.test.ts
+++ b/middleware/test/sandboxListenGuard.test.ts
@@ -1,0 +1,174 @@
+import { strict as assert } from 'node:assert';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+
+import { isSandboxListenDenied, loopbackRequired } from './_helpers/listenLoopback.js';
+
+/**
+ * #1024 — one guard, seven call sites, and a grep so an eighth cannot appear.
+ *
+ * WHY THIS FILE EXISTS AT ALL
+ * ---------------------------
+ * Seven places had grown their own version of "the sandbox refused a loopback
+ * listener, so skip". Three were named `isSandboxListenDenied`, two
+ * `isSandboxListenError`, two were written inline — and they did not agree.
+ * #1017 taught only the `cliBridge` copy to respect `OMADIA_EXPECT_LOOPBACK`,
+ * so on a runner where `bind(127.0.0.1:0)` returns `EPERM`
+ * `publicMcpPrivacy.e2e`, `publicMcpMaskingAssertion` and
+ * `devEndpointsAuth.e2e` still deleted themselves and reported success. A
+ * privacy-masking assertion and an auth e2e are the last two suites that
+ * should be able to do that.
+ *
+ * WHY A GREP GUARD AND NOT JUST THE UNIT TEST
+ * -------------------------------------------
+ * The unit test below pins the helper's behaviour. It cannot notice a NEW
+ * eighth copy appearing beside it — which is exactly how this spread in the
+ * first place: each author reasonably wrote three lines rather than hunting
+ * for a shared one. Two "guards" in this repo have already turned out to prove
+ * nothing (a deny-list drift check that built its candidates from the list it
+ * was checking, and a service-grant scanner that skipped the very verb the
+ * code used), so this file states its own blind spot and covers it.
+ */
+
+/** Every `.ts` under `middleware/test`, so a new copy anywhere is in scope. */
+function testTreeFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      testTreeFiles(full, out);
+      continue;
+    }
+    if (entry.endsWith('.ts') || entry.endsWith('.mts')) out.push(full);
+  }
+  return out;
+}
+
+const TEST_ROOT = new URL('.', import.meta.url).pathname;
+const HELPER = join(TEST_ROOT, '_helpers', 'listenLoopback.ts');
+
+/**
+ * Files the scans below cannot include, and why — stated rather than quietly
+ * filtered, because a guard's exclusion list is where a guard goes blind.
+ *
+ *   - the helper: it is the one place that MAY define the predicate.
+ *   - this file: it necessarily contains the very literals it searches for,
+ *     namely the regex source on the next few lines and the doc comment that
+ *     explains it. Nothing else here can hide a rogue guard, since a copy
+ *     defined inside its own detector would still fail the `defined in exactly
+ *     one place` assertion above.
+ */
+const SCAN_EXEMPT = new Set([HELPER, join(TEST_ROOT, 'sandboxListenGuard.test.ts')]);
+
+describe('sandbox loopback guard (#1024)', () => {
+  const eperm = (): Error => Object.assign(new Error('listen EPERM'), { code: 'EPERM' });
+
+  it('skips on EPERM when the environment tolerates a denied listener', () => {
+    const saved = { flag: process.env.OMADIA_EXPECT_LOOPBACK, ci: process.env.CI };
+    delete process.env.OMADIA_EXPECT_LOOPBACK;
+    delete process.env.CI;
+    try {
+      assert.equal(loopbackRequired(), false);
+      assert.equal(isSandboxListenDenied(eperm()), true);
+    } finally {
+      if (saved.flag !== undefined) process.env.OMADIA_EXPECT_LOOPBACK = saved.flag;
+      if (saved.ci !== undefined) process.env.CI = saved.ci;
+    }
+  });
+
+  /**
+   * The load-bearing case. Before #1017/#1024 this returned `true` at six of
+   * the seven sites, which turned a bind failure into a green suite.
+   */
+  it('refuses to skip on EPERM when OMADIA_EXPECT_LOOPBACK is set', () => {
+    const saved = { flag: process.env.OMADIA_EXPECT_LOOPBACK, ci: process.env.CI };
+    process.env.OMADIA_EXPECT_LOOPBACK = '1';
+    delete process.env.CI;
+    try {
+      assert.equal(loopbackRequired(), true);
+      assert.equal(isSandboxListenDenied(eperm()), false);
+    } finally {
+      delete process.env.OMADIA_EXPECT_LOOPBACK;
+      if (saved.flag !== undefined) process.env.OMADIA_EXPECT_LOOPBACK = saved.flag;
+      if (saved.ci !== undefined) process.env.CI = saved.ci;
+    }
+  });
+
+  /** `CI` is the signal the two `test/auth/**` suites already used. */
+  it('refuses to skip on EPERM when CI is set', () => {
+    const saved = { flag: process.env.OMADIA_EXPECT_LOOPBACK, ci: process.env.CI };
+    delete process.env.OMADIA_EXPECT_LOOPBACK;
+    process.env.CI = 'true';
+    try {
+      assert.equal(loopbackRequired(), true);
+      assert.equal(isSandboxListenDenied(eperm()), false);
+    } finally {
+      delete process.env.CI;
+      if (saved.flag !== undefined) process.env.OMADIA_EXPECT_LOOPBACK = saved.flag;
+      if (saved.ci !== undefined) process.env.CI = saved.ci;
+    }
+  });
+
+  it('never swallows an error that is not a denied listener', () => {
+    const saved = { flag: process.env.OMADIA_EXPECT_LOOPBACK, ci: process.env.CI };
+    delete process.env.OMADIA_EXPECT_LOOPBACK;
+    delete process.env.CI;
+    try {
+      const inUse = Object.assign(new Error('listen EADDRINUSE'), { code: 'EADDRINUSE' });
+      assert.equal(isSandboxListenDenied(inUse), false);
+      assert.equal(isSandboxListenDenied(new Error('plain')), false);
+      assert.equal(isSandboxListenDenied('EPERM'), false);
+      assert.equal(isSandboxListenDenied(undefined), false);
+    } finally {
+      if (saved.flag !== undefined) process.env.OMADIA_EXPECT_LOOPBACK = saved.flag;
+      if (saved.ci !== undefined) process.env.CI = saved.ci;
+    }
+  });
+
+  /**
+   * The anti-regrowth half: only the shared helper may DEFINE this predicate.
+   * Importing and calling it is what every other file should do.
+   */
+  it('is defined in exactly one place under middleware/test', () => {
+    const definition = /(?:function|const)\s+isSandboxListen[A-Za-z]*\s*[(:=]/;
+    const offenders = testTreeFiles(TEST_ROOT)
+      .filter((file) => !SCAN_EXEMPT.has(file))
+      .filter((file) => definition.test(readFileSync(file, 'utf8')))
+      .map((file) => file.slice(TEST_ROOT.length));
+
+    assert.deepEqual(
+      offenders,
+      [],
+      `These files define their own sandbox-listen guard instead of importing ` +
+        `the shared one from test/_helpers/listenLoopback.ts: ${offenders.join(', ')}. ` +
+        `A local copy will not honour OMADIA_EXPECT_LOOPBACK, so the suite ` +
+        `silently deletes itself on a listener-denied runner (#1024).`,
+    );
+  });
+
+  /** A bare inline `code === 'EPERM'` is the same bug without a function name. */
+  it('has no inline EPERM listener check outside the shared helper', () => {
+    const inline = /code\s*===\s*'EPERM'/;
+    const offenders = testTreeFiles(TEST_ROOT)
+      .filter((file) => !SCAN_EXEMPT.has(file))
+      .filter((file) => inline.test(readFileSync(file, 'utf8')))
+      .map((file) => file.slice(TEST_ROOT.length));
+
+    assert.deepEqual(
+      offenders,
+      [],
+      `These files compare an error code to 'EPERM' inline instead of calling ` +
+        `isSandboxListenDenied / loopbackRequired: ${offenders.join(', ')}. ` +
+        `An inline check cannot honour OMADIA_EXPECT_LOOPBACK (#1024).`,
+    );
+  });
+
+  /** The flag has to stay discoverable, or the next author writes a local copy. */
+  it('documents the flag in .env.example', () => {
+    const env = readFileSync(join(TEST_ROOT, '..', '.env.example'), 'utf8');
+    assert.ok(
+      env.includes('OMADIA_EXPECT_LOOPBACK'),
+      '.env.example must document OMADIA_EXPECT_LOOPBACK so the guard is discoverable',
+    );
+  });
+});

--- a/middleware/test/sandboxListenGuard.test.ts
+++ b/middleware/test/sandboxListenGuard.test.ts
@@ -1,6 +1,7 @@
 import { strict as assert } from 'node:assert';
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, it } from 'node:test';
 
 import { isSandboxListenDenied, loopbackRequired } from './_helpers/listenLoopback.js';
@@ -31,7 +32,29 @@ import { isSandboxListenDenied, loopbackRequired } from './_helpers/listenLoopba
  * code used), so this file states its own blind spot and covers it.
  */
 
-/** Every `.ts` under `middleware/test`, so a new copy anywhere is in scope. */
+/**
+ * Every source file under `middleware/test`, so a new copy anywhere is in
+ * scope.
+ *
+ * #1029 — this used to collect `.ts` and `.mts` only. A rogue guard in a
+ * `.js` test helper, a `.cts` fixture or a `.tsx` file was invisible to
+ * both scans below, which is the same "the guard has an exclusion list and
+ * the exclusion list is where it goes blind" failure the doc comment warns
+ * about. Extensions are enumerated rather than "anything not a directory"
+ * because the tree also holds `.json`, `.sql` and binary fixtures whose
+ * contents would produce noise, not signal.
+ */
+const SCANNED_EXTENSIONS = [
+  '.ts',
+  '.mts',
+  '.cts',
+  '.tsx',
+  '.js',
+  '.mjs',
+  '.cjs',
+  '.jsx',
+];
+
 function testTreeFiles(dir: string, out: string[] = []): string[] {
   for (const entry of readdirSync(dir)) {
     const full = join(dir, entry);
@@ -39,12 +62,19 @@ function testTreeFiles(dir: string, out: string[] = []): string[] {
       testTreeFiles(full, out);
       continue;
     }
-    if (entry.endsWith('.ts') || entry.endsWith('.mts')) out.push(full);
+    if (SCANNED_EXTENSIONS.some((ext) => entry.endsWith(ext))) out.push(full);
   }
   return out;
 }
 
-const TEST_ROOT = new URL('.', import.meta.url).pathname;
+/**
+ * #1029 — `new URL('.', import.meta.url).pathname` leaves percent-encoding
+ * in place, so a checkout path containing a space or any character needing
+ * escaping yields a directory that does not exist. `readdirSync` would then
+ * throw, or worse the scan would walk nothing and report zero offenders:
+ * a guard that fails OPEN. `fileURLToPath` decodes properly.
+ */
+const TEST_ROOT = fileURLToPath(new URL('.', import.meta.url));
 const HELPER = join(TEST_ROOT, '_helpers', 'listenLoopback.ts');
 
 /**
@@ -147,20 +177,100 @@ describe('sandbox loopback guard (#1024)', () => {
   });
 
   /** A bare inline `code === 'EPERM'` is the same bug without a function name. */
-  it('has no inline EPERM listener check outside the shared helper', () => {
-    const inline = /code\s*===\s*'EPERM'/;
-    const offenders = testTreeFiles(TEST_ROOT)
-      .filter((file) => !SCAN_EXEMPT.has(file))
-      .filter((file) => inline.test(readFileSync(file, 'utf8')))
-      .map((file) => file.slice(TEST_ROOT.length));
+  /**
+   * #1029 — the previous pattern was `/code\s*===\s*'EPERM'/`, which is
+   * literal-and-quote shaped. All of these slipped past it, each a plausible
+   * thing to type:
+   *
+   *   code === "EPERM"        double quotes
+   *   code == 'EPERM'         loose equality
+   *   'EPERM' === code        comparison written the other way round
+   *   ['EPERM'].includes(c)   array membership
+   *   c.includes('EPERM')     substring test
+   *   errno === -1            the numeric form of the same errno
+   *   os.constants.errno.EPERM  the named constant
+   *
+   * Detection is now behaviour-shaped rather than name-shaped, which also
+   * subsumes the sibling scan above: a rogue guard may be called anything,
+   * but it cannot avoid naming the condition it tests.
+   */
+  const ROGUE_CHECKS: ReadonlyArray<readonly [RegExp, string]> = [
+    [/===?\s*['"`]EPERM['"`]/, "compares something to 'EPERM'"],
+    [/['"`]EPERM['"`]\s*===?/, "compares 'EPERM' to something"],
+    [/\.includes\(\s*['"`]EPERM['"`]/, "tests membership of 'EPERM'"],
+    [/\[\s*['"`]EPERM['"`]\s*\]/, "indexes or lists 'EPERM'"],
+    [/errno\s*===?\s*-\s*1\b/, 'compares errno to -1 (the numeric EPERM)'],
+    [/constants\s*\.\s*errno\s*\.\s*EPERM/, 'reads os.constants.errno.EPERM'],
+  ];
+
+  it('has no inline listener check outside the shared helper, in any spelling', () => {
+    const offenders: string[] = [];
+    for (const file of testTreeFiles(TEST_ROOT)) {
+      if (SCAN_EXEMPT.has(file)) continue;
+      const source = readFileSync(file, 'utf8');
+      for (const [pattern, why] of ROGUE_CHECKS) {
+        if (pattern.test(source)) {
+          offenders.push(`${file.slice(TEST_ROOT.length)} (${why})`);
+          break;
+        }
+      }
+    }
 
     assert.deepEqual(
       offenders,
       [],
-      `These files compare an error code to 'EPERM' inline instead of calling ` +
-        `isSandboxListenDenied / loopbackRequired: ${offenders.join(', ')}. ` +
-        `An inline check cannot honour OMADIA_EXPECT_LOOPBACK (#1024).`,
+      `These files decide for themselves whether a refused listener is ` +
+        `tolerable, instead of calling isSandboxListenDenied / ` +
+        `loopbackRequired: ${offenders.join(', ')}. Such a check cannot ` +
+        `honour OMADIA_EXPECT_LOOPBACK, so the suite self-skips on a runner ` +
+        `where the listener is genuinely broken (#1024).`,
     );
+  });
+
+  /**
+   * What this guard still cannot see, stated rather than implied — a
+   * guard's blind spot belongs in the file, not in a reviewer's head.
+   *
+   *   - a literal assembled at runtime (`'EP' + 'ERM'`, `fromCharCode`);
+   *   - the code imported from a constant in a non-test file;
+   *   - a check that swallows EVERY listen error rather than naming EPERM
+   *     (`catch { return; }` around a bind) — shape-invisible, and the
+   *     reason the positive assertions above exist alongside the scans;
+   *   - source outside `middleware/test`.
+   *
+   * The first two are deliberate evasion rather than the accident this
+   * guard exists to catch; the third is why `loopbackRequired()` is
+   * exported for callers that want their own diagnostic.
+   */
+  it('proves the widened scan actually matches every spelling it claims', () => {
+    // A guard that lists patterns but never proves they fire is the exact
+    // class of decorative check this file was written to replace.
+    const rogueSpellings = [
+      "if (err.code === \"EPERM\") return;",
+      "if (err.code == 'EPERM') return;",
+      "if ('EPERM' === err.code) return;",
+      "if (['EPERM'].includes(err.code)) return;",
+      "if (String(err.code).includes('EPERM')) return;",
+      'if (err.errno === -1) return;',
+      'if (err.errno === constants.errno.EPERM) return;',
+    ];
+
+    for (const snippet of rogueSpellings) {
+      const matched = ROGUE_CHECKS.some(([pattern]) => pattern.test(snippet));
+      assert.ok(matched, `no ROGUE_CHECKS pattern matches: ${snippet}`);
+    }
+
+    // And it must not fire on the correct usage, or every honest caller
+    // becomes an offender and the guard gets deleted for crying wolf.
+    const legitimate = [
+      "import { isSandboxListenDenied } from './_helpers/listenLoopback.js';",
+      'if (isSandboxListenDenied(error)) return;',
+      'if (loopbackRequired()) throw error;',
+    ];
+    for (const snippet of legitimate) {
+      const matched = ROGUE_CHECKS.some(([pattern]) => pattern.test(snippet));
+      assert.equal(matched, false, `false positive on: ${snippet}`);
+    }
   });
 
   /** The flag has to stay discoverable, or the next author writes a local copy. */


### PR DESCRIPTION
The two issues the #1023 review turned up. Both were found by reviewing, not by a failing test.

Closes #1024
Closes #1025

## #1025 — pause, resume, delete and trigger were unscoped

`manage_routine` resolved the channel turn context and refused without it in `create` and `list` only. `pause`, `resume` and `delete` never called `resolveContext` and passed a bare `id` to a runner that did no tenant scoping, so anyone who could reach the tool and knew a routine id could act on another tenant's row. Ids are uuids and `list` is scoped, so the barrier was that an id had to leak. That is obscurity, not authorization.

- The scope is `(tenant, userId)`, not tenant-only: `listForUser` filters on that pair and `create` enforces uniqueness within it, so tenant-only would let a colleague delete your routine.
- It is a **required discriminated argument** (`{kind:'channel-user',tenant,userId}` | `{kind:'operator'}`), not an optional `owner?`. An optional scope is one a caller can forget, and forgetting it is exactly how this gap arose. Cross-tenant access is now a greppable `OPERATOR_SCOPE` literal.
- The predicate lives in the SQL, so it cannot be raced by a read-then-act caller and cannot be bypassed by a caller that supplied nothing.
- A scoped miss raises the same `RoutineNotFoundError` as an absent id, so the error channel is not an existence oracle. A test asserts the two messages are identical modulo the id.

**Two neighbouring doors had the same gap.** `integration.ts handleRoutineAction`, the smart-card buttons, was equally unscoped, and the card carries the id, so a replayed payload reached pause/resume/trigger/delete for any row. Worse, `triggerRoutineNow` delivers into the routine's own `conversationRef`, so an unscoped trigger let one principal push messages into another tenant's conversation on demand. Both are scoped now. The operator HTTP router stays deliberately cross-tenant behind `requireAuth`, as its own comment already documented.

**An ordering bug surfaced while scoping delete:** the runner unregistered the scheduler *before* deleting, so a cross-tenant id silently disarmed someone else's cron while the row survived. A routine that still looks active in `list` and never fires again is harder to notice than a deleted one. Unregistration now happens only after a confirmed delete.

## #1024 — the sandbox-listen guard existed seven times

#1017 made the loopback tests fail instead of self-skipping where a sandbox denies a localhost listener, but the flag reached one of them. The issue named four sites; there were **seven**: two more local definitions and two inline copies in the auth suites. Consumers included `publicMcpPrivacy.e2e`, `publicMcpMaskingAssertion` and `devEndpointsAuth.e2e` — a privacy-masking assertion and an auth e2e that stayed green on a listener-denied runner while asserting nothing. `ci.yml` cites #640 and #752 for exactly this family.

One helper in `test/_helpers/listenLoopback.ts`, beside the `listenLoopback` those files already shared. It honours both `OMADIA_EXPECT_LOOPBACK` and `CI`, so no site is weakened by unification, and it exposes the error shape separately because the two auth suites need the halves apart to keep their diagnostics — which is how two of the seven copies came to exist. A grep-guard test now fails if any file under `middleware/test` defines its own, in either shape: a named definition or a bare inline comparison.

Deliberately untouched: 40 suites that skip on a missing Postgres DSN or Docker. Those dependencies are genuinely optional and CI provisions pgvector for the `schema` job separately, so a skip there is a capability gap rather than a swallowed failure.

## Probes, because two guards in this repo have already proven nothing

Every claim below was planted and restored, not merely observed.

| planted | result |
|---|---|
| a local guard copy re-added to one site | 5 pass, 2 fail (both greps named the file) |
| the tool handler loses its scope | 15 pass, 2 fail |
| the store SQL predicate dropped | 16 pass, 1 fail |
| the delete ordering flipped | 16 pass, 1 fail |
| restored | 7/7 and 17/17 |

**The store probe did not bite at first, and that mattered.** With the SQL predicate removed, all 14 layer tests stayed green: the store stub mirrored the predicate independently, so the layers only proved they *pass* a scope, not that the store *uses* it. A suite driving the real `RoutineStore` against a recording pool now follows each `$n` the SQL names into its bound value, using this repo's existing `boundTo` pattern, so a swap on either side is caught by the other.

## Test plan

- [x] middleware `npm run build` exit 0, `npx tsc --noEmit` **0 errors**, `npm run lint` clean, `npm run typecheck:test` 364 known / no regressions (baseline 370, untouched)
- [x] Full suite `OMADIA_EXPECT_LOOPBACK=1 npm run test`: **8473 tests, 8455 pass, 0 fail, 18 skipped**
- [x] Zero loopback skips remain; every one of the 18 is a Postgres or Docker suite
- [x] The count delta against main was chased to ground rather than waved off: identical executed file sets (751 vs 750, the difference being the new guard test), identical counts in the seven converted files (96 = 96), and the two extra skips are `*.pg.test.ts` suites gated on `probePgTest` reaching a real Postgres, which one run had and the other did not
- [x] #1016's "absent context passes" rationale was recorded as true for two of five actions; it now holds for all five, and `turnOwnerGuard.ts` plus security-architecture §3a say so

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/1028"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791102139&installation_model_id=428086&pr_number=1028&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F1028&signature=903bbc522570ce99270976451207ee7191534be6877193d95cce2fb9b93029b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->