### PR TITLE
fix(desktop): stop shipping omadia.Setup.0.1.0.exe — repair the entry-point guards

### DIFF
--- a/.github/workflows/desktop-apps.yml
+++ b/.github/workflows/desktop-apps.yml
@@ -209,6 +209,29 @@ jobs:
         working-directory: desktop
         run: node scripts/set-desktop-version.mjs "$TAG"
 
+      # Belt and braces. The step above used to be able to do NOTHING and still
+      # report success: its entry-point guard compared a URL against a raw
+      # `process.argv[1]`, which is never equal on Windows, so every Windows
+      # installer up to v0.149.2 shipped as `omadia.Setup.0.1.0.exe` while the
+      # macOS and Linux artifacts of the same release carried the real version.
+      # The guard is fixed and tested, but a version this pipeline stamps into
+      # three release-facing surfaces (Info.plist, artifact filenames, the
+      # feed electron-updater compares) is worth verifying rather than trusting
+      # — and the check costs one node invocation on every runner, including
+      # the one where the bug lived.
+      - name: Assert the version actually landed
+        working-directory: desktop
+        run: |
+          want="${TAG#v}"
+          got="$(node -p "require('./package.json').version")"
+          if [ "$got" != "$want" ]; then
+            echo "::error::desktop/package.json says '$got', release tag says '$want'." >&2
+            echo "set-desktop-version.mjs did not take effect — refusing to build" >&2
+            echo "artifacts that would be labelled '$got'." >&2
+            exit 1
+          fi
+          echo "✓ desktop/package.json version = $got"
+
       # Verify the middleware's native modules load under Electron's Node (the
       # kernel runs via ELECTRON_RUN_AS_NODE). All three are N-API → ABI-stable
       # across node/electron, so their shipped binaries already work and NONE of

--- a/desktop/scripts/isEntryPoint.mjs
+++ b/desktop/scripts/isEntryPoint.mjs
@@ -1,0 +1,48 @@
+// Is this module the process entry point? — the one guard, two call sites.
+//
+// WHY THIS IS NOT A ONE-LINER
+// The obvious form compares `import.meta.url` against a `file://` URL built by
+// concatenating `process.argv[1]`. That puts a filesystem path where a URL
+// belongs and is wrong in three separate ways, each of which turns a CLI script
+// into a SILENT NO-OP that exits 0:
+//
+//   1. Windows. `process.argv[1]` is `D:\a\omadia\…`; `import.meta.url` is
+//      `file:///D:/a/omadia/…`. Never equal. This is why every Windows
+//      installer up to and including v0.149.2 shipped as
+//      `omadia.Setup.0.1.0.exe` while the macOS and Linux artifacts of the very
+//      same release carried the real version: `set-desktop-version.mjs` ran,
+//      matched nothing, wrote nothing, and CI called the step a success.
+//   2. Percent-encoding. A path containing a space, `#` or `?` is encoded in
+//      the URL (`desktop dir` -> `desktop%20dir`) and spelled literally in
+//      argv. Breaks on macOS and Linux too.
+//   3. Symlinks. Node resolves `import.meta.url` through realpath; argv[1] is
+//      not resolved. On macOS `os.tmpdir()` is `/var/folders/…`, a symlink to
+//      `/private/var/folders/…` — so even a correct `fileURLToPath` comparison
+//      fails there. Any checkout reached through a symlink has the same shape.
+//
+// So: cross the URL/path boundary with `fileURLToPath`, then realpath BOTH
+// sides. Realpathing the module too is not redundant — it keeps the comparison
+// honest under `--preserve-symlinks-main`, where Node leaves `import.meta.url`
+// unresolved while argv[1] still resolves.
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * @param {string} moduleUrl - the caller's `import.meta.url`
+ * @returns {boolean} true when Node was started with this very file
+ */
+export function isEntryPoint(moduleUrl) {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return (
+      fs.realpathSync(fileURLToPath(moduleUrl)) ===
+      fs.realpathSync(path.resolve(entry))
+    );
+  } catch {
+    // A vanished or unreadable entry path is not this module — and a guard is
+    // the wrong place to throw.
+    return false;
+  }
+}

--- a/desktop/scripts/merge-mac-update-feed.mjs
+++ b/desktop/scripts/merge-mac-update-feed.mjs
@@ -26,6 +26,8 @@
 // merge would break updates for every user at once.
 import fs from 'node:fs';
 
+import { isEntryPoint } from './isEntryPoint.mjs';
+
 const SCALARS = new Set(['version', 'path', 'sha512', 'releaseDate']);
 
 /** Strips one layer of YAML quoting. electron-builder quotes only releaseDate. */
@@ -147,7 +149,7 @@ export function mergeFeeds(primary, secondary) {
   return { scalars: { ...primary.scalars }, files };
 }
 
-const isMain = import.meta.url === `file://${process.argv[1]}`;
+const isMain = isEntryPoint(import.meta.url);
 if (isMain) {
   const [primaryPath, secondaryPath, outPath] = process.argv.slice(2);
   if (!primaryPath || !secondaryPath || !outPath) {

--- a/desktop/scripts/set-desktop-version.mjs
+++ b/desktop/scripts/set-desktop-version.mjs
@@ -17,6 +17,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { isEntryPoint } from './isEntryPoint.mjs';
+
 const VERSION_RE = /^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/;
 const here = path.dirname(fileURLToPath(import.meta.url));
 const desktopPackageJsonPath = path.join(here, '..', 'package.json');
@@ -46,7 +48,7 @@ export function setPackageVersion(packageJsonText, version) {
   return `${JSON.stringify(pkg, null, 2)}\n`;
 }
 
-const isMain = import.meta.url === `file://${process.argv[1]}`;
+const isMain = isEntryPoint(import.meta.url);
 if (isMain) {
   const tag = process.argv[2];
   if (!tag) {

--- a/desktop/scripts/set-desktop-version.test.mjs
+++ b/desktop/scripts/set-desktop-version.test.mjs
@@ -4,10 +4,18 @@
 // guard rails matter more than the happy path: one bad parse or one sloppy JSON
 // rewrite would label the installer, the app metadata, and the updater wrong.
 //
-// Run: node --test desktop/scripts/
+// Run: npm test --workspace-root=false  (from desktop/), or
+//      node --test desktop/scripts/*.test.mjs
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { deriveVersion, setPackageVersion } from './set-desktop-version.mjs';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
 
 test('strips one leading v from a release tag', () => {
   assert.equal(deriveVersion('v1.2.3'), '1.2.3');
@@ -79,4 +87,90 @@ test('rewrites package.json with repo-stable formatting', () => {
 }
 `,
   );
+});
+
+/**
+ * The CLI half — which is where this script actually failed.
+ *
+ * Every test above covers `deriveVersion` / `setPackageVersion`, and all of
+ * them passed while the shipped Windows installer was named
+ * `omadia.Setup.0.1.0.exe`: the entry-point guard compared `import.meta.url`
+ * against a `file://` URL concatenated from `process.argv[1]`, which on Windows
+ * is a backslash path and never matches. `isMain` was false, the script exited
+ * 0 having written nothing, and CI's "Set desktop app version" step reported
+ * success. Pure-function coverage cannot see that; only running the thing can.
+ *
+ * The reproduction below is deliberately platform-portable. A path containing a
+ * SPACE breaks the old guard on macOS and Linux too, for exactly the same
+ * reason Windows breaks it: `import.meta.url` percent-encodes (`probe dir` →
+ * `probe%20dir`) what `process.argv[1]` spells literally. So this test fails on
+ * every runner if the guard regresses — it does not need a Windows machine to
+ * catch a Windows bug.
+ */
+function runInCopiedTree(dirName, args) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'omadia-setver-'));
+  const scriptDir = path.join(root, dirName, 'scripts');
+  fs.mkdirSync(scriptDir, { recursive: true });
+  for (const file of ['set-desktop-version.mjs', 'isEntryPoint.mjs']) {
+    fs.copyFileSync(path.join(here, file), path.join(scriptDir, file));
+  }
+  // The script rewrites `../package.json` relative to its own location.
+  const pkgPath = path.join(root, dirName, 'package.json');
+  fs.writeFileSync(
+    pkgPath,
+    '{\n  "name": "omadia-desktop",\n  "version": "0.1.0",\n  "private": true\n}\n',
+  );
+  const stdout = execFileSync(
+    process.execPath,
+    [path.join(scriptDir, 'set-desktop-version.mjs'), ...args],
+    { encoding: 'utf8' },
+  );
+  const version = JSON.parse(fs.readFileSync(pkgPath, 'utf8')).version;
+  fs.rmSync(root, { recursive: true, force: true });
+  return { stdout, version };
+}
+
+test('run as a CLI, it actually writes the version', () => {
+  const { stdout, version } = runInCopiedTree('desktop', ['v9.8.7']);
+  assert.equal(version, '9.8.7');
+  assert.match(stdout, /desktop\/package\.json version -> 9\.8\.7/);
+});
+
+test('writes the version even from a path that percent-encodes — the Windows failure, reproduced portably', () => {
+  const { version } = runInCopiedTree('desktop dir', ['v9.8.7']);
+  assert.equal(
+    version,
+    '9.8.7',
+    'the entry-point guard must survive a path the URL form encodes differently ' +
+      '(a space here, backslashes on Windows) — otherwise the script is a silent no-op',
+  );
+});
+
+test('run as a CLI with no tag, it fails loudly instead of no-opping', () => {
+  assert.throws(
+    () => runInCopiedTree('desktop', []),
+    (err) => {
+      assert.equal(err.status, 1);
+      assert.match(String(err.stderr), /usage: set-desktop-version\.mjs <tag>/);
+      return true;
+    },
+  );
+});
+
+test('run as a CLI with a bad tag, it fails instead of shipping a mislabeled build', () => {
+  assert.throws(
+    () => runInCopiedTree('desktop', ['latest']),
+    (err) => {
+      assert.equal(err.status, 1);
+      assert.match(String(err.stderr), /Invalid version tag: "latest"/);
+      return true;
+    },
+  );
+});
+
+test('imported rather than executed, it writes nothing', () => {
+  // The other half of the guard: `npm test` imports this module, and an
+  // import that rewrote package.json would corrupt the working tree.
+  const before = fs.readFileSync(path.join(here, '..', 'package.json'), 'utf8');
+  assert.equal(JSON.parse(before).version, '0.1.0');
 });

--- a/middleware/packages/canvas-core/tools/stubServer.ts
+++ b/middleware/packages/canvas-core/tools/stubServer.ts
@@ -3,7 +3,9 @@
  * /omadia-ui/canvas, runs the offer→select→ack handshake, and replays the
  * Walkthrough-1 recording once per incoming `turn`. No auth — local dev only.
  */
-import { readFileSync } from 'node:fs';
+import { readFileSync, realpathSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { WebSocketServer, type WebSocket } from 'ws';
 
 interface RecordedFrame {
@@ -96,9 +98,33 @@ export function startStubServer(port = 0): Promise<{ port: number; close: () => 
   });
 }
 
-// CLI entry: `npm run stub-server`
-const argv1 = process.argv[1];
-if (argv1 && import.meta.url.endsWith(argv1.split('/').pop() ?? '')) {
+/**
+ * CLI entry: `npm run stub-server`.
+ *
+ * The previous form compared only the BASENAME — `import.meta.url.endsWith(
+ * argv[1].split('/').pop())` — which is wrong twice over: it splits on `/`
+ * only, so on Windows the whole backslash path is the "basename" and the guard
+ * is never true; and any entry script that happens to share this filename would
+ * start a WebSocket server as a side effect of an unrelated import. Compare
+ * full paths instead, realpathing both sides: Node resolves `import.meta.url`
+ * through realpath while leaving `argv[1]` alone, so a symlinked checkout or a
+ * macOS `/var` → `/private/var` temp dir breaks a plain string compare. Same
+ * rule as `desktop/scripts/isEntryPoint.mjs`; kept local because these are
+ * separate packages.
+ */
+function isEntryPoint(moduleUrl: string): boolean {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return (
+      realpathSync(fileURLToPath(moduleUrl)) === realpathSync(resolve(entry))
+    );
+  } catch {
+    return false;
+  }
+}
+
+if (isEntryPoint(import.meta.url)) {
   void startStubServer(8181).then(({ port }) =>
     console.log(`omadia-ui stub server: ws://127.0.0.1:${port}/omadia-ui/canvas`),
   );

--- a/middleware/sidecars/updater/src/server.mjs
+++ b/middleware/sidecars/updater/src/server.mjs
@@ -16,8 +16,11 @@
  *   POST /update   → 202 {"accepted":true} | 409 | 400
  */
 
+import fs from 'node:fs';
 import http from 'node:http';
 import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { timingSafeEqual } from 'node:crypto';
 
 import { isValidTargetVersion, loadConfig } from './config.mjs';
@@ -231,8 +234,34 @@ export function createServer(deps = {}) {
   return { server, config, getStatus: () => status };
 }
 
+/**
+ * True when Node was started with THIS file — the sidecar's boot switch.
+ *
+ * Not a comparison against a `file://` URL built by concatenating
+ * `process.argv[1]`: `import.meta.url` percent-encodes what a path spells
+ * literally (a bind mount named with a space is enough), and Node resolves the
+ * module URL through realpath while leaving argv[1] alone, so a symlinked
+ * WORKDIR breaks it too. Either way the guard goes false, `server.listen` is
+ * never reached, and the container exits 0 as if all were well. The same
+ * comparison was silently disabling `desktop/scripts/set-desktop-version.mjs`
+ * on every Windows CI run — see `desktop/scripts/isEntryPoint.mjs`. Kept local
+ * rather than imported: the Dockerfile ships only this `src/` tree.
+ */
+function isEntryPoint(moduleUrl) {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return (
+      fs.realpathSync(fileURLToPath(moduleUrl)) ===
+      fs.realpathSync(path.resolve(entry))
+    );
+  } catch {
+    return false;
+  }
+}
+
 // Entrypoint — skipped when imported by tests.
-if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+if (isEntryPoint(import.meta.url)) {
   const { server, config } = createServer();
   // Fail fast on the pin target: an unusable .env mount would otherwise be
   // discovered mid-update, after images have been pulled and before anything

--- a/middleware/test/entryPointGuard.test.ts
+++ b/middleware/test/entryPointGuard.test.ts
@@ -1,0 +1,337 @@
+import { strict as assert } from 'node:assert';
+import {
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from 'node:test';
+
+/**
+ * One grep so the entry-point guard bug cannot come back a fourth time.
+ *
+ * WHAT WENT WRONG
+ * ---------------
+ * Three CLI modules decided "am I the process entry point?" by comparing
+ * their module URL against a `file://` URL built by string-concatenating
+ * `argv[1]`. That puts a filesystem path where a URL belongs, and it is wrong
+ * in three independent ways — Windows backslashes, percent-encoding of spaces
+ * and `#`, and Node resolving the module URL through realpath while leaving
+ * argv alone. Each failure mode makes the guard FALSE, so the script does
+ * nothing and exits 0.
+ *
+ * The consequence shipped: every Windows installer up to and including
+ * v0.149.2 was named `omadia.Setup.0.1.0.exe`, because
+ * `desktop/scripts/set-desktop-version.mjs` never rewrote the version on the
+ * Windows runner — while CI reported the step as a success and the macOS and
+ * Linux artifacts of the same release carried the real version.
+ *
+ * WHY A REPO-WIDE GREP AND NOT JUST THE UNIT TESTS
+ * ------------------------------------------------
+ * `desktop/scripts/set-desktop-version.test.mjs` now drives the real CLI from
+ * a path containing a space, which reproduces the same defect portably and
+ * fails on any runner if the guard regresses. What it cannot do is notice a
+ * FOURTH copy appearing in some other package — which is exactly how this
+ * spread: the pattern is the first result for "esm main module" and looks
+ * right on a developer's Mac. So the scan below covers the whole repository,
+ * and it deliberately has NO per-file exclusion list: two guards in this repo
+ * have already turned out to prove nothing because the exclusion list was
+ * where they went blind.
+ *
+ * This file also lives in `middleware/test` on purpose rather than next to the
+ * scripts it protects: `middleware (lint + typecheck + test)` is a required
+ * status check on `main`, `desktop (typecheck + test)` is not.
+ *
+ * WHAT THIS GUARD DOES NOT CATCH — measured, not assumed
+ * ------------------------------------------------------
+ * The scan keys on the two tokens appearing near each other in code, so it
+ * sees the INLINE form — which is the form all five real occurrences had, and
+ * the form a newcomer writes. It does NOT see a regression hidden behind a
+ * helper's parameter names: reverting `isEntryPoint` to
+ * `moduleUrl === 'file://' + entry` leaves both tokens out of the file and this
+ * guard stays green (verified by planting exactly that).
+ *
+ * That case is covered by the other half of the pair, and covered hard:
+ * `desktop/scripts/set-desktop-version.test.mjs` drives the real CLI from a
+ * path containing a space, and the same plant takes that suite from 217/217 to
+ * 213/217. Two mechanisms, one blind spot each, and neither blind spot shared —
+ * which is the only arrangement worth calling coverage.
+ */
+
+/**
+ * The two tokens, assembled from fragments.
+ *
+ * If they appeared as plain adjacent literals, this file would be its own
+ * first offender — the scan covers the repo including itself, which is the
+ * point.
+ */
+const MODULE_URL = 'import.meta' + '.url';
+const ENTRY_ARGV = 'process.argv' + '[1]';
+
+/** The correct ways to cross the URL/path boundary. */
+const SANCTIONED = ['fileURLToPath', 'pathToFileURL'];
+
+const SCANNED_EXTENSIONS = [
+  '.ts',
+  '.mts',
+  '.cts',
+  '.tsx',
+  '.js',
+  '.mjs',
+  '.cjs',
+  '.jsx',
+];
+
+/** Build output, dependencies and scratch trees carry copies we do not own. */
+const SKIPPED_DIRS = new Set([
+  // Local agent scratch worktrees. They hold whole extra copies of the repo,
+  // so without this the scan reports the same handful of files a hundred times
+  // over — and reports them against code nobody is shipping.
+  '.claude',
+  '.git',
+  '.next',
+  '.test-build',
+  '.worktrees',
+  'build',
+  'coverage',
+  'dist',
+  'node_modules',
+  'out',
+  'release',
+  'runtime',
+]);
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+function sourceFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (SKIPPED_DIRS.has(entry)) continue;
+    const full = join(dir, entry);
+    let stats;
+    try {
+      stats = statSync(full);
+    } catch {
+      continue; // a broken symlink is not a source file
+    }
+    if (stats.isDirectory()) sourceFiles(full, out);
+    else if (SCANNED_EXTENSIONS.some((ext) => entry.endsWith(ext))) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Comments removed, newlines kept so offsets still map to lines.
+ *
+ * Prose has to be excluded or this guard would flag the very doc comments that
+ * explain the bug — including the one above. Stripping is deliberately crude:
+ * it does not understand a `//` inside a string literal, which at worst blinds
+ * the scan to code on that one line. A named exclusion list would blind it to
+ * whole files, which is worse.
+ */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
+    .replace(/(^|[^:])\/\/[^\n]*/g, (m, lead: string) =>
+      lead + ' '.repeat(m.length - lead.length),
+    );
+}
+
+function lineOf(text: string, index: number): number {
+  return text.slice(0, index).split('\n').length;
+}
+
+/**
+ * Template-literal interpolation braces rewritten as parentheses, in place.
+ *
+ * `${` and its matching `}` are not statement boundaries, but the crude
+ * boundary scan below cannot tell them from a block. Without this,
+ * `` `file://${process.argv[1]}` `` gets cut at the `${` and the entry token
+ * lands outside the statement — the offender then reads as clean. Caught by
+ * the fixture cases, which is the whole reason they exist. Lengths are
+ * preserved so reported line numbers stay true.
+ */
+function neutralizeInterpolation(code: string): string {
+  const out = code.split('');
+  const stack: number[] = [];
+  for (let i = 0; i < out.length; i += 1) {
+    if (out[i] === '$' && out[i + 1] === '{') {
+      out[i + 1] = '(';
+      stack.push(1);
+      i += 1;
+    } else if (stack.length > 0) {
+      if (out[i] === '{') stack[stack.length - 1] += 1;
+      else if (out[i] === '}') {
+        const depth = (stack[stack.length - 1] as number) - 1;
+        if (depth === 0) {
+          out[i] = ')';
+          stack.pop();
+        } else stack[stack.length - 1] = depth;
+      }
+    }
+  }
+  return out.join('');
+}
+
+/**
+ * The statement containing `index`, bounded by `;`, `{` and `}`.
+ *
+ * A character-proximity window looked simpler and was WRONG: with the correct
+ * `isEntryPoint` helper defined a few lines above a bad inline guard, the
+ * window picked up the helper's `fileURLToPath` and forgave the guard. Verified
+ * by planting exactly that — the scan stayed green on a genuine offender.
+ * Statement bounds keep a neighbouring correct call from vouching for its
+ * broken neighbour, and still tolerate a comparison prettier split over four
+ * lines, since none of those lines carries a `;` or a brace.
+ */
+function enclosingStatement(code: string, index: number): string {
+  const isBoundary = (ch: string): boolean =>
+    ch === ';' || ch === '{' || ch === '}';
+  let start = index;
+  while (start > 0 && !isBoundary(code[start - 1] as string)) start -= 1;
+  let end = index;
+  while (end < code.length && !isBoundary(code[end] as string)) end += 1;
+  return code.slice(start, end);
+}
+
+/** Every statement that compares the module URL against the entry path. */
+function findComparisons(
+  files: readonly string[],
+): { file: string; line: number; sanctioned: boolean }[] {
+  const hits: { file: string; line: number; sanctioned: boolean }[] = [];
+  for (const file of files) {
+    const code = neutralizeInterpolation(
+      stripComments(readFileSync(file, 'utf8')),
+    );
+    let from = 0;
+    for (;;) {
+      const at = code.indexOf(MODULE_URL, from);
+      if (at === -1) break;
+      from = at + MODULE_URL.length;
+      const statement = enclosingStatement(code, at);
+      if (!statement.includes(ENTRY_ARGV)) continue;
+      hits.push({
+        file: relative(repoRoot, file),
+        line: lineOf(code, at),
+        sanctioned: SANCTIONED.some((ok) => statement.includes(`${ok}(`)),
+      });
+    }
+  }
+  return hits;
+}
+
+describe('entry-point guards compare paths as paths', () => {
+  const files = sourceFiles(repoRoot);
+
+  it('scans a repository, not an empty list', () => {
+    // Anti-vacuity: a walker that silently reached nothing would make every
+    // assertion below pass. Two of this repo's guards failed exactly that way.
+    assert.ok(
+      files.length > 500,
+      `expected the repo scan to reach hundreds of files, got ${files.length}`,
+    );
+    const scanned = new Set(files.map((f) => relative(repoRoot, f)));
+    for (const known of [
+      'desktop/scripts/isEntryPoint.mjs',
+      'desktop/scripts/set-desktop-version.mjs',
+      'desktop/scripts/merge-mac-update-feed.mjs',
+      'middleware/sidecars/updater/src/server.mjs',
+    ]) {
+      assert.ok(scanned.has(known), `scan must reach ${known}`);
+    }
+  });
+
+  it('actually fires on the bad form and stays quiet on the good one', () => {
+    // The detector's own negative control. A clean repository legitimately
+    // yields zero hits, so "found nothing" is not evidence that the scan
+    // works — only a planted sample is. Fixtures are written to disk rather
+    // than passed as strings so they go through the very same read + strip +
+    // scan path as real files.
+    const dir = mkdtempSync(join(tmpdir(), 'omadia-entryguard-'));
+    const cases: [string, string, boolean][] = [
+      // [filename, body, should be flagged]
+      [
+        'template.mjs',
+        'const m = import' + '.meta.url === `file://${process.argv[1]}`;\n',
+        true,
+      ],
+      [
+        'concat.mjs',
+        "const m = import" + ".meta.url === 'file://' + process.argv[1];\n",
+        true,
+      ],
+      [
+        'reversed.mjs',
+        'const m = `file://${process.argv[1]}` === import' + '.meta.url;\n',
+        true,
+      ],
+      [
+        'basename.ts',
+        'const m = import' +
+          ".meta.url.endsWith(process.argv[1].split('/').pop());\n",
+        true,
+      ],
+      [
+        'multiline.mjs',
+        'const m =\n  import' +
+          '.meta.url ===\n  `file://` +\n  process.argv[1];\n',
+        true,
+      ],
+      [
+        'good-fileurltopath.mjs',
+        'const m = fileURLToPath(import' +
+          '.meta.url) === realpathSync(process.argv[1]);\n',
+        false,
+      ],
+      [
+        'good-pathtofileurl.mjs',
+        'const m = import' +
+          '.meta.url === pathToFileURL(process.argv[1]).href;\n',
+        false,
+      ],
+      [
+        'commented-out.mjs',
+        '// const m = import' +
+          '.meta.url === `file://${process.argv[1]}`;\n',
+        false,
+      ],
+    ];
+    for (const [name, body] of cases) writeFileSync(join(dir, name), body);
+
+    const flagged = new Set(
+      findComparisons(
+        cases.map(([name]) => join(dir, name)),
+      )
+        .filter((h) => !h.sanctioned)
+        .map((h) => h.file.split('/').pop()),
+    );
+    rmSync(dir, { recursive: true, force: true });
+
+    for (const [name, , shouldFlag] of cases) {
+      assert.equal(
+        flagged.has(name),
+        shouldFlag,
+        shouldFlag
+          ? `the scan must flag ${name} — otherwise it proves nothing`
+          : `the scan must NOT flag ${name} — a false positive makes the guard noise`,
+      );
+    }
+  });
+
+  it('never builds a file:// URL out of the entry path', () => {
+    const offenders = findComparisons(files).filter((h) => !h.sanctioned);
+    assert.deepEqual(
+      offenders,
+      [],
+      'Compare paths with fileURLToPath (and realpath both sides), or reuse ' +
+        'desktop/scripts/isEntryPoint.mjs. Concatenating the entry path into a ' +
+        'file:// URL is false on Windows, on paths that percent-encode, and ' +
+        'through symlinks — and it fails SILENTLY.\nOffenders:\n' +
+        offenders.map((o) => `  ${o.file}:${o.line}`).join('\n'),
+    );
+  });
+});

--- a/middleware/test/entryPointGuard.test.ts
+++ b/middleware/test/entryPointGuard.test.ts
@@ -49,12 +49,16 @@ import { describe, it } from 'node:test';
  *
  * WHAT THIS GUARD DOES NOT CATCH — measured, not assumed
  * ------------------------------------------------------
- * The scan keys on the two tokens appearing near each other in code, so it
- * sees the INLINE form — which is the form all five real occurrences had, and
- * the form a newcomer writes. It does NOT see a regression hidden behind a
- * helper's parameter names: reverting `isEntryPoint` to
- * `moduleUrl === 'file://' + entry` leaves both tokens out of the file and this
- * guard stays green (verified by planting exactly that).
+ * The scan works on the statement around each `import.meta.url`, so it sees
+ * every spelling the real occurrences used — including the one that assigns
+ * argv to a local first, which pure statement scoping missed until the
+ * substring rule was added (measured, by planting the original `stubServer`
+ * form back).
+ *
+ * What it does NOT see is a regression hidden behind a helper's PARAMETER
+ * names: reverting `isEntryPoint` to `moduleUrl === 'file://' + entry` leaves
+ * neither token in the file and this guard stays green. Verified by planting
+ * exactly that.
  *
  * That case is covered by the other half of the pair, and covered hard:
  * `desktop/scripts/set-desktop-version.test.mjs` drives the real CLI from a
@@ -75,6 +79,23 @@ const ENTRY_ARGV = 'process.argv' + '[1]';
 
 /** The correct ways to cross the URL/path boundary. */
 const SANCTIONED = ['fileURLToPath', 'pathToFileURL'];
+
+/**
+ * Substring matching ON the module URL — the fourth real spelling.
+ *
+ * `stubServer.ts` compared only the basename:
+ * `import.meta.url.endsWith(argv[1].split('/').pop())`. Dead on Windows, and
+ * it fires for ANY entry script sharing the filename. Worth flagging on its
+ * own, because this form does not need the entry token in the same statement:
+ * the real code assigned argv to a local one line earlier, which is precisely
+ * how statement scoping alone would have missed it (measured — the first
+ * statement-scoped version did).
+ */
+const SUBSTRING_MATCHERS = ['endsWith(', 'startsWith(', 'includes('];
+
+/** A literal `file://` in the same statement is the defect, whatever it is
+ *  concatenated with — the entry path is not the only wrong operand. */
+const URL_LITERAL = 'file://';
 
 const SCANNED_EXTENSIONS = [
   '.ts',
@@ -157,22 +178,24 @@ function lineOf(text: string, index: number): number {
  */
 function neutralizeInterpolation(code: string): string {
   const out = code.split('');
-  const stack: number[] = [];
+  // Brace depth per open interpolation — a template literal can nest inside
+  // one. Only push/pop, never an indexed write: `noUncheckedIndexedAccess`
+  // types `depths[depths.length - 1]` as possibly undefined, and casting that
+  // away in a guard's own helper would be the wrong kind of shortcut.
+  const depths: number[] = [];
   for (let i = 0; i < out.length; i += 1) {
     if (out[i] === '$' && out[i + 1] === '{') {
       out[i + 1] = '(';
-      stack.push(1);
+      depths.push(1);
       i += 1;
-    } else if (stack.length > 0) {
-      if (out[i] === '{') stack[stack.length - 1] += 1;
-      else if (out[i] === '}') {
-        const depth = (stack[stack.length - 1] as number) - 1;
-        if (depth === 0) {
-          out[i] = ')';
-          stack.pop();
-        } else stack[stack.length - 1] = depth;
-      }
+      continue;
     }
+    const depth = depths.pop();
+    if (depth === undefined) continue; // outside any interpolation
+    if (out[i] === '{') depths.push(depth + 1);
+    else if (out[i] !== '}') depths.push(depth);
+    else if (depth === 1) out[i] = ')';
+    else depths.push(depth - 1);
   }
   return out.join('');
 }
@@ -213,11 +236,22 @@ function findComparisons(
       if (at === -1) break;
       from = at + MODULE_URL.length;
       const statement = enclosingStatement(code, at);
-      if (!statement.includes(ENTRY_ARGV)) continue;
+      const comparesToEntryPath = statement.includes(ENTRY_ARGV);
+      const buildsUrlLiteral = statement.includes(URL_LITERAL);
+      const matchesSubstring = SUBSTRING_MATCHERS.some((m) =>
+        statement.includes(`${MODULE_URL}.${m}`),
+      );
+      if (!comparesToEntryPath && !buildsUrlLiteral && !matchesSubstring) {
+        continue;
+      }
       hits.push({
         file: relative(repoRoot, file),
         line: lineOf(code, at),
-        sanctioned: SANCTIONED.some((ok) => statement.includes(`${ok}(`)),
+        // A substring match on the module URL is wrong even with
+        // `fileURLToPath` in the statement, so it is never sanctioned.
+        sanctioned:
+          !matchesSubstring &&
+          SANCTIONED.some((ok) => statement.includes(`${ok}(`)),
       });
     }
   }
@@ -291,6 +325,18 @@ describe('entry-point guards compare paths as paths', () => {
         'good-pathtofileurl.mjs',
         'const m = import' +
           '.meta.url === pathToFileURL(process.argv[1]).href;\n',
+        false,
+      ],
+      [
+        'split-statements.ts',
+        'const argv1 = process.argv[1];\n' +
+          "const m = argv1 && import" +
+          ".meta.url.endsWith(argv1.split('/').pop());\n",
+        true,
+      ],
+      [
+        'good-new-url.mjs',
+        "const asset = new URL('./data.json', import" + ".meta.url);\n",
         false,
       ],
       [


### PR DESCRIPTION
Jeder Windows-Installer bis einschließlich **v0.149.2** hieß `omadia.Setup.0.1.0.exe`, während die macOS- und Linux-Artefakte desselben Release die echte Version trugen. Für Windows-Nutzer heißt das: der Dateiname sagt nichts über den Inhalt, und `electron-updater` kann nicht vergleichen, weil auch `Info.plist`/`package.json` im Paket auf `0.1.0` stehen.

## Ursache

`desktop/scripts/set-desktop-version.mjs` entschied „bin ich der Entry Point?" so:

```js
const isMain = import.meta.url === `file://${process.argv[1]}`;
```

Das stellt einen **Dateisystempfad** dorthin, wo eine **URL** hingehört. Auf Windows ist `process.argv[1]` gleich `D:\a\omadia\…`, `import.meta.url` aber `file:///D:/a/omadia/…` — **nie gleich**. Der Guard war dort immer `false`: das Skript lief, traf nichts, schrieb nichts und beendete sich mit **0**. Der CI-Schritt „Set desktop app version from release tag" meldete Erfolg.

Und genau diesen Wert liest electron-builder für drei release-relevante Oberflächen: den Artefakt-Dateinamen, die App-Metadaten und die Version, die `electron-updater` gegen den Feed vergleicht.

## Fünf Fundstellen, nicht eine

Zwei hat mein erstes `rg` übersehen, weil sie anders geschrieben sind:

| Datei | Was daran kaputt war |
|---|---|
| `desktop/scripts/set-desktop-version.mjs` | **Der ausgelieferte Defekt** (Windows) |
| `desktop/scripts/merge-mac-update-feed.mjs` | Gleiche Form, gleiche Klasse |
| `middleware/sidecars/updater/src/server.mjs` | Würde **nie lauschen**, wenn der Container-Pfad prozent-kodiert (Leerzeichen genügt) oder über einen Symlink auflöst — Exit 0, als wäre alles gut |
| `middleware/packages/canvas-core/tools/stubServer.ts` | Verglich nur den **Basename** über `.split('/')`: auf Windows tot, und würde für *jedes* Entry-Skript mit demselben Dateinamen einen WebSocket-Server starten |
| *(`dev-runner-shim`)* | Nicht auf `main`, existiert nur in offenen Branches — der neue Guard fängt es beim Merge |

Alle überschreiten die URL/Pfad-Grenze jetzt mit `fileURLToPath` **und** realpathen **beide** Seiten.

**Das Realpathen ist nicht Gürtel-und-Hosenträger.** Node löst `import.meta.url` über realpath auf und lässt `argv[1]` in Ruhe. Auf macOS ist `os.tmpdir()` `/var/folders/…`, ein Symlink auf `/private/var/folders/…` — dort scheitert auch ein korrekter `fileURLToPath`-Vergleich. **Meine erste Fassung dieses Fixes hatte das nicht, und der neue CLI-Test hat es gefunden.**

## Zwei Wächter, kein gemeinsamer blinder Fleck

**1. `desktop/scripts/set-desktop-version.test.mjs` fährt jetzt die echte CLI.**
Die bisherigen Tests deckten `deriveVersion` und `setPackageVersion` ab — und waren die ganze Zeit grün, während der Installer falsch benannt ausgeliefert wurde. Reine Funktionsabdeckung kann einen toten Entry-Guard nicht sehen; nur Ausführen kann das.

Die Reproduktion ist **plattformportabel**: ein Pfad mit **Leerzeichen** bricht den alten Guard auf jedem OS, aus demselben Grund, aus dem Windows ihn bricht — `import.meta.url` kodiert `probe dir` zu `probe%20dir`, `argv[1]` schreibt es wörtlich. Der Test braucht also keine Windows-Maschine, um einen Windows-Bug zu fangen.

**2. `middleware/test/entryPointGuard.test.ts` greppt das ganze Repo**, damit keine sechste Kopie entsteht — ohne Datei-Ausnahmeliste (genau dort werden Guards blind), mit Anti-Vakuum-Check, dass der Walker die Dateien überhaupt erreicht, und mit **acht gepflanzten Fixtures als eigener Negativkontrolle** (fünf schlechte Formen, zwei korrekte, eine auskommentierte).

Er liegt in `middleware`, weil `middleware (lint + typecheck + test)` ein **required** Check auf `main` ist — `desktop (typecheck + test)` ist es nicht. Das ist eine eigene Lücke; siehe unten.

**3. CI prüft das Ergebnis.** Nach dem Versions-Schreiben vergleicht ein neuer Schritt `desktop/package.json` gegen das Release-Tag und bricht ab, statt falsch benannte Artefakte zu bauen.

## Verifikation — durch gepflanzte Regression

| Pflanzung | Ergebnis |
|---|---|
| Naiver Guard **im gemeinsamen Helper** | desktop **217/217 → 213/217** |
| Naiver Guard **inline an einer Aufrufstelle** | entryPointGuard **3/3 → 2/3**, Offender mit `file:line` benannt |
| *(Guard-Selbstprüfung)* | Der Grep bleibt beim Helper-Plant grün — **im Docblock als blinder Fleck benannt**, abgedeckt durch Wächter 1 |

Zwei Defekte an meinem eigenen Detektor kamen erst durchs Pflanzen heraus und sind behoben: ein Zeichen-Proximity-Fenster ließ einen korrekten Helper in der Nähe den kaputten Guard *entschuldigen*, und ein Template-Literal-`${` schnitt die Anweisung ab. Beides ist jetzt anweisungs-gescoped.

**Volle Läufe:** middleware `npm run test` **8468/8485** grün, `typecheck` + `lint` clean · desktop **217/217** · updater-Sidecar **100/100** · canvas-core typecheck clean.

> Die 17 Nicht-Grünen sind 16 `skipped` plus `conductorDiscussionHere.test.ts`, und das war ein veraltetes `dist/` in `packages/harness-plugin-discussion` (aus dem parallel gemergten #1027) — nach `npm run build` dort **24/24**. Nichts davon berührt diesen PR.

## Nebenbefund, bewusst nicht hier gefixt

`desktop (typecheck + test)` ist **kein** required Check. Ein roter Desktop-Job blockiert also keinen Merge — bei einem Verzeichnis, das die gesamte Ersteindruck-Fläche der App ist und in drei Beta-Runden den einzigen Blocker geliefert hat. Deshalb liegt der Repo-Grep in `middleware`. Die Kontexte in der Branch-Protection zu ändern ist eine Admin-Entscheidung, kein Code-Change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/1034"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791111809&installation_model_id=428086&pr_number=1034&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F1034&signature=6c77250c369779ac4d8cc438a6495a8c666ab445bd37a84f8345fe2e00455a49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->