### PR TITLE
fix(bootstrap): kein zweiter embeddingClient@1-Provider beim Boot — main bootet mit Ollama nicht

### DIFF
--- a/middleware/src/plugins/bootstrap.ts
+++ b/middleware/src/plugins/bootstrap.ts
@@ -10,7 +10,10 @@ import { parseCapabilityRef } from '@omadia/plugin-api';
 
 import type { Config } from '../config.js';
 import type { BuiltInPackageStore } from './builtInPackageStore.js';
-import { findCapabilityProvidersInCatalog } from './capabilityResolver.js';
+import {
+  findActiveProviderCollision,
+  findCapabilityProvidersInCatalog,
+} from './capabilityResolver.js';
 import type { InstalledAgent, InstalledRegistry } from './installedRegistry.js';
 import type { PluginCatalog } from './manifestLoader.js';
 import type { SecretVault } from '../secrets/vault.js';
@@ -19,6 +22,8 @@ import type { UploadedPackageStore } from './uploadedPackageStore.js';
 const DIAGRAMS_TOOL_ID = '@omadia/diagrams';
 const OFFICE_TOOL_ID = '@omadia/plugin-office';
 const EMBEDDINGS_TOOL_ID = '@omadia/embeddings';
+/** #1041 — the keyless (in-process) embedder; the OTHER `embeddingClient@1`. */
+const EMBEDDINGS_LOCAL_ID = '@omadia/embedding-adapter-local';
 const MEMORY_TOOL_ID = '@omadia/memory';
 const MEMORY_POSTGRES_ID = '@omadia/memory-postgres';
 const ORCHESTRATOR_TOOL_ID = '@omadia/orchestrator';
@@ -502,6 +507,36 @@ export async function bootstrapEmbeddingsFromEnv(
 ): Promise<void> {
   const log = deps.log ?? ((m) => console.log(m));
 
+  // Mutual exclusion for `embeddingClient@1` — the same rule memoryStore and
+  // knowledgeGraph already have, and for the same reason: the capability
+  // resolver THROWS on two active providers, and a throw there is a fatal
+  // startup error, not a degraded plugin. Before #1041 there was only one
+  // embedder; now the keyless in-process one (`@omadia/embedding-adapter-local`)
+  // is an extension built-in without a secret field, which is exactly the shape
+  // the catch-all auto-installs — next to an already-installed Ollama adapter.
+  //
+  // A both-active state is not a valid operator state, so self-heal it here,
+  // BEFORE the catch-all: keep the Ollama adapter when it is actually
+  // configured (a base URL from env or from the operator), otherwise keep the
+  // keyless one. The removed side stays installable from the admin page —
+  // `findActiveProviderCollision` refuses the install with a clear 409 while
+  // the other is active, which is the operator-facing form of this rule.
+  const ollamaEntry = deps.registry.get(EMBEDDINGS_TOOL_ID);
+  const localEntry = deps.registry.get(EMBEDDINGS_LOCAL_ID);
+  if (
+    ollamaEntry?.status === 'active' &&
+    localEntry?.status === 'active'
+  ) {
+    const ollamaConfigured =
+      Boolean(deps.config.OLLAMA_BASE_URL) ||
+      typeof ollamaEntry.config?.['ollama_base_url'] === 'string';
+    const loserId = ollamaConfigured ? EMBEDDINGS_LOCAL_ID : EMBEDDINGS_TOOL_ID;
+    await deps.registry.remove(loserId);
+    log(
+      `[bootstrap] ⚐ both ${EMBEDDINGS_TOOL_ID} and ${EMBEDDINGS_LOCAL_ID} were active — removed ${loserId} (only one embeddingClient@1 provider may be active; ${ollamaConfigured ? 'Ollama is configured' : 'Ollama has no base URL'})`,
+    );
+  }
+
   if (deps.registry.has(EMBEDDINGS_TOOL_ID)) {
     const entry = deps.registry.get(EMBEDDINGS_TOOL_ID);
     if (entry && deps.config.OLLAMA_BASE_URL) {
@@ -542,6 +577,21 @@ export async function bootstrapEmbeddingsFromEnv(
   if (!catalogEntry) {
     log(
       `[bootstrap] cannot migrate ${EMBEDDINGS_TOOL_ID}: not in plugin catalog (built-in package not picked up?)`,
+    );
+    return;
+  }
+
+  // Same rule as the catch-all below: an operator who runs on the keyless
+  // adapter must not wake up to a second, env-driven Ollama install next to
+  // it — that is the both-active state this function just learned to heal.
+  const collision = findActiveProviderCollision(
+    EMBEDDINGS_TOOL_ID,
+    deps.catalog,
+    deps.registry,
+  );
+  if (collision) {
+    log(
+      `[bootstrap] ${EMBEDDINGS_TOOL_ID} not auto-installed — '${collision.capability}' is already provided by active ${collision.ownerId}`,
     );
     return;
   }
@@ -1271,6 +1321,25 @@ export async function bootstrapBuiltInPackages(
     if (hasRequiredSecret) {
       log(
         `[bootstrap] built-in ${pkg.id} needs setup (required secret field) — skipping auto-install`,
+      );
+      continue;
+    }
+
+    // Never auto-install a SECOND provider of a capability that an active
+    // plugin already provides. The two skip-lists above are the hand-written
+    // instances of this rule for memoryStore and knowledgeGraph; this is the
+    // general one, and it is what keeps a new built-in provider (the keyless
+    // embedder of #1041 was the first to hit it) from turning a boot into a
+    // `capability … is provided by both` fatal. The operator can still install
+    // it from the admin page — that path runs the same check and answers 409.
+    const collision = findActiveProviderCollision(
+      pkg.id,
+      deps.catalog,
+      deps.registry,
+    );
+    if (collision) {
+      log(
+        `[bootstrap] built-in ${pkg.id} skipped — '${collision.capability}' is already provided by active ${collision.ownerId} (install it from the admin page after uninstalling the other)`,
       );
       continue;
     }

--- a/middleware/test/bootstrap.test.ts
+++ b/middleware/test/bootstrap.test.ts
@@ -1026,3 +1026,87 @@ describe('bootstrapEmbeddingsFromEnv — env→config reconcile (overlay-on-exis
     assert.equal(cfg?.['some_operator_key'], 'keep-me', 'unrelated key survives the register spread');
   });
 });
+
+// ---------------------------------------------------------------------------
+// embeddingClient@1 mutual exclusion (#1041 follow-up — production boot fatal)
+// ---------------------------------------------------------------------------
+
+describe('embeddingClient@1 mutual exclusion — Ollama vs keyless local adapter', () => {
+  const EMB_ID = '@omadia/embeddings';
+  const LOCAL_ID = '@omadia/embedding-adapter-local';
+  const twoCatalog = makeCatalog([
+    { id: EMB_ID, kind: 'extension', provides: ['embeddingClient@1'], requires: [], depends_on: [] },
+    { id: LOCAL_ID, kind: 'extension', provides: ['embeddingClient@1'], requires: [], depends_on: [] },
+  ]);
+  const stubVault = { get: async () => undefined, setMany: async () => {} } as unknown as SecretVault;
+  const cfg = (url?: string): Config => ({ ...(url ? { OLLAMA_BASE_URL: url } : {}) }) as unknown as Config;
+  async function seed(reg: InMemoryInstalledRegistry, id: string, config: Record<string, unknown> = {}) {
+    await reg.register({ id, installed_version: '0.1.0', installed_at: '2026-09-07T00:00:00Z', status: 'active', config });
+  }
+
+  it('catch-all does NOT auto-install the local adapter next to an active Ollama adapter', async () => {
+    // The production incident: v0.154.0 booted with both, the resolver threw
+    // `capability 'embeddingClient@1' is provided by both …`, the machine died.
+    const reg = new InMemoryInstalledRegistry();
+    await seed(reg, EMB_ID, { ollama_base_url: 'http://ollama:11434' });
+    const logs: string[] = [];
+    await bootstrapBuiltInPackages({
+      config: cfg('http://ollama:11434'),
+      vault: stubVault,
+      registry: reg,
+      catalog: twoCatalog,
+      builtInStore: makeBuiltInStore([
+        { id: EMB_ID, path: '/x/embeddings' },
+        { id: LOCAL_ID, path: '/x/embedding-adapter-local' },
+      ]) as unknown as Parameters<typeof bootstrapBuiltInPackages>[0]['builtInStore'],
+      log: (m: string) => logs.push(m),
+    });
+    assert.equal(reg.get(LOCAL_ID), undefined, 'second embeddingClient@1 provider must not be auto-installed');
+    assert.equal(reg.get(EMB_ID)?.status, 'active');
+    assert.ok(logs.some((l) => l.includes(LOCAL_ID) && l.includes('already provided by active')));
+  });
+
+  it('catch-all still auto-installs the local adapter when NO other embedder is installed', async () => {
+    const reg = new InMemoryInstalledRegistry();
+    await bootstrapBuiltInPackages({
+      config: cfg(),
+      vault: stubVault,
+      registry: reg,
+      catalog: twoCatalog,
+      builtInStore: makeBuiltInStore([{ id: LOCAL_ID, path: '/x/embedding-adapter-local' }]) as unknown as Parameters<typeof bootstrapBuiltInPackages>[0]['builtInStore'],
+      log: () => {},
+    });
+    assert.equal(reg.get(LOCAL_ID)?.status, 'active');
+  });
+
+  it('self-heals a persisted both-active state: keeps Ollama when it is configured', async () => {
+    // What the volume looks like after the failed v0.154.0 boot registered both.
+    const reg = new InMemoryInstalledRegistry();
+    await seed(reg, EMB_ID, { ollama_base_url: 'http://ollama:11434' });
+    await seed(reg, LOCAL_ID);
+    await bootstrapEmbeddingsFromEnv({ config: cfg('http://ollama:11434'), vault: stubVault, registry: reg, catalog: twoCatalog, log: () => {} });
+    assert.equal(reg.get(LOCAL_ID), undefined, 'local adapter removed');
+    assert.equal(reg.get(EMB_ID)?.status, 'active');
+  });
+
+  it('self-heals a persisted both-active state: keeps the local adapter when Ollama has no base URL', async () => {
+    const reg = new InMemoryInstalledRegistry();
+    await seed(reg, EMB_ID);
+    await seed(reg, LOCAL_ID);
+    await bootstrapEmbeddingsFromEnv({ config: cfg(), vault: stubVault, registry: reg, catalog: twoCatalog, log: () => {} });
+    assert.equal(reg.get(EMB_ID), undefined, 'unconfigured Ollama adapter removed');
+    assert.equal(reg.get(LOCAL_ID)?.status, 'active');
+  });
+
+  it('leaves a single active embedder alone', async () => {
+    const reg = new InMemoryInstalledRegistry();
+    await seed(reg, LOCAL_ID);
+    await bootstrapEmbeddingsFromEnv({ config: cfg(), vault: stubVault, registry: reg, catalog: twoCatalog, log: () => {} });
+    assert.equal(reg.get(LOCAL_ID)?.status, 'active');
+    // and Ollama is then installed alongside? No — the catch-all's collision
+    // guard is what keeps it out; bootstrapEmbeddingsFromEnv itself installs
+    // Ollama only when nothing named `@omadia/embeddings` exists, which would
+    // now collide. Pin that the explicit installer also respects the rule.
+    assert.equal(reg.get(EMB_ID), undefined);
+  });
+});


### PR DESCRIPTION
**Produktionsvorfall:** `main` (v0.154.0) bootet auf jeder Installation mit Ollama-Embedder nicht mehr. odoo-bot-middleware starb beim Deploy mit

```
fatal startup error: capability 'embeddingClient@1' is provided by both
'@omadia/embedding-adapter-local' and '@omadia/embeddings' — uninstall one
```

Rollback auf v341 ist erfolgt; dieser PR macht `main` wieder deploybar. Closes #1054.

## Ursache

#1041 hat den Duplikatfall in `activate()` abgefangen („loggen, wer gewonnen hat, nichts veröffentlichen"). Der **Manifest-Resolver** (`buildProviderIndex`) wirft aber schon **vor** jedem `activate()`, sobald zwei aktive installierte Plugins dieselbe `<name>@<major>` deklarieren — und der neue keyless Embedder ist ein `extension`-Built-in ohne Secret-Feld, also exakt die Form, die `bootstrapBuiltInPackages` neben den bereits installierten Ollama-Adapter registriert. Der Throw ist ein fataler Startfehler, kein degradiertes Plugin.

## Fix (`bootstrap.ts`)

| Stelle | Änderung |
|---|---|
| `bootstrapBuiltInPackages` | **Generischer Guard** via `findActiveProviderCollision`: nie einen zweiten Provider einer Capability auto-installieren. Die Skip-Listen für `memoryStore`/`knowledgeGraph` sind hand-geschriebene Instanzen dieser Regel; das hier ist die allgemeine — der nächste Built-in-Provider läuft nicht wieder hinein |
| `bootstrapEmbeddingsFromEnv` | **Selbstheilung** eines persistierten Both-Active-Zustands (der Volume-Stand nach dem fehlgeschlagenen Boot): Ollama bleibt, wenn eine Base-URL konfiguriert ist (env oder Operator), sonst der lokale Adapter — Muster von `bootstrapMemoryFromEnv`. Plus Kollisions-Guard vor dem expliziten Ollama-Install (ein Operator auf dem keyless Adapter bekommt keinen zweiten Embedder per env) |

Die entfernte Seite bleibt über die Admin-Seite installierbar — dort antwortet dieselbe Prüfung mit 409, solange die andere aktiv ist.

## Verifikation

- `bootstrap.test.ts` + `capabilityResolver.test.ts`: **85/85** — neu: Catch-all überspringt neben aktivem Ollama, installiert aber ohne Konkurrenz; beide Heal-Richtungen; Einzelprovider unangetastet; expliziter Ollama-Install respektiert die Regel
- `tsc --noEmit` ✅ · ESLint ✅
- Reproduktion: Live-Log des v342-Deploys (oben), Rollback verifiziert (`/api/health` antwortet wieder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PuMKaZh4XDEmKts5y34Uhb
