### PR TITLE
feat(embeddings): make the keyless embedder installable from the admin page

### DIFF
--- a/middleware/packages/embedding-adapter-local/scripts/fetch-model.mjs
+++ b/middleware/packages/embedding-adapter-local/scripts/fetch-model.mjs
@@ -2,146 +2,68 @@
 /**
  * fetch-model.mjs — download the keyless embedder's weights, once.
  *
- * WHY A SCRIPT AND NOT A RUNTIME DOWNLOAD
- * `@huggingface/transformers` will happily fetch a missing model on first use.
- * That would put a ~144 MB download inside the first user turn, on a machine
- * that may have no egress, with no integrity check and no way to say no. So
- * the adapter runs with `allowRemoteModels = false` and this script is the only
- * thing that reaches the network.
- *
- * WHY NOT VENDOR THE WEIGHTS
- * `desktop/scripts/stage-runtime.mjs` stages the middleware's FULL node_modules
- * into every installer, so a vendored model would land in the macOS arm64,
- * macOS x64, Windows and Linux builds alike — on top of an installer already
- * near 300 MB — for a provider that operators with a key or an Ollama box never
- * activate.
- *
- * Everything is pinned: repository, commit revision, and a SHA-256 per file.
- * A moved tag or a truncated download fails loudly instead of producing a
- * model that embeds into a slightly different vector space than the corpus
- * already holds — a corruption cosine similarity cannot detect.
+ * A thin wrapper. The implementation lives in `src/fetchModel.ts` because the
+ * admin UI drives the same download (see `modelFetcherService.ts`), and the
+ * pinned revision plus the four SHA-256 digests must exist in exactly one
+ * place — they are what stands between a corpus and a silently mixed vector
+ * space.
  *
  * Usage:
+ *   npm run build --workspace @omadia/embedding-adapter-local
  *   node scripts/fetch-model.mjs [targetDir]      # default: var/embedding-models
  *   OMADIA_EMBEDDING_MODEL_DIR=/data/models node scripts/fetch-model.mjs
  */
 
-import { createHash } from 'node:crypto';
-import { mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const REPO = 'Xenova/paraphrase-multilingual-MiniLM-L12-v2';
-/** Commit pin. Bump this and the hashes below together, never one alone. */
-const REVISION = '2c4055b12046f11709e9df2c122e59ffbdc2f900';
-const BASE = 'https://huggingface.co';
+const here = path.dirname(fileURLToPath(import.meta.url));
+const built = path.join(here, '..', 'dist', 'fetchModel.js');
 
-/** The four files transformers.js needs to run this model fully offline,
- *  with the size and digest observed at {@link REVISION}. */
-const FILES = [
-  {
-    name: 'config.json',
-    bytes: 673,
-    sha256: '05b570bff786faa5c4604152aa16f19f77ed6dfc31e47dd0f3dd987078693ac7',
-  },
-  {
-    name: 'tokenizer.json',
-    bytes: 17082913,
-    sha256: 'b60b6b43406a48bf3638526314f3d232d97058bc93472ff2de930d43686fa441',
-  },
-  {
-    name: 'tokenizer_config.json',
-    bytes: 496,
-    sha256: '3f5961b9ac86288cccdb97f32fb848d6187c78e1603958c53f3ea1f296b7d8a2',
-  },
-  {
-    name: 'onnx/model_quantized.onnx',
-    bytes: 118308126,
-    sha256: '66fc00f5f29afcaff34092e1bdd20008ca3918265a82fb9695a551e510cc4ebc',
-  },
-];
+if (!existsSync(built)) {
+  console.error(
+    `[fetch-model] ${built} is missing — run:\n` +
+      '  npm run build --workspace @omadia/embedding-adapter-local',
+  );
+  process.exit(1);
+}
+
+const { PINNED_MODEL_TOTAL_BYTES, fetchLocalEmbeddingModel } = await import(built);
 
 const DEFAULT_DIR = 'var/embedding-models';
+const mb = (bytes) => (bytes / 1024 / 1024).toFixed(1);
 
-function sha256(buffer) {
-  return createHash('sha256').update(buffer).digest('hex');
-}
+const target =
+  process.argv[2] ?? process.env['OMADIA_EMBEDDING_MODEL_DIR'] ?? DEFAULT_DIR;
 
-/** Already there, right size, right digest? Then leave it alone — re-running
- *  this script must be cheap, so a partially-fetched set resumes rather than
- *  starting over. */
-function isIntact(file, absolute) {
-  try {
-    if (statSync(absolute).size !== file.bytes) return false;
-    return sha256(readFileSync(absolute)) === file.sha256;
-  } catch {
-    return false;
-  }
-}
+console.log(
+  `[fetch-model] ${mb(PINNED_MODEL_TOTAL_BYTES)} MB → ${path.resolve(target)}`,
+);
 
-async function download(file, absolute) {
-  const url = `${BASE}/${REPO}/resolve/${REVISION}/${file.name}`;
-  const res = await fetch(url);
-  if (!res.ok) {
-    throw new Error(`GET ${url} → HTTP ${String(res.status)}`);
-  }
-  const buffer = Buffer.from(await res.arrayBuffer());
-  const digest = sha256(buffer);
-  if (digest !== file.sha256) {
-    throw new Error(
-      `${file.name}: expected sha256 ${file.sha256}, got ${digest} — ` +
-        'refusing to install weights that do not match the pin',
-    );
-  }
-  if (buffer.byteLength !== file.bytes) {
-    throw new Error(
-      `${file.name}: expected ${String(file.bytes)} bytes, got ${String(buffer.byteLength)}`,
-    );
-  }
-  // Write to a temporary name and rename: a process killed mid-write must not
-  // leave a file that passes an existence check but fails a digest check
-  // deep inside onnxruntime.
-  const temporary = `${absolute}.partial`;
-  mkdirSync(path.dirname(absolute), { recursive: true });
-  writeFileSync(temporary, buffer);
-  renameSync(temporary, absolute);
-}
-
-async function main() {
-  const target =
-    process.argv[2] ?? process.env['OMADIA_EMBEDDING_MODEL_DIR'] ?? DEFAULT_DIR;
-  const root = path.resolve(target, ...REPO.split('/'));
-  console.log(`[fetch-model] ${REPO} @ ${REVISION.slice(0, 8)} → ${root}`);
-
-  let fetched = 0;
-  for (const file of FILES) {
-    const absolute = path.join(root, ...file.name.split('/'));
-    if (isIntact(file, absolute)) {
-      console.log(`  ✓ ${file.name} (already present, digest verified)`);
-      continue;
-    }
-    const mb = (file.bytes / 1024 / 1024).toFixed(1);
-    console.log(`  ↓ ${file.name} (${mb} MB)`);
-    try {
-      await download(file, absolute);
-    } catch (err) {
-      rmSync(`${absolute}.partial`, { force: true });
-      throw err;
-    }
-    fetched += 1;
-  }
-
-  const total = FILES.reduce((sum, f) => sum + f.bytes, 0);
+let lastFile;
+try {
+  const result = await fetchLocalEmbeddingModel({
+    targetDir: target,
+    onProgress: ({ downloadedBytes, totalBytes, currentFile }) => {
+      if (currentFile && currentFile !== lastFile) {
+        lastFile = currentFile;
+        console.log(`  ↓ ${currentFile}`);
+      }
+      if (!currentFile) {
+        const pct = ((downloadedBytes / totalBytes) * 100).toFixed(0);
+        console.log(`    ${pct}% (${mb(downloadedBytes)} / ${mb(totalBytes)} MB)`);
+      }
+    },
+  });
   console.log(
-    `[fetch-model] done — ${String(fetched)} file(s) fetched, ` +
-      `${(total / 1024 / 1024).toFixed(0)} MB on disk.`,
+    `[fetch-model] done — ${String(result.fetched)} file(s) fetched into ${result.modelDir}.`,
   );
   console.log(
     '[fetch-model] Remember: set process_dedup_threshold=0.45 in the knowledge-graph ' +
       "plugin. This model's cosine scale is not the 0.90 default, and at 0.90 dedup never fires.",
   );
-}
-
-main().catch((err) => {
+} catch (err) {
   console.error(`[fetch-model] ${err instanceof Error ? err.message : String(err)}`);
   process.exit(1);
-});
+}

--- a/middleware/packages/embedding-adapter-local/src/fetchModel.ts
+++ b/middleware/packages/embedding-adapter-local/src/fetchModel.ts
@@ -1,0 +1,212 @@
+import { createHash } from 'node:crypto';
+import {
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import path from 'node:path';
+
+import { LOCAL_EMBEDDING_MODEL, modelPath } from './localEmbeddingClient.js';
+
+/**
+ * Downloading the keyless embedder's weights, once — programmatically.
+ *
+ * WHY THIS IS A MODULE AND NOT JUST THE CLI IT USED TO BE
+ * The CLI (`scripts/fetch-model.mjs`) covers a developer. It does not cover the
+ * person this whole adapter exists for: a subscription user on the desktop app,
+ * who has no terminal in the flow and for whom "run npm run fetch-model" is
+ * indistinguishable from "you cannot have this". So the admin UI drives the same
+ * download, and both entry points share this one implementation rather than two
+ * copies of a pinned digest list.
+ *
+ * `@huggingface/transformers` would happily fetch a missing model on first use.
+ * That would put a ~135 MB download inside the first user turn, on a machine
+ * that may have no egress, with no integrity check and no way to say no — so
+ * the adapter runs with `allowRemoteModels = false` and this is the only code
+ * that reaches the network.
+ *
+ * Everything is pinned: repository, commit revision, and a SHA-256 per file. A
+ * moved tag or a truncated download fails loudly instead of producing a model
+ * that embeds into a slightly different space than the corpus already holds —
+ * a corruption cosine similarity cannot detect and no later check repairs.
+ */
+
+/** Commit pin. Bump this and the digests below together, never one alone. */
+export const MODEL_REVISION = '2c4055b12046f11709e9df2c122e59ffbdc2f900';
+
+const HUGGINGFACE_BASE = 'https://huggingface.co';
+
+export interface PinnedModelFile {
+  readonly name: string;
+  readonly bytes: number;
+  readonly sha256: string;
+}
+
+/** The four files transformers.js needs to run this model fully offline, with
+ *  the size and digest observed at {@link MODEL_REVISION}. */
+export const PINNED_MODEL_FILES: readonly PinnedModelFile[] = [
+  {
+    name: 'config.json',
+    bytes: 673,
+    sha256: '05b570bff786faa5c4604152aa16f19f77ed6dfc31e47dd0f3dd987078693ac7',
+  },
+  {
+    name: 'tokenizer.json',
+    bytes: 17_082_913,
+    sha256: 'b60b6b43406a48bf3638526314f3d232d97058bc93472ff2de930d43686fa441',
+  },
+  {
+    name: 'tokenizer_config.json',
+    bytes: 496,
+    sha256: '3f5961b9ac86288cccdb97f32fb848d6187c78e1603958c53f3ea1f296b7d8a2',
+  },
+  {
+    name: 'onnx/model_quantized.onnx',
+    bytes: 118_308_126,
+    sha256: '66fc00f5f29afcaff34092e1bdd20008ca3918265a82fb9695a551e510cc4ebc',
+  },
+];
+
+/** Total download size — what a UI has to be honest about before starting. */
+export const PINNED_MODEL_TOTAL_BYTES = PINNED_MODEL_FILES.reduce(
+  (sum, file) => sum + file.bytes,
+  0,
+);
+
+export interface FetchProgress {
+  /** Bytes of fully verified, installed files. Never a partial file: a
+   *  half-downloaded file is not progress the operator can rely on. */
+  readonly downloadedBytes: number;
+  readonly totalBytes: number;
+  /** File currently being fetched, or `undefined` once everything is in. */
+  readonly currentFile?: string;
+}
+
+export interface FetchModelOptions {
+  readonly targetDir: string;
+  readonly onProgress?: (progress: FetchProgress) => void;
+  /** Injectable for tests — no test may reach huggingface.co. */
+  readonly fetchImpl?: typeof fetch;
+  /**
+   * The file set to verify and fetch. Defaults to {@link PINNED_MODEL_FILES},
+   * which is what production always uses.
+   *
+   * It is a parameter so the skip / download / refuse logic can be tested
+   * against digests a test can actually produce. The alternative was a test
+   * that writes files of the right LENGTH and pretends their digest matches —
+   * which cannot be true, and would have quietly turned the resume case into a
+   * download case. Better an honest seam than a test that lies about what it
+   * exercised.
+   */
+  readonly files?: readonly PinnedModelFile[];
+}
+
+export interface FetchModelResult {
+  readonly modelDir: string;
+  /** Files actually downloaded; 0 means everything was already verified. */
+  readonly fetched: number;
+  readonly totalBytes: number;
+}
+
+function sha256(buffer: Buffer): string {
+  return createHash('sha256').update(buffer).digest('hex');
+}
+
+/**
+ * Already there, right size, right digest?
+ *
+ * Re-running must be cheap, so a partially-fetched set resumes instead of
+ * starting over — and the digest is re-checked rather than trusted, because
+ * the failure this guards against (a file that exists but is wrong) is exactly
+ * the one a size check alone lets through.
+ */
+export function isFileIntact(file: PinnedModelFile, absolute: string): boolean {
+  try {
+    if (statSync(absolute).size !== file.bytes) return false;
+    return sha256(readFileSync(absolute)) === file.sha256;
+  } catch {
+    return false;
+  }
+}
+
+export function modelFileUrl(file: PinnedModelFile): string {
+  return `${HUGGINGFACE_BASE}/${LOCAL_EMBEDDING_MODEL}/resolve/${MODEL_REVISION}/${file.name}`;
+}
+
+async function downloadOne(
+  file: PinnedModelFile,
+  absolute: string,
+  fetchImpl: typeof fetch,
+): Promise<void> {
+  const url = modelFileUrl(file);
+  const response = await fetchImpl(url);
+  if (!response.ok) {
+    throw new Error(`GET ${url} → HTTP ${String(response.status)}`);
+  }
+  const buffer = Buffer.from(await response.arrayBuffer());
+  const digest = sha256(buffer);
+  if (digest !== file.sha256) {
+    throw new Error(
+      `${file.name}: expected sha256 ${file.sha256}, got ${digest} — ` +
+        'refusing to install weights that do not match the pin',
+    );
+  }
+  if (buffer.byteLength !== file.bytes) {
+    throw new Error(
+      `${file.name}: expected ${String(file.bytes)} bytes, got ${String(buffer.byteLength)}`,
+    );
+  }
+  // Write to a temporary name and rename. A process killed mid-write must not
+  // leave a file that passes an existence check and then fails a digest check
+  // deep inside onnxruntime.
+  const temporary = `${absolute}.partial`;
+  mkdirSync(path.dirname(absolute), { recursive: true });
+  try {
+    writeFileSync(temporary, buffer);
+    renameSync(temporary, absolute);
+  } catch (err) {
+    rmSync(temporary, { force: true });
+    throw err;
+  }
+}
+
+/** Fetch every pinned file that is not already present and verified. */
+export async function fetchLocalEmbeddingModel(
+  options: FetchModelOptions,
+): Promise<FetchModelResult> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const files = options.files ?? PINNED_MODEL_FILES;
+  const totalBytes = files.reduce((sum, file) => sum + file.bytes, 0);
+  const root = modelPath(options.targetDir);
+  let downloadedBytes = 0;
+  let fetched = 0;
+
+  for (const file of files) {
+    const absolute = path.join(root, ...file.name.split('/'));
+    if (isFileIntact(file, absolute)) {
+      downloadedBytes += file.bytes;
+      options.onProgress?.({
+        downloadedBytes,
+        totalBytes,
+      });
+      continue;
+    }
+    options.onProgress?.({
+      downloadedBytes,
+      totalBytes,
+      currentFile: file.name,
+    });
+    await downloadOne(file, absolute, fetchImpl);
+    downloadedBytes += file.bytes;
+    fetched += 1;
+    options.onProgress?.({
+      downloadedBytes,
+      totalBytes,
+    });
+  }
+
+  return { modelDir: root, fetched, totalBytes };
+}

--- a/middleware/packages/embedding-adapter-local/src/index.ts
+++ b/middleware/packages/embedding-adapter-local/src/index.ts
@@ -28,3 +28,26 @@ export {
   missingModelFiles,
   modelPath,
 } from './localEmbeddingClient.js';
+
+export type {
+  FetchModelOptions,
+  FetchModelResult,
+  FetchProgress,
+  PinnedModelFile,
+} from './fetchModel.js';
+export {
+  MODEL_REVISION,
+  PINNED_MODEL_FILES,
+  PINNED_MODEL_TOTAL_BYTES,
+  fetchLocalEmbeddingModel,
+  isFileIntact,
+  modelFileUrl,
+} from './fetchModel.js';
+
+export type {
+  FetchJobState,
+  LocalEmbeddingModelFetcher,
+  LocalEmbeddingModelStatus,
+  ModelFetcherOptions,
+} from './modelFetcherService.js';
+export { createLocalEmbeddingModelFetcher } from './modelFetcherService.js';

--- a/middleware/packages/embedding-adapter-local/src/modelFetcherService.ts
+++ b/middleware/packages/embedding-adapter-local/src/modelFetcherService.ts
@@ -1,0 +1,121 @@
+import {
+  PINNED_MODEL_TOTAL_BYTES,
+  fetchLocalEmbeddingModel,
+  type FetchProgress,
+} from './fetchModel.js';
+import { missingModelFiles } from './localEmbeddingClient.js';
+
+/**
+ * `localEmbeddingModelFetcher` — the service that makes the keyless path
+ * clickable.
+ *
+ * WHY A SERVICE AND NOT AN IMPORT IN THE ROUTE
+ * `embeddingProviderCatalog.ts` states the rule: the kernel names the embedding
+ * adapters by id and reads what they publish structurally, but never imports
+ * them — either adapter may be uninstalled, and a build dependency on them
+ * would invert that. A download, unlike the dimension previews next door,
+ * cannot tolerate a duplicated table either: the pinned revision and the four
+ * SHA-256 digests are what stand between a corpus and a silently mixed vector
+ * space, so they must live in exactly one place. Publishing a service satisfies
+ * both — the plugin keeps the pin, the route keeps its distance.
+ *
+ * It is published EVEN WHEN THE WEIGHTS ARE MISSING, which is the only moment
+ * it is useful. That is also why it is a separate service from
+ * `embeddingClient`: that one means "embeddings work", this one means "here is
+ * how to make them work", and conflating them would have the admin page ask a
+ * capability that does not exist yet whether it can install itself.
+ */
+
+export type FetchJobState = 'idle' | 'running' | 'done' | 'failed';
+
+export interface LocalEmbeddingModelStatus {
+  /** Cache root the adapter reads — shown so an operator can see WHERE. */
+  readonly modelDir: string;
+  /** Empty ⇒ the adapter can publish the capability. */
+  readonly missingFiles: readonly string[];
+  readonly totalBytes: number;
+  readonly job: {
+    readonly state: FetchJobState;
+    readonly downloadedBytes: number;
+    readonly totalBytes: number;
+    readonly currentFile: string | null;
+    /** Set only in `failed`. Kept until the next run so the UI can show it. */
+    readonly error: string | null;
+  };
+}
+
+/** Structural contract the admin route reads. Keep in sync with
+ *  `LocalEmbeddingModelFetcher` in `adminEmbeddingProvider.ts`. */
+export interface LocalEmbeddingModelFetcher {
+  status(): LocalEmbeddingModelStatus;
+  /** Single-flight. `false` ⇒ a run was already in progress. */
+  start(): boolean;
+}
+
+export interface ModelFetcherOptions {
+  readonly modelDir: string;
+  readonly log: (message: string) => void;
+  /** Injectable for tests — no test may reach huggingface.co. */
+  readonly fetchImpl?: typeof fetch;
+}
+
+export function createLocalEmbeddingModelFetcher(
+  options: ModelFetcherOptions,
+): LocalEmbeddingModelFetcher {
+  let state: FetchJobState = 'idle';
+  let progress: FetchProgress = {
+    downloadedBytes: 0,
+    totalBytes: PINNED_MODEL_TOTAL_BYTES,
+  };
+  let error: string | null = null;
+
+  return {
+    status: () => ({
+      modelDir: options.modelDir,
+      missingFiles: missingModelFiles(options.modelDir),
+      totalBytes: PINNED_MODEL_TOTAL_BYTES,
+      job: {
+        state,
+        downloadedBytes: progress.downloadedBytes,
+        totalBytes: progress.totalBytes,
+        currentFile: progress.currentFile ?? null,
+        error,
+      },
+    }),
+
+    start: () => {
+      // Single-flight by state, not by a lock: two operators clicking at once
+      // would otherwise write the same 135 MB through the same `.partial`
+      // paths and race the renames.
+      if (state === 'running') return false;
+      state = 'running';
+      error = null;
+      progress = { downloadedBytes: 0, totalBytes: PINNED_MODEL_TOTAL_BYTES };
+
+      // Deliberately NOT awaited. The caller is an HTTP handler and this takes
+      // minutes; the route answers 202 and the UI polls `status()`.
+      void fetchLocalEmbeddingModel({
+        targetDir: options.modelDir,
+        onProgress: (next) => {
+          progress = next;
+        },
+        ...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+      })
+        .then((result) => {
+          state = 'done';
+          options.log(
+            `[embedding-adapter-local] weights ready in ${result.modelDir} ` +
+              `(${String(result.fetched)} file(s) fetched). ` +
+              'Activate the adapter to publish embeddingClient@1.',
+          );
+        })
+        .catch((err: unknown) => {
+          state = 'failed';
+          error = err instanceof Error ? err.message : String(err);
+          options.log(`[embedding-adapter-local] weight download failed: ${error}`);
+        });
+
+      return true;
+    },
+  };
+}

--- a/middleware/packages/embedding-adapter-local/src/plugin.ts
+++ b/middleware/packages/embedding-adapter-local/src/plugin.ts
@@ -4,6 +4,7 @@ import {
   type PluginContext,
 } from '@omadia/plugin-api';
 
+import { createLocalEmbeddingModelFetcher } from './modelFetcherService.js';
 import {
   LOCAL_EMBEDDING_DIMENSIONS,
   LOCAL_EMBEDDING_MODEL,
@@ -52,6 +53,8 @@ import {
  */
 
 const EMBEDDING_CLIENT_SERVICE = 'embeddingClient';
+/** Published even without weights — see `modelFetcherService.ts`. */
+const MODEL_FETCHER_SERVICE = 'localEmbeddingModelFetcher';
 /** Under the middleware's own tree, so a container bind-mount or a desktop
  *  data dir can redirect it with one config field. */
 const DEFAULT_MODEL_DIR = 'var/embedding-models';
@@ -83,6 +86,28 @@ export async function activate(
     DEFAULT_MAX_CONCURRENT,
   );
 
+  // Published on BOTH paths, and on the missing-weights path it is the whole
+  // point: the admin page needs something to ask "can I install this?" exactly
+  // when the capability does not exist yet. `provide` is wrapped because this
+  // plugin may activate beside a sibling adapter (see the note further down)
+  // and a duplicate name throws.
+  const fetcher = createLocalEmbeddingModelFetcher({
+    modelDir,
+    log: (message) => ctx.log(message),
+  });
+  let disposeFetcher: (() => void) | undefined;
+  try {
+    disposeFetcher = ctx.services.provide(MODEL_FETCHER_SERVICE, fetcher);
+  } catch (err) {
+    ctx.log(
+      `[embedding-adapter-local] ${MODEL_FETCHER_SERVICE} already provided ` +
+        `(${err instanceof Error ? err.message : String(err)}) — not re-publishing`,
+    );
+  }
+  const releaseFetcher = (): void => {
+    disposeFetcher?.();
+  };
+
   const missing = (overrides.missingFiles ?? missingModelFiles)(modelDir);
   if (missing.length > 0) {
     // Naming the first missing file rather than "model not found": the two
@@ -91,9 +116,10 @@ export async function activate(
     ctx.log(
       `[embedding-adapter-local] model weights incomplete in ${modelPath(modelDir)} ` +
         `(missing: ${missing.join(', ')}) — plugin active but capability not published. ` +
-        `Fetch them with: npm run fetch-model --workspace @omadia/embedding-adapter-local`,
+        `Fetch them with: npm run fetch-model --workspace @omadia/embedding-adapter-local, ` +
+        'or from ADMIN → LLM-Zugang → Embeddings, which drives the same download.',
     );
-    return { close: closeNoop(ctx) };
+    return { close: closeNoop(ctx, releaseFetcher) };
   }
 
   const raw: EmbeddingProvider = createLocalEmbeddingClient({
@@ -128,7 +154,7 @@ export async function activate(
         `(${err instanceof Error ? err.message : String(err)}) — standing down, capability not published. ` +
         'Uninstall or blank out the Ollama / OpenAI-compatible adapter to switch to the keyless one.',
     );
-    return { close: closeNoop(ctx) };
+    return { close: closeNoop(ctx, releaseFetcher) };
   }
   ctx.log(
     `[embedding-adapter-local] ${client.modelId} ready ` +
@@ -140,14 +166,21 @@ export async function activate(
   return {
     close: async () => {
       dispose();
+      releaseFetcher();
       ctx.log('[embedding-adapter-local] capability withdrawn');
     },
   };
 }
 
-function closeNoop(ctx: PluginContext): () => Promise<void> {
+function closeNoop(
+  ctx: PluginContext,
+  release?: () => void,
+): () => Promise<void> {
   return async () => {
-    ctx.log('[embedding-adapter-local] deactivated (nothing was published)');
+    release?.();
+    ctx.log(
+      '[embedding-adapter-local] deactivated (embeddingClient was never published)',
+    );
   };
 }
 

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -168,7 +168,10 @@ import { createRegistryInstallRouter } from './routes/registryInstall.js';
 import { createRuntimeRouter } from './routes/runtime.js';
 import { createAdminSettingsRouter } from './routes/adminSettings.js';
 import { createAdminProvidersRouter } from './routes/adminProviders.js';
-import { createAdminEmbeddingProviderRouter } from './routes/adminEmbeddingProvider.js';
+import {
+  createAdminEmbeddingProviderRouter,
+  type LocalEmbeddingModelFetcher,
+} from './routes/adminEmbeddingProvider.js';
 import { createAdminTranscriptionProviderRouter } from './routes/adminTranscriptionProvider.js';
 import { createAdminCliBackendsRouter } from './routes/adminCliBackends.js';
 import { setCliLoginAuthorizedHook } from './platform/cliAuthService.js';
@@ -5008,6 +5011,14 @@ async function main(): Promise<void> {
       catalog: pluginCatalog,
       getEmbeddingClient: () =>
         serviceRegistry.get<EmbeddingClient>('embeddingClient'),
+      // OM-84 follow-up — the keyless adapter publishes this even while its
+      // weights are missing, which is the only moment it is useful. Resolved
+      // per request: it appears the moment that adapter activates and vanishes
+      // when it is swapped out, and a captured copy would outlive both.
+      getLocalModelFetcher: () =>
+        serviceRegistry.get<LocalEmbeddingModelFetcher>(
+          'localEmbeddingModelFetcher',
+        ),
       // Resolved per request, never captured: `vectorWritesAllowed` flips
       // false→true in-process when a stale-vector clear drains, and the whole
       // point of the page is that the operator sees that without a reload.

--- a/middleware/src/routes/adminEmbeddingProvider.ts
+++ b/middleware/src/routes/adminEmbeddingProvider.ts
@@ -95,12 +95,51 @@ const SwitchBodySchema = z.object({
   confirmDiscardVectors: z.boolean().optional(),
 });
 
+/**
+ * Structural view of the keyless adapter's `localEmbeddingModelFetcher`
+ * service. The plugin publishes a plain object
+ * (`packages/embedding-adapter-local/src/modelFetcherService.ts`); this module
+ * only reads it, so neither side imports the other. Same shape of contract as
+ * `EmbeddingGateStatus`.
+ */
+export interface LocalEmbeddingModelFetcher {
+  status(): {
+    readonly modelDir: string;
+    readonly missingFiles: readonly string[];
+    readonly totalBytes: number;
+    readonly job: {
+      readonly state: 'idle' | 'running' | 'done' | 'failed';
+      readonly downloadedBytes: number;
+      readonly totalBytes: number;
+      readonly currentFile: string | null;
+      readonly error: string | null;
+    };
+  };
+  /** Single-flight. `false` ⇒ a run was already in progress. */
+  start(): boolean;
+}
+
 export interface AdminEmbeddingProviderDeps {
   readonly installedRegistry: InstalledRegistry;
   /** Manifest catalog — the source of truth for who provides the capability. */
   readonly catalog: EmbeddingProviderCatalog;
   /** Live `embeddingClient@1` service, as the knowledge-graph resolves it. */
   readonly getEmbeddingClient: () => EmbeddingClient | undefined;
+  /**
+   * The keyless adapter's weight downloader, when that adapter is active.
+   *
+   * OM-84 follow-up — the keyless provider exists but its weights are not
+   * bundled, and "run npm run fetch-model" is indistinguishable from "you
+   * cannot have this" for the desktop user this adapter was built for. So the
+   * page drives the download.
+   *
+   * Resolved per request and never imported: same rule as the dimension
+   * previews in `embeddingProviderCatalog.ts` — the kernel reads what the
+   * adapters publish structurally and takes no build dependency on either,
+   * since both may be uninstalled. `undefined` simply means the keyless
+   * adapter is not active, which is the normal state on a keyed deployment.
+   */
+  readonly getLocalModelFetcher?: () => LocalEmbeddingModelFetcher | undefined;
   /** Live gate verdict. NOT cached — `vectorWritesAllowed` flips false→true
    *  in-process when a stale-vector clear drains, and a captured copy would
    *  show a stale red forever. Also carries the (non-enumerable) `reevaluate`
@@ -454,6 +493,62 @@ export function createAdminEmbeddingProviderRouter(deps: AdminEmbeddingProviderD
         message: err instanceof Error ? err.message : String(err),
       });
     }
+  });
+
+  /**
+   * What the keyless adapter needs before it can publish anything, and how far
+   * a running download has got. 404 rather than an empty body when the adapter
+   * is not active: "there is no keyless provider here" and "its weights are
+   * missing" are different answers and the UI reacts differently to each.
+   */
+  router.get('/local-model', (_req: Request, res: Response) => {
+    const fetcher = deps.getLocalModelFetcher?.();
+    if (!fetcher) {
+      res.status(404).json({
+        code: 'embeddingProvider.local_model_unavailable',
+        message:
+          'the keyless embedding adapter (@omadia/embedding-adapter-local) is not active',
+      });
+      return;
+    }
+    res.json(fetcher.status());
+  });
+
+  /**
+   * Start the download. Answers 202 immediately — it moves ~135 MB and takes
+   * minutes, so holding the request open would just time out behind whatever
+   * proxy sits in front. The UI polls `GET /local-model`.
+   *
+   * 409 on a second click while one is running, rather than silently starting
+   * a second run: two runs would write the same `.partial` paths and race the
+   * renames.
+   */
+  router.post('/local-model/fetch', (_req: Request, res: Response) => {
+    const fetcher = deps.getLocalModelFetcher?.();
+    if (!fetcher) {
+      res.status(404).json({
+        code: 'embeddingProvider.local_model_unavailable',
+        message:
+          'the keyless embedding adapter (@omadia/embedding-adapter-local) is not active',
+      });
+      return;
+    }
+    const status = fetcher.status();
+    if (status.missingFiles.length === 0) {
+      // Nothing to do, and saying so beats a 202 that resolves instantly and
+      // leaves the operator wondering whether anything happened.
+      res.json({ ok: true, started: false, reason: 'already-complete', ...status });
+      return;
+    }
+    if (!fetcher.start()) {
+      res.status(409).json({
+        code: 'embeddingProvider.local_model_busy',
+        message: 'a weight download is already running',
+        ...fetcher.status(),
+      });
+      return;
+    }
+    res.status(202).json({ ok: true, started: true, ...fetcher.status() });
   });
 
   router.post('/switch', async (req: Request, res: Response) => {

--- a/middleware/test/adminEmbeddingProviderLocalModel.test.ts
+++ b/middleware/test/adminEmbeddingProviderLocalModel.test.ts
@@ -1,0 +1,183 @@
+import { strict as assert } from 'node:assert';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { after, before, describe, it } from 'node:test';
+
+import express from 'express';
+
+import {
+  createAdminEmbeddingProviderRouter,
+  type AdminEmbeddingProviderDeps,
+  type LocalEmbeddingModelFetcher,
+} from '../src/routes/adminEmbeddingProvider.js';
+import { InMemoryInstalledRegistry } from '../src/plugins/installedRegistry.js';
+
+/**
+ * `GET /local-model` and `POST /local-model/fetch` (OM-84 follow-up).
+ *
+ * Its own tiny app rather than the shared `adminEmbeddingProvider.harness.ts`:
+ * these two routes touch none of the corpus/gate machinery that harness exists
+ * to model, and teaching it a fetcher would have meant changing a file three
+ * other specs depend on for a feature none of them exercise.
+ *
+ * The fetcher is a fake with an explicit state, because the thing under test is
+ * the ROUTE's contract — which status code means what — and the real fetcher's
+ * behaviour is pinned next door in `localEmbeddingModelFetch.test.ts`.
+ */
+
+let server: Server;
+let baseUrl: string;
+let fetcher: LocalEmbeddingModelFetcher | undefined;
+let startResult = true;
+let startCalls = 0;
+
+function status(missing: readonly string[], state: 'idle' | 'running' | 'done' | 'failed', error: string | null = null) {
+  return {
+    modelDir: '/var/embedding-models',
+    missingFiles: missing,
+    totalBytes: 135_392_208,
+    job: {
+      state,
+      downloadedBytes: state === 'done' ? 135_392_208 : 0,
+      totalBytes: 135_392_208,
+      currentFile: state === 'running' ? 'onnx/model_quantized.onnx' : null,
+      error,
+    },
+  };
+}
+
+function fakeFetcher(
+  missing: readonly string[],
+  state: 'idle' | 'running' | 'done' | 'failed' = 'idle',
+  error: string | null = null,
+): LocalEmbeddingModelFetcher {
+  return {
+    status: () => status(missing, state, error),
+    start: () => {
+      startCalls += 1;
+      return startResult;
+    },
+  };
+}
+
+before(async () => {
+  const deps = {
+    installedRegistry: new InMemoryInstalledRegistry(),
+    catalog: { list: () => [], get: () => undefined },
+    getEmbeddingClient: () => undefined,
+    getLocalModelFetcher: () => fetcher,
+    getGateStatus: () => undefined,
+    getGraphPool: () => undefined,
+    tenantId: 'default',
+    activate: async () => {},
+    deactivate: async () => true,
+  } as unknown as AdminEmbeddingProviderDeps;
+
+  const app = express();
+  app.use(express.json());
+  app.use('/', createAdminEmbeddingProviderRouter(deps));
+  server = createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  baseUrl = `http://127.0.0.1:${String((server.address() as AddressInfo).port)}`;
+});
+
+after(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+async function get(path: string) {
+  const res = await fetch(`${baseUrl}${path}`);
+  return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+}
+
+async function post(path: string) {
+  const res = await fetch(`${baseUrl}${path}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: '{}',
+  });
+  return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+}
+
+describe('GET /local-model', () => {
+  it('404s when the keyless adapter is not active', async () => {
+    fetcher = undefined;
+    const res = await get('/local-model');
+    // Not an empty 200: "there is no keyless provider here" and "its weights
+    // are missing" are different answers and the page reacts differently — a
+    // keyed deployment must render no button and no error at all.
+    assert.equal(res.status, 404);
+    assert.equal(res.body['code'], 'embeddingProvider.local_model_unavailable');
+  });
+
+  it('reports the missing files and the download size', async () => {
+    fetcher = fakeFetcher(['onnx/model_quantized.onnx']);
+    const res = await get('/local-model');
+    assert.equal(res.status, 200);
+    assert.deepEqual(res.body['missingFiles'], ['onnx/model_quantized.onnx']);
+    assert.equal(res.body['totalBytes'], 135_392_208);
+    assert.equal(res.body['modelDir'], '/var/embedding-models');
+  });
+
+  it('passes a failure message through so the page can show it', async () => {
+    fetcher = fakeFetcher(['config.json'], 'failed', 'GET … → HTTP 503');
+    const res = await get('/local-model');
+    const job = res.body['job'] as Record<string, unknown>;
+    assert.equal(job['state'], 'failed');
+    assert.equal(job['error'], 'GET … → HTTP 503');
+  });
+});
+
+describe('POST /local-model/fetch', () => {
+  it('404s when the keyless adapter is not active', async () => {
+    fetcher = undefined;
+    const res = await post('/local-model/fetch');
+    assert.equal(res.status, 404);
+    assert.equal(res.body['code'], 'embeddingProvider.local_model_unavailable');
+  });
+
+  it('answers 202 and starts the run', async () => {
+    fetcher = fakeFetcher(['onnx/model_quantized.onnx']);
+    startResult = true;
+    startCalls = 0;
+
+    const res = await post('/local-model/fetch');
+
+    // 202, not 200: the download moves ~135 MB and takes minutes. Holding the
+    // request open would time out behind a proxy, which is indistinguishable
+    // from a broken download.
+    assert.equal(res.status, 202);
+    assert.equal(res.body['started'], true);
+    assert.equal(startCalls, 1);
+  });
+
+  it('answers 409 on a second click while one is running', async () => {
+    fetcher = fakeFetcher(['onnx/model_quantized.onnx'], 'running');
+    startResult = false;
+    startCalls = 0;
+
+    const res = await post('/local-model/fetch');
+
+    // Two runs would write the same `.partial` paths and race the renames.
+    assert.equal(res.status, 409);
+    assert.equal(res.body['code'], 'embeddingProvider.local_model_busy');
+    assert.equal(startCalls, 1, 'the route asks the fetcher, it does not guess');
+    // The busy answer still carries the progress, so the page has something
+    // to show instead of only an error.
+    assert.ok(res.body['job']);
+  });
+
+  it('does not start a run when nothing is missing', async () => {
+    fetcher = fakeFetcher([], 'idle');
+    startCalls = 0;
+
+    const res = await post('/local-model/fetch');
+
+    // A 202 that resolves instantly would leave the operator wondering
+    // whether anything happened at all.
+    assert.equal(res.status, 200);
+    assert.equal(res.body['started'], false);
+    assert.equal(res.body['reason'], 'already-complete');
+    assert.equal(startCalls, 0, 'must not touch the network when complete');
+  });
+});

--- a/middleware/test/localEmbeddingModelFetch.test.ts
+++ b/middleware/test/localEmbeddingModelFetch.test.ts
@@ -1,0 +1,250 @@
+import { strict as assert } from 'node:assert';
+import { createHash } from 'node:crypto';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { after, describe, it } from 'node:test';
+
+import {
+  PINNED_MODEL_FILES,
+  PINNED_MODEL_TOTAL_BYTES,
+  fetchLocalEmbeddingModel,
+  isFileIntact,
+  modelFileUrl,
+} from '../packages/embedding-adapter-local/src/fetchModel.js';
+import { createLocalEmbeddingModelFetcher } from '../packages/embedding-adapter-local/src/modelFetcherService.js';
+import { modelPath } from '../packages/embedding-adapter-local/src/localEmbeddingClient.js';
+
+/**
+ * The weight download (OM-84 follow-up), with no network anywhere.
+ *
+ * `fetchImpl` is injected in every case. A test that actually reached
+ * huggingface.co would move 135 MB per run and would pass or fail on someone
+ * else's uptime — and the thing worth pinning here is not that HTTP works, it
+ * is that a WRONG payload is refused. Digests are what stand between a corpus
+ * and a silently mixed vector space, so each rejection has its own case.
+ */
+
+const temporaries: string[] = [];
+after(() => {
+  for (const dir of temporaries) rmSync(dir, { recursive: true, force: true });
+});
+
+function scratch(): string {
+  const root = mkdtempSync(path.join(tmpdir(), 'omadia-fetchmodel-'));
+  temporaries.push(root);
+  return root;
+}
+
+/** The real pinned bytes are unknowable here, so the fake server answers with
+ *  the digest each file declares — proving the CHECK, not the content. */
+function serverWithCorrectDigests(bodies: Map<string, Buffer>): typeof fetch {
+  return (async (input: string | URL | Request) => {
+    const url = String(input);
+    const body = bodies.get(url);
+    if (!body) return new Response('not found', { status: 404 });
+    return new Response(new Uint8Array(body), { status: 200 });
+  }) as unknown as typeof fetch;
+}
+
+/** Bodies whose sha256 matches the pin — built by brute-forcing nothing: the
+ *  test replaces the pinned list instead where content matters. */
+describe('fetchLocalEmbeddingModel — the refusals', () => {
+  it('refuses a payload whose digest does not match the pin', async () => {
+    const root = scratch();
+    const bodies = new Map<string, Buffer>();
+    for (const file of PINNED_MODEL_FILES) {
+      bodies.set(modelFileUrl(file), Buffer.from('wrong content'));
+    }
+    await assert.rejects(
+      () => fetchLocalEmbeddingModel({ targetDir: root, fetchImpl: serverWithCorrectDigests(bodies) }),
+      /expected sha256 .* got .* refusing to install weights that do not match the pin/s,
+    );
+    // And nothing may be left behind that a later existence check would accept.
+    const first = PINNED_MODEL_FILES[0];
+    assert.ok(first);
+    const landed = path.join(modelPath(root), ...first.name.split('/'));
+    assert.throws(() => statSync(landed), /ENOENT/);
+    assert.throws(() => statSync(`${landed}.partial`), /ENOENT/);
+  });
+
+  it('surfaces an HTTP failure with the URL it asked for', async () => {
+    const root = scratch();
+    const empty = serverWithCorrectDigests(new Map());
+    await assert.rejects(
+      () => fetchLocalEmbeddingModel({ targetDir: root, fetchImpl: empty }),
+      /HTTP 404/,
+    );
+  });
+
+  it('pins the revision into every URL', () => {
+    for (const file of PINNED_MODEL_FILES) {
+      const url = modelFileUrl(file);
+      assert.match(url, /^https:\/\/huggingface\.co\//);
+      // A `resolve/main` URL would silently follow a moved branch — the whole
+      // reason the digests exist is that the bytes must not change under us.
+      assert.doesNotMatch(url, /\/resolve\/main\//);
+      assert.match(url, /\/resolve\/[0-9a-f]{40}\//);
+    }
+  });
+
+  it('states a total that matches the sum of the parts', () => {
+    const summed = PINNED_MODEL_FILES.reduce((s, f) => s + f.bytes, 0);
+    assert.equal(PINNED_MODEL_TOTAL_BYTES, summed);
+    // The UI promises this number to the operator before a 135 MB download.
+    assert.ok(summed > 100 * 1024 * 1024, 'expected a nine-figure byte total');
+  });
+});
+
+describe('isFileIntact', () => {
+  it('is false for a missing file, a short file and a wrong-digest file', () => {
+    const root = scratch();
+    const file = PINNED_MODEL_FILES[0];
+    assert.ok(file);
+    const absolute = path.join(root, 'config.json');
+
+    assert.equal(isFileIntact(file, absolute), false, 'missing');
+
+    writeFileSync(absolute, Buffer.alloc(file.bytes - 1, 0x61));
+    assert.equal(isFileIntact(file, absolute), false, 'short');
+
+    // Right SIZE, wrong CONTENT — the case a size check alone lets through,
+    // and the one that would poison the corpus.
+    writeFileSync(absolute, Buffer.alloc(file.bytes, 0x62));
+    assert.equal(isFileIntact(file, absolute), false, 'right size, wrong bytes');
+  });
+});
+
+describe('createLocalEmbeddingModelFetcher', () => {
+  function fetcher(root: string, fetchImpl: typeof fetch) {
+    const logs: string[] = [];
+    return {
+      logs,
+      instance: createLocalEmbeddingModelFetcher({
+        modelDir: root,
+        log: (m) => logs.push(m),
+        fetchImpl,
+      }),
+    };
+  }
+
+  const neverResolves = (() =>
+    new Promise<Response>(() => {
+      /* held open on purpose */
+    })) as unknown as typeof fetch;
+
+  it('reports the missing files before anything runs', () => {
+    const { instance } = fetcher(scratch(), neverResolves);
+    const status = instance.status();
+    assert.equal(status.job.state, 'idle');
+    assert.deepEqual(
+      [...status.missingFiles],
+      PINNED_MODEL_FILES.map((f) => f.name),
+    );
+    assert.equal(status.totalBytes, PINNED_MODEL_TOTAL_BYTES);
+  });
+
+  it('is single-flight — a second start while running is refused', () => {
+    const { instance } = fetcher(scratch(), neverResolves);
+    assert.equal(instance.start(), true);
+    assert.equal(instance.status().job.state, 'running');
+    // Two runs would write the same `.partial` paths and race the renames.
+    assert.equal(instance.start(), false);
+    assert.equal(instance.start(), false);
+  });
+
+  it('returns immediately — start() must not await the download', () => {
+    // The caller is an HTTP handler and this moves 135 MB. If start() awaited,
+    // the request would sit open behind whatever proxy is in front and time
+    // out, which is indistinguishable from a broken download.
+    const { instance } = fetcher(scratch(), neverResolves);
+    const before = Date.now();
+    instance.start();
+    assert.ok(Date.now() - before < 500, 'start() blocked');
+  });
+
+  it('records a failure with its message and stays queryable', async () => {
+    const failing = (async () => new Response('nope', { status: 500 })) as unknown as typeof fetch;
+    const { instance, logs } = fetcher(scratch(), failing);
+    instance.start();
+    await waitFor(() => instance.status().job.state === 'failed');
+    const status = instance.status();
+    assert.match(status.job.error ?? '', /HTTP 500/);
+    assert.match(logs.join('\n'), /weight download failed/);
+    // A failed run must be retryable, not a dead end.
+    assert.equal(instance.start(), true);
+  });
+
+  it('a run that finds everything intact reaches done without a single request', async () => {
+    // Driven by a test-owned file list so the digests are ones this test can
+    // actually produce. The pinned list is exercised by the refusal cases
+    // above; what matters here is the SKIP path, and a "resume" test whose
+    // files could never satisfy the digest check would have silently been
+    // testing the download path instead.
+    const root = scratch();
+    const files = writePinnedSet(root, ['config.json', 'onnx/model_quantized.onnx']);
+    let calls = 0;
+    const counting = (async () => {
+      calls += 1;
+      return new Response('should not be called', { status: 500 });
+    }) as unknown as typeof fetch;
+
+    const result = await fetchLocalEmbeddingModel({
+      targetDir: root,
+      files,
+      fetchImpl: counting,
+    });
+    assert.equal(calls, 0, 'an intact file must not be re-downloaded');
+    assert.equal(result.fetched, 0);
+  });
+
+  it('fetches only the files that are missing', async () => {
+    const root = scratch();
+    const present = writePinnedSet(root, ['config.json']);
+    const missing = pinnedFor('tokenizer_config.json', Buffer.from('fresh bytes'));
+    const served = new Map([[modelFileUrl(missing), Buffer.from('fresh bytes')]]);
+
+    const progress: number[] = [];
+    const result = await fetchLocalEmbeddingModel({
+      targetDir: root,
+      files: [...present, missing],
+      fetchImpl: serverWithCorrectDigests(served),
+      onProgress: (p) => progress.push(p.downloadedBytes),
+    });
+
+    assert.equal(result.fetched, 1, 'only the missing file');
+    const landed = path.join(modelPath(root), 'tokenizer_config.json');
+    assert.equal(readFileSync(landed, 'utf8'), 'fresh bytes');
+    // Progress must be monotonic, or a UI reading it would jump backwards.
+    assert.deepEqual([...progress].sort((a, b) => a - b), progress);
+  });
+});
+
+/** A pinned descriptor for `content`, with the digest computed from it. */
+function pinnedFor(name: string, content: Buffer) {
+  return {
+    name,
+    bytes: content.byteLength,
+    sha256: createHash('sha256').update(content).digest('hex'),
+  };
+}
+
+/** Write `names` into the model dir and return their true descriptors. */
+function writePinnedSet(root: string, names: readonly string[]) {
+  return names.map((name) => {
+    const content = Buffer.from(`content of ${name}`);
+    const absolute = path.join(modelPath(root), ...name.split('/'));
+    mkdirSync(path.dirname(absolute), { recursive: true });
+    writeFileSync(absolute, content);
+    return pinnedFor(name, content);
+  });
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 4_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((r) => setTimeout(r, 10));
+  }
+  throw new Error('condition not reached in time');
+}

--- a/web-ui/app/_components/dashboard/DashboardOnboarding.tsx
+++ b/web-ui/app/_components/dashboard/DashboardOnboarding.tsx
@@ -453,8 +453,11 @@ export function DashboardOnboarding({
       {/* OM-84 (#1003) — a default install runs with embeddings OFF: process
           memory, semantic search and dedup are all disabled, and nothing in
           setup says so. The tester found out when an agent failed mid-answer.
-          Not a fourth step (there is no keyless embedding path yet), but the
-          card must not read as "done" without naming the limitation. */}
+          Still not a fourth step: it is not something every install has to do.
+          But the copy no longer says "no provider is configured" full stop —
+          since #1041 there IS a keyless one, and naming it is the difference
+          between a limitation and a dead end for a subscription user who holds
+          no key. The link lands on the page that can install it. */}
       {embeddingsOff ? (
         <p
           data-testid="onboarding-embeddings-note"

--- a/web-ui/app/_lib/api.ts
+++ b/web-ui/app/_lib/api.ts
@@ -4362,6 +4362,67 @@ export async function switchEmbeddingProvider(
   );
 }
 
+/** How far a keyless-embedder weight download has got. */
+export type LocalEmbeddingFetchState = 'idle' | 'running' | 'done' | 'failed';
+
+/**
+ * OM-84 follow-up — the keyless adapter's weights are deliberately not
+ * bundled (~135 MB in four installers, for a provider a keyed deployment never
+ * activates), so until they are fetched it publishes nothing. This is what the
+ * page needs to offer the download instead of printing a shell command at
+ * someone who has no terminal in the flow.
+ */
+export interface LocalEmbeddingModelState {
+  /** Where the adapter looks for the weights. */
+  modelDir: string;
+  /** Empty ⇒ the adapter can publish `embeddingClient@1`. */
+  missingFiles: string[];
+  totalBytes: number;
+  job: {
+    state: LocalEmbeddingFetchState;
+    downloadedBytes: number;
+    totalBytes: number;
+    currentFile: string | null;
+    /** Set only in `failed`, and kept until the next run. */
+    error: string | null;
+  };
+}
+
+/**
+ * `null` when the keyless adapter is not active — the middleware answers 404,
+ * which is a different fact from "its weights are missing" and the page shows
+ * neither a button nor an error for it.
+ */
+export async function getLocalEmbeddingModel(): Promise<LocalEmbeddingModelState | null> {
+  try {
+    return await getJson<LocalEmbeddingModelState>(
+      '/v1/admin/embedding-provider/local-model',
+    );
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) return null;
+    throw err;
+  }
+}
+
+export interface StartLocalEmbeddingFetchResult extends LocalEmbeddingModelState {
+  ok: true;
+  /** `false` with `reason: 'already-complete'` when nothing was missing. */
+  started: boolean;
+  reason?: 'already-complete';
+}
+
+/**
+ * Start the download. Returns immediately (the middleware answers 202) — poll
+ * {@link getLocalEmbeddingModel} for progress. A second call while one runs
+ * answers 409 `embeddingProvider.local_model_busy`.
+ */
+export async function startLocalEmbeddingModelFetch(): Promise<StartLocalEmbeddingFetchResult> {
+  return postJson<StartLocalEmbeddingFetchResult>(
+    '/v1/admin/embedding-provider/local-model/fetch',
+    {},
+  );
+}
+
 // -----------------------------------------------------------------------------
 // Transcription provider (#584 WS T) — the lean sibling of the embedding
 // section above: /api/v1/admin/transcription-provider, surfaced to the browser

--- a/web-ui/app/admin/embedding-provider/__tests__/page.test.tsx
+++ b/web-ui/app/admin/embedding-provider/__tests__/page.test.tsx
@@ -14,9 +14,16 @@ import EmbeddingProviderPage from '../page';
  *     `vectorWritesAllowed: true` and means "the corpus is being re-earned".
  */
 
-const { mockGetEmbeddingProvider, mockSwitchEmbeddingProvider } = vi.hoisted(() => ({
+const {
+  mockGetEmbeddingProvider,
+  mockSwitchEmbeddingProvider,
+  mockGetLocalEmbeddingModel,
+  mockStartLocalEmbeddingModelFetch,
+} = vi.hoisted(() => ({
   mockGetEmbeddingProvider: vi.fn(),
   mockSwitchEmbeddingProvider: vi.fn(),
+  mockGetLocalEmbeddingModel: vi.fn(),
+  mockStartLocalEmbeddingModelFetch: vi.fn(),
 }));
 
 vi.mock('../../../_lib/api', () => ({
@@ -31,6 +38,8 @@ vi.mock('../../../_lib/api', () => ({
   },
   getEmbeddingProvider: mockGetEmbeddingProvider,
   switchEmbeddingProvider: mockSwitchEmbeddingProvider,
+  getLocalEmbeddingModel: mockGetLocalEmbeddingModel,
+  startLocalEmbeddingModelFetch: mockStartLocalEmbeddingModelFetch,
 }));
 
 const OLLAMA = '@omadia/embeddings';
@@ -85,7 +94,10 @@ function baseState(overrides: Record<string, unknown> = {}) {
   };
 }
 
+/** The default for every existing case: no keyless adapter active, which is
+ *  what a keyed deployment looks like and must render nothing. */
 beforeEach(() => {
+  mockGetLocalEmbeddingModel.mockResolvedValue(null);
   mockGetEmbeddingProvider.mockResolvedValue(baseState());
 });
 
@@ -237,5 +249,113 @@ describe('<EmbeddingProviderPage />', () => {
     const panel = reason.closest('section');
     expect(panel?.className).toContain('--danger');
     expect(panel?.className).not.toContain('--accent');
+  });
+});
+
+/**
+ * OM-84 follow-up — the keyless embedder's weights are not bundled, so until
+ * they are fetched the adapter publishes nothing. Printing a shell command at
+ * a desktop user with no terminal in the flow is the same as telling them no,
+ * so the page drives the download.
+ */
+describe('keyless embedder — weight download', () => {
+  const LOCAL_MODEL = {
+    modelDir: '/var/embedding-models',
+    missingFiles: ['onnx/model_quantized.onnx'],
+    totalBytes: 135_392_208,
+    job: {
+      state: 'idle' as const,
+      downloadedBytes: 0,
+      totalBytes: 135_392_208,
+      currentFile: null,
+      error: null,
+    },
+  };
+
+  it('renders nothing when no keyless adapter is active', async () => {
+    mockGetLocalEmbeddingModel.mockResolvedValue(null);
+
+    renderWithIntl(<EmbeddingProviderPage />);
+    // Same render signal the other cases use: the plugin id, which appears
+    // verbatim in the current-state list.
+    await screen.findByText(OLLAMA);
+
+    // A keyed deployment must not be shown a card about a provider it does not
+    // have — the 404 is a fact about the install, not a failure.
+    expect(screen.queryByTestId('local-model-card')).toBeNull();
+    expect(screen.queryByTestId('local-model-ready')).toBeNull();
+  });
+
+  it('offers the download with its size and location when weights are missing', async () => {
+    mockGetLocalEmbeddingModel.mockResolvedValue(LOCAL_MODEL);
+
+    renderWithIntl(<EmbeddingProviderPage />);
+
+    const card = await screen.findByTestId('local-model-card');
+    // The size has to be stated BEFORE the click: 135 MB on a metered
+    // connection is a decision, not a detail.
+    expect(card.textContent).toContain('129');
+    expect(card.textContent).toContain('/var/embedding-models');
+    expect(screen.getByTestId('local-model-fetch')).toBeTruthy();
+  });
+
+  it('names the dedup threshold, which nobody would otherwise notice', async () => {
+    mockGetLocalEmbeddingModel.mockResolvedValue(LOCAL_MODEL);
+
+    renderWithIntl(<EmbeddingProviderPage />);
+
+    // At the knowledge-graph default of 0.90 this model's dedup never fires,
+    // silently — the same failure class OM-84 was about.
+    const card = await screen.findByTestId('local-model-card');
+    expect(card.textContent).toContain('0.45');
+    expect(card.textContent).toContain('0.90');
+  });
+
+  it('starts the download on click and shows progress instead of the button', async () => {
+    mockGetLocalEmbeddingModel.mockResolvedValue(LOCAL_MODEL);
+    mockStartLocalEmbeddingModelFetch.mockResolvedValue({
+      ok: true,
+      started: true,
+      ...LOCAL_MODEL,
+      job: { ...LOCAL_MODEL.job, state: 'running', currentFile: 'onnx/model_quantized.onnx' },
+    });
+
+    renderWithIntl(<EmbeddingProviderPage />);
+    await userEvent.click(await screen.findByTestId('local-model-fetch'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('local-model-progress')).toBeTruthy();
+    });
+    expect(mockStartLocalEmbeddingModelFetch).toHaveBeenCalledTimes(1);
+    // The button must go away, or a second click races two downloads through
+    // the same .partial paths.
+    expect(screen.queryByTestId('local-model-fetch')).toBeNull();
+  });
+
+  it('shows a failed download with its message', async () => {
+    mockGetLocalEmbeddingModel.mockResolvedValue({
+      ...LOCAL_MODEL,
+      job: { ...LOCAL_MODEL.job, state: 'failed', error: 'GET … → HTTP 503' },
+    });
+
+    renderWithIntl(<EmbeddingProviderPage />);
+
+    const error = await screen.findByTestId('local-model-error');
+    expect(error.textContent).toContain('HTTP 503');
+    // And a failure must stay retryable rather than dead-ending.
+    expect(screen.getByTestId('local-model-fetch')).toBeTruthy();
+  });
+
+  it('confirms readiness once the weights are complete', async () => {
+    mockGetLocalEmbeddingModel.mockResolvedValue({
+      ...LOCAL_MODEL,
+      missingFiles: [],
+      job: { ...LOCAL_MODEL.job, state: 'done', downloadedBytes: LOCAL_MODEL.totalBytes },
+    });
+
+    renderWithIntl(<EmbeddingProviderPage />);
+
+    await screen.findByTestId('local-model-ready');
+    expect(screen.queryByTestId('local-model-card')).toBeNull();
   });
 });

--- a/web-ui/app/admin/embedding-provider/page.tsx
+++ b/web-ui/app/admin/embedding-provider/page.tsx
@@ -9,10 +9,13 @@ import { Button } from '@/app/_components/ui/Button';
 import {
   ApiError,
   getEmbeddingProvider,
+  getLocalEmbeddingModel,
+  startLocalEmbeddingModelFetch,
   switchEmbeddingProvider,
   type EmbeddingGateState,
   type EmbeddingProviderOption,
   type EmbeddingProviderState,
+  type LocalEmbeddingModelState,
 } from '../../_lib/api';
 
 /**
@@ -43,6 +46,8 @@ import {
  *  without a reload. */
 const POLL_INTERVAL_MS = 10_000;
 const POLL_INTERVAL_SECONDS = POLL_INTERVAL_MS / 1000;
+/** While weights are downloading, 10s of nothing reads as "stuck". */
+const DOWNLOAD_POLL_INTERVAL_MS = 2_000;
 
 /** Gate reasons that are progress reports, not failures. Both are published
  *  together with `vectorWritesAllowed: true`. */
@@ -97,6 +102,17 @@ export default function EmbeddingProviderPage(): React.ReactElement {
   const [switchError, setSwitchError] = useState<string | null>(null);
   const [switchedTo, setSwitchedTo] = useState<string | null>(null);
 
+  /**
+   * OM-84 follow-up — the keyless adapter's weights. `null` means that adapter
+   * is not active (the middleware answers 404), which is the normal state on a
+   * keyed deployment and must render nothing at all.
+   */
+  const [localModel, setLocalModel] = useState<LocalEmbeddingModelState | null>(
+    null,
+  );
+  const [fetchStarting, setFetchStarting] = useState(false);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+
   /** Silent re-read used by both the mount fetch and the poll. Never toggles
    *  `loading`, so a poll cannot make the page flash. */
   const refresh = useCallback(async (): Promise<void> => {
@@ -105,6 +121,15 @@ export default function EmbeddingProviderPage(): React.ReactElement {
       setLoadError(null);
     } catch (err) {
       setLoadError(err instanceof Error ? err.message : String(err));
+    }
+    // Settled separately and deliberately not inside the try above: a keyed
+    // deployment has no keyless adapter, and letting its absence blank the
+    // whole page would be a regression for every install that will never use
+    // it.
+    try {
+      setLocalModel(await getLocalEmbeddingModel());
+    } catch {
+      setLocalModel(null);
     }
   }, []);
 
@@ -115,9 +140,33 @@ export default function EmbeddingProviderPage(): React.ReactElement {
     void refresh().finally(() => setLoading(false));
   }, [refresh]);
 
+  const downloading = localModel?.job.state === 'running';
+
   useEffect(() => {
-    const timer = setInterval(() => void refresh(), POLL_INTERVAL_MS);
+    const timer = setInterval(
+      () => void refresh(),
+      downloading ? DOWNLOAD_POLL_INTERVAL_MS : POLL_INTERVAL_MS,
+    );
     return () => clearInterval(timer);
+  }, [refresh, downloading]);
+
+  const onFetchWeights = useCallback(async (): Promise<void> => {
+    setFetchStarting(true);
+    setFetchError(null);
+    try {
+      const result = await startLocalEmbeddingModelFetch();
+      setLocalModel(result);
+    } catch (err) {
+      // A 409 means someone else already started it — not an error worth
+      // shouting about, so re-read and let the progress row speak.
+      if (err instanceof ApiError && err.status === 409) {
+        await refresh();
+      } else {
+        setFetchError(err instanceof Error ? err.message : String(err));
+      }
+    } finally {
+      setFetchStarting(false);
+    }
   }, [refresh]);
 
   const candidates = useMemo(
@@ -238,6 +287,92 @@ export default function EmbeddingProviderPage(): React.ReactElement {
               {t('pollingNote', { seconds: POLL_INTERVAL_SECONDS })}
             </p>
           </section>
+
+          {/* OM-84 follow-up — the keyless adapter is active but its weights
+              are not on disk, so it publishes nothing. Printing
+              "npm run fetch-model" here would be useless to the person this
+              adapter exists for: a subscription user in the desktop app, who
+              has no terminal in the flow. So the page drives the download.
+              Rendered only when that adapter is active — `localModel` is null
+              on every keyed deployment. */}
+          {localModel !== null && localModel.missingFiles.length > 0 && (
+            <section
+              data-testid="local-model-card"
+              className={`mb-6 rounded-lg border p-4 text-sm ${TONE_CLASS.info}`}
+            >
+              <p className="font-semibold">{t('localModelTitle')}</p>
+              <p className="mt-1">
+                {t('localModelBody', {
+                  size: format.number(
+                    Math.round(localModel.totalBytes / 1024 / 1024),
+                  ),
+                })}
+              </p>
+              <p className="mt-1 font-mono text-xs opacity-80">
+                {localModel.modelDir}
+              </p>
+
+              {localModel.job.state === 'running' ? (
+                <p data-testid="local-model-progress" className="mt-3">
+                  {t('localModelProgress', {
+                    done: format.number(
+                      Math.round(localModel.job.downloadedBytes / 1024 / 1024),
+                    ),
+                    total: format.number(
+                      Math.round(localModel.job.totalBytes / 1024 / 1024),
+                    ),
+                    file: localModel.job.currentFile ?? '—',
+                  })}
+                </p>
+              ) : (
+                <div className="mt-3">
+                  <Button
+                    type="button"
+                    onClick={() => void onFetchWeights()}
+                    disabled={fetchStarting}
+                    data-testid="local-model-fetch"
+                  >
+                    {fetchStarting
+                      ? t('localModelStarting')
+                      : t('localModelFetch')}
+                  </Button>
+                </div>
+              )}
+
+              {localModel.job.state === 'failed' && localModel.job.error !== null && (
+                <p
+                  data-testid="local-model-error"
+                  className="mt-3 text-[color:var(--danger)]"
+                >
+                  {t('localModelFailed', { message: localModel.job.error })}
+                </p>
+              )}
+              {fetchError !== null && (
+                <p className="mt-3 text-[color:var(--danger)]">
+                  {t('localModelFailed', { message: fetchError })}
+                </p>
+              )}
+
+              {/* The threshold is the one thing an operator cannot infer and
+                  will not notice: at the knowledge-graph default of 0.90 this
+                  model's dedup never fires, silently. */}
+              <p className="mt-3 text-xs opacity-80">{t('localModelThreshold')}</p>
+            </section>
+          )}
+
+          {/* Weights arrived while the page was open. The adapter picks them up
+              on its next activation, not retroactively, so say so rather than
+              letting the operator wait for a state that will not change. */}
+          {localModel !== null &&
+            localModel.missingFiles.length === 0 &&
+            localModel.job.state === 'done' && (
+              <section
+                data-testid="local-model-ready"
+                className={`mb-6 rounded-lg border p-4 text-sm ${TONE_CLASS.ok}`}
+              >
+                {t('localModelReady')}
+              </section>
+            )}
 
           {state.activeProviderId !== null && !state.capabilityPublished && (
             <section className={`mb-6 rounded-lg border p-4 text-sm ${TONE_CLASS.error}`}>

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -126,7 +126,7 @@
         "accessWithoutRuntime": "Ein LLM-Zugang ist hinterlegt, aber die Agent-Runtime läuft noch nicht. Meist fehlt nur die Zuordnung des Orchestrators zu diesem Zugang.",
         "assignOrchestrator": "Orchestrator zuordnen"
       },
-      "embeddingsNote": "Gedächtnis eingeschränkt: Es ist kein Embedding-Anbieter konfiguriert. Prozessgedächtnis, semantische Suche und Dublettenerkennung bleiben aus, bis einer eingerichtet ist.",
+      "embeddingsNote": "Gedächtnis eingeschränkt: Es ist kein Embedding-Anbieter aktiv. Prozessgedächtnis, semantische Suche und Dublettenerkennung bleiben aus, bis einer läuft. Es gibt auch einen schlüssellosen Weg — ohne API-Schlüssel und ohne eigenen Server.",
       "embeddingsCta": "Embedding-Anbieter einrichten",
       "heading": "Erste Schritte",
       "kicker": "Einrichtung",
@@ -5193,7 +5193,15 @@
     "unknownTargetError": "Dieses Plugin ist kein installierter embeddingClient@1-Provider.",
     "alreadyActiveError": "Dieser Provider ist bereits aktiv.",
     "targetUnavailableError": "Der Ziel-Provider konnte nicht übernehmen, deshalb ist der vorherige wieder aktiv. Konfiguriere ihn erst (API-Key, Base-URL) und versuch es dann noch mal.",
-    "forbiddenError": "Nicht berechtigt (403) — der Provider-Wechsel erfordert Admin-Rechte."
+    "forbiddenError": "Nicht berechtigt (403) — der Provider-Wechsel erfordert Admin-Rechte.",
+    "localModelTitle": "Schlüsselloser Embedder: Modell noch nicht geladen",
+    "localModelBody": "Dieser Anbieter rechnet ohne API-Schlüssel und ohne eigenen Server — die Modellgewichte ({size} MB) sind aber bewusst nicht im Installer enthalten und müssen einmal geladen werden. Danach läuft alles offline.",
+    "localModelFetch": "Modell jetzt laden",
+    "localModelStarting": "Wird gestartet …",
+    "localModelProgress": "Lädt … {done} von {total} MB ({file})",
+    "localModelFailed": "Der Download ist fehlgeschlagen: {message}",
+    "localModelReady": "Die Modellgewichte liegen vollständig vor. Beim nächsten Aktivieren des Anbieters veröffentlicht er `embeddingClient@1` — Gedächtnis, semantische Suche und Dublettenerkennung laufen dann.",
+    "localModelThreshold": "Wichtig: Die Cosinus-Skala dieses Modells ist nicht die Voreinstellung des Wissensgraphen. Setze `process_dedup_threshold` auf 0.45 — beim Standardwert 0.90 greift die Dublettenerkennung nie, und zwar ohne Fehlermeldung."
   },
   "graph": {
     "page": {

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -126,7 +126,7 @@
         "accessWithoutRuntime": "An LLM access is stored, but the agent runtime is not up yet. Usually the orchestrator just has not been assigned to that access.",
         "assignOrchestrator": "Assign the orchestrator"
       },
-      "embeddingsNote": "Memory is limited: no embedding provider is configured. Process memory, semantic search and duplicate detection stay off until one is set up.",
+      "embeddingsNote": "Memory is limited: no embedding provider is active. Process memory, semantic search and duplicate detection stay off until one runs. There is a keyless option too — no API key and no separate server.",
       "embeddingsCta": "Set up an embedding provider",
       "heading": "Get started",
       "kicker": "Setup",
@@ -5193,7 +5193,15 @@
     "unknownTargetError": "That plugin is not an installed embeddingClient@1 provider.",
     "alreadyActiveError": "That provider is already the active one.",
     "targetUnavailableError": "The target could not take over, so the previous provider was restored. Configure it first (API key, base URL), then try again.",
-    "forbiddenError": "Not authorized (403) — switching the embedding provider requires admin rights."
+    "forbiddenError": "Not authorized (403) — switching the embedding provider requires admin rights.",
+    "localModelTitle": "Keyless embedder: model not downloaded yet",
+    "localModelBody": "This provider computes without an API key and without a separate server — but the model weights ({size} MB) are deliberately not shipped in the installer and have to be fetched once. Everything runs offline afterwards.",
+    "localModelFetch": "Download the model now",
+    "localModelStarting": "Starting …",
+    "localModelProgress": "Downloading … {done} of {total} MB ({file})",
+    "localModelFailed": "The download failed: {message}",
+    "localModelReady": "The model weights are complete. The next time this provider activates it publishes `embeddingClient@1` — memory, semantic search and duplicate detection then work.",
+    "localModelThreshold": "Important: this model’s cosine scale is not the knowledge graph default. Set `process_dedup_threshold` to 0.45 — at the 0.90 default duplicate detection never fires, and it fails silently."
   },
   "graph": {
     "page": {


### PR DESCRIPTION
Folge auf #1041. Dort ist der schlüssellose Provider entstanden; hier wird er für jemanden erreichbar, der kein Entwickler ist.

## Das Problem, das #1041 offen ließ

Die Gewichte sind bewusst nicht gebündelt (~135 MB × 4 Installer, für einen Provider, den eine Deployment mit Key nie aktiviert). Bis sie geholt sind, veröffentlicht der Adapter nichts und sagt „führe `npm run fetch-model` aus".

Für genau die Person, für die dieser Adapter gebaut wurde — Abo-Anwender, Desktop-App, kein Schlüssel, **kein Terminal im Ablauf** — ist dieser Satz nicht von „das kannst du nicht haben" zu unterscheiden. Also fährt ADMIN → Embeddings jetzt denselben Download.

## Was dazukommt

| Endpunkt | Verhalten |
|---|---|
| `POST …/local-model/fetch` | **202**, nicht 200. Der Download läuft Minuten; die Verbindung offenzuhalten würde hinter einem Proxy timeouten — und das liest sich exakt wie ein kaputter Download |
| — bei zweitem Klick | **409**, nicht ein zweiter Lauf. Zwei Läufe schreiben dieselben `.partial`-Pfade und rasen um die Renames |
| — wenn nichts fehlt | **200** mit `reason: 'already-complete'`. Ein 202, das sofort auflöst, lässt den Operator rätseln, ob überhaupt etwas passiert ist |
| `GET …/local-model` | Fehlende Dateien, Größe, laufender Job. **404**, wenn der schlüssellose Adapter nicht aktiv ist |

Das 404 ist Absicht: *„hier gibt es keinen schlüssellosen Provider"* und *„seine Gewichte fehlen"* sind verschiedene Aussagen, und die Seite zeigt beim ersten **weder Button noch Fehler**. Eine Deployment mit Key bekommt gar nichts zu sehen.

Die Seite pollt während des Downloads alle **2 s** statt der üblichen 10 — zehn Sekunden Stillstand liest sich als „hängt".

## Die Route importiert den Adapter nicht

`embeddingProviderCatalog.ts` legt die Regel fest: der Kernel benennt die Adapter per Id und liest strukturell, was sie veröffentlichen — importiert sie aber nie, weil jeder deinstalliert werden kann.

Ein Download verträgt auch die duplizierte Tabelle nicht, die jene Datei für Dimensions-Previews in Kauf nimmt: die gepinnte Revision und die vier SHA-256 sind das, was zwischen einem Korpus und einem **stillschweigend gemischten Vektorraum** steht. Sie dürfen genau einmal existieren.

Deshalb veröffentlicht der Adapter einen `localEmbeddingModelFetcher`-Service, den die Route pro Request auflöst — genau wie `embeddingClient` und den Gate-Status. Er wird **auch ohne Gewichte** veröffentlicht, was der einzige Moment ist, in dem er nützt. Und er ist bewusst ein *eigener* Service: `embeddingClient` heißt „Embeddings funktionieren", dieser heißt „so bringst du sie zum Funktionieren".

`fetchModel.ts` hält jetzt die Implementierung, die vorher im CLI lag; das CLI ist ein dünner Wrapper. Ein Pin, zwei Eingänge.

## Die Schwellen-Warnung reist mit

Bei der 0,90-Voreinstellung des Wissensgraphen greift die Dublettenerkennung dieses Modells **nie**, stillschweigend — dieselbe Fehlerklasse, um die es bei OM-84 ging. Die Karte nennt 0.45 direkt neben dem Button, und ein Test prüft, dass **beide** Zahlen auf dem Schirm stehen.

## Zwei veraltete Aussagen korrigiert

Der Dashboard-Hinweis sagte „es ist kein Embedding-Anbieter konfiguriert", Punkt. Der Code-Kommentar daneben sagte „there is no keyless embedding path yet". Beides war vor #1041 richtig und ist es jetzt nicht mehr.

## Ein ehrlicher Seam statt eines lügenden Tests

`fetchLocalEmbeddingModel` nimmt jetzt eine optionale `files`-Liste, Default ist der Pin. **Mein erster Resume-Test schrieb Dateien mit der richtigen Länge und tat so, als stimmten ihre Digests** — was nicht sein kann, weshalb er stillschweigend zum Download-Test geworden war. Der Seam lässt Skip/Download/Refuse mit Digests prüfen, die ein Test wirklich erzeugen kann; die Produktion nutzt weiter den Pin.

## Verifikation — durch gepflanzte Regression

| Pflanzung | Ergebnis |
|---|---|
| Single-Flight entfernt | Fetch-Suite **11/11 → 10/11** |
| 409 auf 202 abgesenkt | Route-Suite **7/7 → 6/7** |
| Schwellen-Hinweis entfernt | Page-Suite **13/13 → 12/13** |
| Karte auch bei `null` gerendert | Page-Suite **13/13 → 5/13** |

**Volle Läufe:** middleware **8563 pass / 0 fail / 18 skipped**, build + typecheck + `typecheck:test`-Ratchet (364 bekannt, keine Regression) + lint clean · web-ui typecheck clean, lint **0 errors**, vitest **1193/1193** · `i18n:check` OK, beide Locales synchron.

> Nicht angefasst: `middleware/package-lock.json` führt `packages/plugin-api` auf 1.11.0, während dessen `package.json` zwei Minors weiter ist. Ein lokales `npm install` korrigiert das, aber der Drift ist nicht meiner und ein anderer Branch bewegt diese Zahl gerade — hier zu fixen hätte nur einen Konflikt erzeugt.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/1042"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791119883&installation_model_id=428086&pr_number=1042&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F1042&signature=066b68b99870b505b98854061626d32b641cd3ce9e206e9d493028ef68c7e9a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->