### PR TITLE
feat(agents): Peer-Chats aus der Bot-Präsenz wählen statt Conversation-IDs tippen (#1018)

### DIFF
--- a/middleware/src/conductor/botPresenceStore.ts
+++ b/middleware/src/conductor/botPresenceStore.ts
@@ -20,13 +20,76 @@
 
 import type { Pool } from 'pg';
 
+/** One conversation a given bot holds a reference in — the reverse lookup. */
+export interface BotConversation {
+  readonly conversationId: string;
+  /** Teams' `conversationType` as captured with the reference: `groupChat`,
+   *  `channel`, `personal`, or null on legacy rows. */
+  readonly teamsType: string | null;
+  /** The chat's topic/name when the reference captured one. Group chats
+   *  without a set topic carry none — the id is then the only handle. */
+  readonly name: string | null;
+  readonly updatedAt: Date;
+  /** Lower-cased app ids of EVERY bot with a reference there (the asked-for
+   *  bot included). What the operator needs to see is who else is there. */
+  readonly botAppIds: readonly string[];
+}
+
 /** Lower-cased Entra app ids of the bots with a reference in a conversation. */
 export interface BotPresenceStore {
   botAppIdsIn(conversationId: string): Promise<readonly string[]>;
+  /**
+   * Which conversations THIS bot can be heard in — the operator-facing
+   * reverse of {@link botAppIdsIn}. The peer-chat picker on the agent page is
+   * built on it: the only chats worth offering for agent-to-agent talk are
+   * the ones the agent's own bot actually holds a handle to; a typed-in id
+   * for any other chat would be accepted and then never used.
+   */
+  conversationsOf(botAppId: string): Promise<readonly BotConversation[]>;
 }
 
 export function createBotPresenceStore(pool: Pool, log?: (msg: string) => void): BotPresenceStore {
   return {
+    async conversationsOf(botAppId) {
+      const wanted = botAppId.trim().toLowerCase();
+      if (wanted.length === 0) return [];
+      try {
+        const { rows } = await pool.query<{
+          conversation_id: string;
+          teams_type: string | null;
+          name: string | null;
+          updated_at: Date;
+          bot_app_ids: string[] | null;
+        }>(
+          `SELECT r.conversation_id,
+                  r.teams_type,
+                  r.ref #>> '{conversation,name}' AS name,
+                  r.updated_at,
+                  (SELECT array_agg(DISTINCT lower(o.bot_app_id))
+                     FROM teams_conversation_refs o
+                    WHERE o.conversation_id = r.conversation_id AND o.bot_app_id <> '') AS bot_app_ids
+             FROM teams_conversation_refs r
+            WHERE lower(r.bot_app_id) = $1
+            ORDER BY r.updated_at DESC`,
+          [wanted],
+        );
+        return rows.map((r) => ({
+          conversationId: r.conversation_id,
+          teamsType: r.teams_type,
+          name: r.name && r.name.trim().length > 0 ? r.name : null,
+          updatedAt: r.updated_at,
+          botAppIds: (r.bot_app_ids ?? []).filter((id) => id.length > 0),
+        }));
+      } catch (err) {
+        // Same degradation as below: no table / transient failure reads as
+        // "no chat this bot is known to be in". The picker then shows the
+        // empty hint instead of an error, and nothing gets enabled blindly.
+        log?.(
+          `[conductor] bot-conversation lookup for '${wanted}' failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        return [];
+      }
+    },
     async botAppIdsIn(conversationId) {
       try {
         const { rows } = await pool.query<{ bot_app_id: string }>(

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -3492,6 +3492,16 @@ async function main(): Promise<void> {
     activeProvider: orchestratorActiveProviderId(),
   });
 
+  // #1018 — the chats an agent's bot is actually in (kernel table from graph
+  // migration 0031), so the peer-chat picker offers only those instead of a
+  // typed-in id. Same store the conductor's presence check reads; created
+  // once, no DATABASE_URL means no candidates. Named here, not inline, for
+  // the wiring-pin tests' lazy regex.
+  const peerChatDirectory = graphPool
+    ? createBotPresenceStore(graphPool, (msg) => console.log(msg))
+    : undefined;
+  const peerChatDirectoryFor = () => peerChatDirectory;
+
   // US9 / T037 — operator-facing Agents dashboard backend. Mounts at
   // /api/v1/operator/agents/*. 503s when the orchestratorRegistry@1
   // service is not published (no DATABASE_URL / orchestrator plugin not
@@ -3509,6 +3519,7 @@ async function main(): Promise<void> {
       getChatSessionStore,
       getPluginCatalog: () => pluginCatalog,
       getInstalledRegistry: () => installedRegistry,
+      getPeerChatDirectory: peerChatDirectoryFor,
       // OM-75 / OM-78 (#1000, #1001) — decorate the 503 with WHY the runtime
       // is down, so the readiness banner can tell "no access at all" from
       // "access exists, orchestrator not assigned to it". Same credential

--- a/middleware/src/routes/operatorAgents.ts
+++ b/middleware/src/routes/operatorAgents.ts
@@ -49,6 +49,7 @@ import {
 } from '../platform/teamsProvisionerService.js';
 import type { DelegatedTokenSet } from '../platform/teamsDelegatedSignIn.js';
 import type { RuntimeReadinessCause } from '../platform/pluginLlmReadiness.js';
+import type { BotPresenceStore } from '../conductor/botPresenceStore.js';
 import { loadTeamsTargetDirectory } from '../services/teamsTargetDirectoryService.js';
 import {
   resetTeamsIdentity,
@@ -1652,6 +1653,75 @@ export interface OperatorAgentsRouterOptions {
    *  and minimal mounts omit it and the 503 carries no `cause`. Must not
    *  throw; a rejection degrades to `unknown`. */
   readonly getReadinessCause?: () => Promise<RuntimeReadinessCause>;
+  /**
+   * #1018 — where this agent's bot can actually be heard (kernel table
+   * `teams_conversation_refs`, graph migration 0031). `GET /:slug/peer-channels`
+   * lists those chats as the ONLY candidates for enabling agent-to-agent talk:
+   * a chat the bot holds no reference to would be accepted and then never
+   * used, so it is not offered. Optional: without it the list carries no
+   * candidates (tests / minimal mounts, no DATABASE_URL).
+   */
+  readonly getPeerChatDirectory?: () => BotPresenceStore | undefined;
+}
+
+/** One chat the agent's own bot is present in — a candidate for enabling. */
+export interface PeerChatCandidate {
+  readonly channelType: string;
+  readonly channelKey: string;
+  /** The chat's topic when the channel captured one; null otherwise. */
+  readonly label: string | null;
+  /** Channel-specific chat kind (`groupChat`, `channel`, …); null if unknown. */
+  readonly kind: string | null;
+  /** The OTHER agents whose bots are present — the possible discussion
+   *  partners. Bots without a live owning agent are not listed. */
+  readonly partners: readonly { slug: string; name: string }[];
+}
+
+/** `28:<app id>` — the Teams bot identity key; the app id is what the
+ *  reference table is keyed on. */
+const TEAMS_BOT_KEY = /^28:([0-9a-f-]+)$/i;
+
+/**
+ * #1018 — the chats an operator may pick for agent-to-agent talk. Derived,
+ * never typed: the agent's own provisioned bots (channel identities) and the
+ * conversations each holds a reference in. A chat missing here is a chat the
+ * bot was never added to, and enabling it would change nothing — so the
+ * picker does not offer it. Personal (1:1) chats are skipped: a discussion
+ * needs a second bot, and a personal chat never has one.
+ */
+async function listPeerChatCandidates(
+  live: { store: ConfigStore; registry: OrchestratorRegistry },
+  agentId: string,
+  directory: BotPresenceStore | undefined,
+): Promise<{ channelTypes: string[]; available: PeerChatCandidate[] }> {
+  const identities = (await live.store.listChannelIdentities()).filter((i) => i.agentId === agentId);
+  const channelTypes = Array.from(new Set(identities.map((i) => i.channelType))).sort();
+  if (!directory) return { channelTypes, available: [] };
+  const available: PeerChatCandidate[] = [];
+  const seen = new Set<string>();
+  for (const identity of identities) {
+    const appId = TEAMS_BOT_KEY.exec(identity.channelKey)?.[1]?.toLowerCase();
+    if (identity.channelType !== 'teams' || !appId) continue;
+    for (const conv of await directory.conversationsOf(appId)) {
+      if (conv.teamsType === 'personal' || seen.has(conv.conversationId)) continue;
+      seen.add(conv.conversationId);
+      const partners: { slug: string; name: string }[] = [];
+      for (const other of conv.botAppIds) {
+        if (other === appId) continue;
+        const owner = live.registry.identityForChannel(identity.channelType, `28:${other}`);
+        if (!owner || owner.agent.id === agentId || partners.some((p) => p.slug === owner.agent.slug)) continue;
+        partners.push({ slug: owner.agent.slug, name: owner.agent.name ?? owner.agent.slug });
+      }
+      available.push({
+        channelType: identity.channelType,
+        channelKey: conv.conversationId,
+        label: conv.name,
+        kind: conv.teamsType,
+        partners,
+      });
+    }
+  }
+  return { channelTypes, available };
 }
 
 export function createOperatorAgentsRouter(
@@ -2162,7 +2232,10 @@ export function createOperatorAgentsRouter(
         res.status(404).json({ error: 'not_found' });
         return;
       }
-      const policies = await live.store.listAgentChannelPolicies(agent.id);
+      const [policies, candidates] = await Promise.all([
+        live.store.listAgentChannelPolicies(agent.id),
+        listPeerChatCandidates(live, agent.id, options.getPeerChatDirectory?.()),
+      ]);
       res.json({
         slug: agent.slug,
         mode: parseAgentToAgentMode(agent.agentToAgent),
@@ -2172,6 +2245,11 @@ export function createOperatorAgentsRouter(
           enabled: p.agentToAgent,
           updatedAt: p.updatedAt.toISOString(),
         })),
+        // Channel kinds this agent owns a bot on — the picker's first select.
+        // Empty means "no provisioned bot": nothing can be enabled yet.
+        channel_types: candidates.channelTypes,
+        // The chats that bot is actually in — the picker's second select.
+        available: candidates.available,
       });
     } catch (err) {
       badRequest(res, err);

--- a/middleware/test/conductorBotPresence.test.ts
+++ b/middleware/test/conductorBotPresence.test.ts
@@ -50,4 +50,64 @@ describe('bot presence', () => {
     assert.deepEqual(await store.botAppIdsIn('c1'), []);
     assert.equal(logs.length, 1);
   });
+
+  // #1018 — the reverse lookup the operator's peer-chat picker is built on:
+  // only chats the agent's own bot holds a reference in are worth offering.
+  describe('conversationsOf', () => {
+    function convPool(rows: Record<string, unknown>[], throws?: Error) {
+      const queries: { sql: string; params: unknown[] }[] = [];
+      return {
+        queries,
+        pool: {
+          query: async (sql: string, params: unknown[]) => {
+            queries.push({ sql, params });
+            if (throws) throw throws;
+            return { rows };
+          },
+        } as never,
+      };
+    }
+
+    it('lists the conversations the bot is in, with topic and every bot present', async () => {
+      const at = new Date('2026-09-07T10:00:00Z');
+      const { pool, queries } = convPool([
+        {
+          conversation_id: '19:abc@thread.skype',
+          teams_type: 'groupChat',
+          name: 'Sales sync',
+          updated_at: at,
+          bot_app_ids: ['3d78d742-eefb-4fb2-bae5-3687f24c46fc', '19ad2729-f7d3-4099-9d2a-7da1230c9533'],
+        },
+        { conversation_id: 'a:1', teams_type: 'personal', name: '   ', updated_at: at, bot_app_ids: null },
+      ]);
+      const store = createBotPresenceStore(pool);
+      const got = await store.conversationsOf('3D78D742-EEFB-4FB2-BAE5-3687F24C46FC');
+      // The app id is matched case-insensitively — Entra hands it out in
+      // either casing and the reference table stores whatever it saw.
+      assert.deepEqual(queries[0]?.params, ['3d78d742-eefb-4fb2-bae5-3687f24c46fc']);
+      assert.match(queries[0]?.sql ?? '', /lower\(r\.bot_app_id\) = \$1/);
+      assert.equal(got.length, 2);
+      assert.deepEqual(got[0], {
+        conversationId: '19:abc@thread.skype',
+        teamsType: 'groupChat',
+        name: 'Sales sync',
+        updatedAt: at,
+        botAppIds: ['3d78d742-eefb-4fb2-bae5-3687f24c46fc', '19ad2729-f7d3-4099-9d2a-7da1230c9533'],
+      });
+      // A blank topic is no topic; a null aggregate is no bot.
+      assert.equal(got[1]?.name, null);
+      assert.deepEqual(got[1]?.botAppIds, []);
+    });
+
+    it('asks nothing for an empty app id and degrades to empty on failure', async () => {
+      const { pool, queries } = convPool([]);
+      assert.deepEqual(await createBotPresenceStore(pool).conversationsOf('  '), []);
+      assert.equal(queries.length, 0);
+
+      const logs: string[] = [];
+      const failing = convPool([], new Error('relation "teams_conversation_refs" does not exist'));
+      assert.deepEqual(await createBotPresenceStore(failing.pool, (m) => logs.push(m)).conversationsOf('x'), []);
+      assert.equal(logs.length, 1);
+    });
+  });
 });

--- a/middleware/test/operatorAgentsRouter.test.ts
+++ b/middleware/test/operatorAgentsRouter.test.ts
@@ -64,6 +64,7 @@ import {
   type OperatorTeamsInstallRecord,
 } from '../src/routes/operatorAgents.js';
 import type { TeamsProvisionerAccessor } from '../src/platform/teamsProvisionerService.js';
+import type { BotPresenceStore } from '../src/conductor/botPresenceStore.js';
 import type { TeamsTargetKind } from '../src/platform/teamsInstallTarget.js';
 import {
   armNotConfiguredDetail,
@@ -162,9 +163,15 @@ class FakeConfigStore {
   plugins = new Map<string, PluginMem>(); // key: agentId|pluginId
   bindings = new Map<string, BindingMem>(); // key: type|key
   fallbackId: string | null = null;
+  /** Provisioned bot identities (`28:<app id>` per agent) — what the
+   *  peer-chat picker derives its candidates from. */
+  identities: Array<{ channelType: string; channelKey: string; agentId: string }> = [];
 
   listAgents(): Promise<AgentMem[]> {
     return Promise.resolve(Array.from(this.agents.values()));
+  }
+  listChannelIdentities(): Promise<Array<{ channelType: string; channelKey: string; agentId: string }>> {
+    return Promise.resolve(this.identities.slice());
   }
   listAllAgentPlugins(): Promise<PluginMem[]> {
     return Promise.resolve(Array.from(this.plugins.values()));
@@ -621,9 +628,15 @@ async function waitFor(predicate: () => boolean, timeoutMs = 1000): Promise<void
 class FakeRegistry {
   reloadCalls = 0;
   invalidateCalls: Array<{ slug: string; mode: 'drain' | 'kill' }> = [];
+  /** Live owners of bot keys — the partner names the peer-chat picker shows. */
+  owners = new Map<string, { id: string; slug: string; name: string }>();
 
   list() {
     return [];
+  }
+  identityForChannel(channelType: string, channelKey: string) {
+    const agent = this.owners.get(`${channelType}|${channelKey}`);
+    return agent ? { agent } : undefined;
   }
   get(slug: string) {
     return { memoryScope: [`agent:fake:${slug}:*`, 'core'] };
@@ -664,6 +677,9 @@ describe('createOperatorAgentsRouter', () => {
   /** Migration 0053 — `undefined` keeps the pre-0053 response shape every
    *  existing case pins; the timeline cases bind it per test. */
   let teamsEvents: FakeTeamsEventStore | undefined;
+  /** #1018 — the presence directory the peer-chat picker reads. `undefined`
+   *  models no DATABASE_URL: the list then carries no candidates. */
+  let peerChats: BotPresenceStore | undefined;
 
   before(async () => {
     store = new FakeConfigStore();
@@ -686,6 +702,8 @@ describe('createOperatorAgentsRouter', () => {
         getAgentGraphStore: () => graph as unknown as AgentGraphStore,
         // #910 — read live, like every other getter here.
         getInstalledRegistry: () => installedPlugins,
+        // #1018 — the chats each bot is in; per-test fixture, undefined = no DB.
+        getPeerChatDirectory: () => peerChats,
         // #1033 — a two-provider catalogue; only anthropic holds a key.
         getModelPolicyContext: () => ({
           resolveModel: (provider: string, model: string) => POLICY_CATALOG[`${provider}:${model}`],
@@ -719,6 +737,8 @@ describe('createOperatorAgentsRouter', () => {
     graph = new FakeGraphStore();
     registry.reloadCalls = 0;
     registry.invalidateCalls = [];
+    registry.owners = new Map();
+    peerChats = undefined;
     teamsStore = new FakeTeamsIdentityStore();
     teamsRunner = new FakeTeamsRunner();
     provisionerInstalled = true;
@@ -897,6 +917,78 @@ describe('createOperatorAgentsRouter', () => {
       assert.equal(bad.status, 400);
       const missing = await fetch(`${baseUrl}/nope/peer-channels`);
       assert.equal(missing.status, 404);
+    });
+
+    it('peer-channels: GET offers only the chats the agent\'s own bot is in, with the partners present', async () => {
+      // Two provisioned agents. `hr` is in a group chat with `messias`, in a
+      // channel alone, and in a personal chat — the operator must be able to
+      // pick the first two and never see the third (no second bot can ever
+      // be there). A chat `hr` was never added to is not a candidate at all.
+      const hr = await store.createAgent({ slug: 'hr', name: 'Karen' });
+      const messias = await store.createAgent({ slug: 'messias', name: 'Messias' });
+      store.identities = [
+        { channelType: 'teams', channelKey: '28:aaaa', agentId: hr.id },
+        { channelType: 'teams', channelKey: '28:bbbb', agentId: messias.id },
+      ];
+      registry.owners.set('teams|28:aaaa', { id: hr.id, slug: 'hr', name: 'Karen' });
+      registry.owners.set('teams|28:bbbb', { id: messias.id, slug: 'messias', name: 'Messias' });
+      const asked: string[] = [];
+      peerChats = {
+        botAppIdsIn: async () => [],
+        conversationsOf: async (appId) => {
+          asked.push(appId);
+          if (appId !== 'aaaa') return [];
+          const at = new Date('2026-09-07T10:00:00Z');
+          return [
+            { conversationId: '19:sales@thread.skype', teamsType: 'groupChat', name: 'Sales sync', updatedAt: at, botAppIds: ['aaaa', 'bbbb', 'cccc'] },
+            { conversationId: '19:ops@thread.tacv2', teamsType: 'channel', name: null, updatedAt: at, botAppIds: ['aaaa'] },
+            { conversationId: 'a:1', teamsType: 'personal', name: null, updatedAt: at, botAppIds: ['aaaa'] },
+          ];
+        },
+      };
+
+      const res = await fetch(`${baseUrl}/hr/peer-channels`);
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as {
+        channel_types: string[];
+        available: Array<{ channelType: string; channelKey: string; label: string | null; kind: string | null; partners: Array<{ slug: string; name: string }> }>;
+      };
+      assert.deepEqual(asked, ['aaaa'], 'only the agent\'s own bot is looked up');
+      assert.deepEqual(body.channel_types, ['teams']);
+      assert.deepEqual(body.available, [
+        // `cccc` has no live owner — an unowned bot is not a partner anyone can name.
+        { channelType: 'teams', channelKey: '19:sales@thread.skype', label: 'Sales sync', kind: 'groupChat', partners: [{ slug: 'messias', name: 'Messias' }] },
+        { channelType: 'teams', channelKey: '19:ops@thread.tacv2', label: null, kind: 'channel', partners: [] },
+      ]);
+
+      // No bot of its own → no channel kind, no candidate: the UI says so
+      // instead of offering an empty picker.
+      const none = await fetch(`${baseUrl}/messias/peer-channels`);
+      const noneBody = (await none.json()) as { channel_types: string[]; available: unknown[] };
+      assert.deepEqual(noneBody.channel_types, ['teams']);
+      assert.deepEqual(noneBody.available, []);
+      store.identities = [];
+      const noBot = (await (await fetch(`${baseUrl}/hr/peer-channels`)).json()) as { channel_types: string[]; available: unknown[] };
+      assert.deepEqual(noBot, { ...noBot, channel_types: [], available: [] });
+    });
+
+    it('peer-channels: GET without a presence directory still lists the enabled rows, just no candidates', async () => {
+      const hr = await store.createAgent({ slug: 'hr', name: 'Karen' });
+      store.identities = [{ channelType: 'teams', channelKey: '28:aaaa', agentId: hr.id }];
+      const key = encodeURIComponent('19:x@thread.skype');
+      await fetch(`${baseUrl}/hr/peer-channels/teams/${key}`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ enabled: true }),
+      });
+      const body = (await (await fetch(`${baseUrl}/hr/peer-channels`)).json()) as {
+        channels: unknown[];
+        channel_types: string[];
+        available: unknown[];
+      };
+      assert.equal(body.channels.length, 1);
+      assert.deepEqual(body.channel_types, ['teams']);
+      assert.deepEqual(body.available, []);
     });
   });
 
@@ -1461,6 +1553,18 @@ describe('createOperatorAgentsRouter', () => {
       mount,
       /getReadinessCause:/,
       'index.ts must pass getReadinessCause to createOperatorAgentsRouter — without it the 503 carries no cause',
+    );
+    // #1018 — without this the peer-chat picker has nothing to offer and the
+    // operator is back to typing conversation ids.
+    assert.match(
+      mount,
+      /getPeerChatDirectory:/,
+      'index.ts must pass getPeerChatDirectory to createOperatorAgentsRouter — without it GET /:slug/peer-channels lists no candidate chats',
+    );
+    assert.match(
+      indexSource,
+      /createBotPresenceStore\(graphPool/,
+      'the peer-chat directory must be the real presence store over graphPool',
     );
   });
 

--- a/web-ui/app/_lib/agents.ts
+++ b/web-ui/app/_lib/agents.ts
@@ -367,17 +367,68 @@ export interface PeerChannelDto {
   updatedAt: string;
 }
 
+/** One chat the agent's own bot is present in — what the picker offers. */
+export interface PeerChatCandidateDto {
+  channelType: string;
+  channelKey: string;
+  /** The chat's topic when the channel captured one; null otherwise. */
+  label: string | null;
+  /** Channel-specific chat kind (`groupChat`, `channel`, …); null if unknown. */
+  kind: string | null;
+  /** The other agents whose bots are present — possible partners. */
+  partners: { slug: string; name: string }[];
+}
+
 export interface PeerChannelsDto {
   slug: string;
   mode: AgentToAgentMode;
   channels: PeerChannelDto[];
+  /** Channel kinds this agent owns a bot on; empty = no provisioned bot. */
+  channelTypes: string[];
+  /** The chats those bots are actually in. Derived server-side, never typed. */
+  available: PeerChatCandidateDto[];
+}
+
+interface PeerChannelsWire extends Omit<PeerChannelsDto, 'channelTypes' | 'available'> {
+  channel_types?: unknown;
+  available?: unknown;
+}
+
+function parsePeerChatCandidate(raw: unknown): PeerChatCandidateDto | null {
+  if (typeof raw !== 'object' || raw === null) return null;
+  const r = raw as Record<string, unknown>;
+  if (typeof r['channelType'] !== 'string' || typeof r['channelKey'] !== 'string') return null;
+  const partners = Array.isArray(r['partners'])
+    ? r['partners'].flatMap((p: unknown) => {
+        if (typeof p !== 'object' || p === null) return [];
+        const q = p as Record<string, unknown>;
+        return typeof q['slug'] === 'string'
+          ? [{ slug: q['slug'], name: typeof q['name'] === 'string' ? q['name'] : q['slug'] }]
+          : [];
+      })
+    : [];
+  return {
+    channelType: r['channelType'],
+    channelKey: r['channelKey'],
+    label: typeof r['label'] === 'string' && r['label'].length > 0 ? r['label'] : null,
+    kind: typeof r['kind'] === 'string' ? r['kind'] : null,
+    partners,
+  };
 }
 
 export async function getAgentPeerChannels(slug: string): Promise<PeerChannelsDto> {
-  const res = await callJson<PeerChannelsDto>(
+  const res = await callJson<PeerChannelsWire>(
     `/v1/operator/agents/${encodeURIComponent(slug)}/peer-channels`,
   );
-  return { ...res, mode: parseAgentToAgentMode(res.mode) };
+  const { channel_types: types, available, ...rest } = res;
+  return {
+    ...rest,
+    mode: parseAgentToAgentMode(res.mode),
+    channelTypes: Array.isArray(types) ? types.filter((t): t is string => typeof t === 'string') : [],
+    available: Array.isArray(available)
+      ? available.map(parsePeerChatCandidate).filter((c): c is PeerChatCandidateDto => c !== null)
+      : [],
+  };
 }
 
 export async function setAgentPeerChannel(

--- a/web-ui/app/operator/agents/[slug]/_components/AgentPeers.tsx
+++ b/web-ui/app/operator/agents/[slug]/_components/AgentPeers.tsx
@@ -13,6 +13,7 @@ import {
   setAgentPeerChannel,
   type AgentToAgentMode,
   type PeerChannelDto,
+  type PeerChatCandidateDto,
 } from '../../../../_lib/agents';
 import { humanizeApiError } from '../../_components/AgentsDashboard';
 
@@ -40,7 +41,9 @@ export function AgentPeers(props: AgentPeersProps): React.ReactElement {
   const tErr = useTranslations('operatorAgents');
   const [mode, setMode] = useState<AgentToAgentMode | null>(null);
   const [channels, setChannels] = useState<PeerChannelDto[]>([]);
-  const [newType, setNewType] = useState('teams');
+  const [channelTypes, setChannelTypes] = useState<string[]>([]);
+  const [available, setAvailable] = useState<PeerChatCandidateDto[]>([]);
+  const [newType, setNewType] = useState('');
   const [newKey, setNewKey] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -62,6 +65,8 @@ export function AgentPeers(props: AgentPeersProps): React.ReactElement {
       const res = await getAgentPeerChannels(props.slug);
       setMode(res.mode);
       setChannels(res.channels);
+      setChannelTypes(res.channelTypes);
+      setAvailable(res.available);
       setError(null);
     } catch (err: unknown) {
       setError(localizeError(err));
@@ -93,12 +98,29 @@ export function AgentPeers(props: AgentPeersProps): React.ReactElement {
     void run(() => setAgentAgentToAgent(props.slug, next));
   };
 
+  // The picker is derived, never typed: only channel kinds this agent owns a
+  // bot on, and only chats that bot is actually in and that are not already
+  // listed. A chat the bot was never added to could be enabled but would
+  // change nothing, so it is not offered.
+  const effectiveType = channelTypes.includes(newType) ? newType : (channelTypes[0] ?? '');
+  const enabledKeys = new Set(channels.map((c) => `${c.channelType}|${c.channelKey}`));
+  const candidates = available.filter(
+    (c) => c.channelType === effectiveType && !enabledKeys.has(`${c.channelType}|${c.channelKey}`),
+  );
+  const candidateByKey = new Map(available.map((c) => [`${c.channelType}|${c.channelKey}`, c]));
+  const selectedKey = candidates.some((c) => c.channelKey === newKey) ? newKey : '';
+
+  const describeChat = (c: PeerChatCandidateDto): string => {
+    const head = c.label ?? c.channelKey;
+    return c.partners.length > 0
+      ? t('chatOption', { chat: head, partners: c.partners.map((p) => p.name).join(', ') })
+      : t('chatOptionNoPartners', { chat: head });
+  };
+
   const addChannel = (): void => {
-    const key = newKey.trim();
-    const type = newType.trim();
-    if (!key || !type) return;
+    if (!selectedKey || !effectiveType) return;
     void run(async () => {
-      await setAgentPeerChannel(props.slug, type, key, true);
+      await setAgentPeerChannel(props.slug, effectiveType, selectedKey, true);
       setNewKey('');
     });
   };
@@ -169,9 +191,24 @@ export function AgentPeers(props: AgentPeersProps): React.ReactElement {
                     key={`${c.channelType}|${c.channelKey}`}
                     className="flex flex-wrap items-center justify-between gap-2 rounded border border-[color:var(--border)]/60 px-2 py-1 text-sm"
                   >
-                    <span className="flex items-center gap-2">
-                      <code className="text-xs text-[color:var(--fg-muted)]">{c.channelType}</code>
-                      <code className="break-all text-xs">{c.channelKey}</code>
+                    <span className="flex flex-col gap-0.5">
+                      <span className="flex items-center gap-2">
+                        <code className="text-xs text-[color:var(--fg-muted)]">{c.channelType}</code>
+                        <span className="text-sm">
+                          {candidateByKey.get(`${c.channelType}|${c.channelKey}`)?.label ?? (
+                            <code className="break-all text-xs">{c.channelKey}</code>
+                          )}
+                        </span>
+                      </span>
+                      <span className="text-xs text-[color:var(--fg-muted)]">
+                        {(() => {
+                          const known = candidateByKey.get(`${c.channelType}|${c.channelKey}`);
+                          if (!known) return t('chatNotPresent');
+                          return known.partners.length > 0
+                            ? t('chatPartners', { partners: known.partners.map((p) => p.name).join(', ') })
+                            : t('chatPartnersNone');
+                        })()}
+                      </span>
                     </span>
                     <span className="flex items-center gap-2">
                       <label className="flex cursor-pointer items-center gap-1 text-xs">
@@ -201,30 +238,54 @@ export function AgentPeers(props: AgentPeersProps): React.ReactElement {
               </ul>
             )}
 
-            <div className="mt-3 flex flex-wrap items-end gap-2">
-              <label className="flex flex-col text-xs">
-                <span className="mb-1 text-[color:var(--fg-muted)]">{t('channelTypeLabel')}</span>
-                <input
-                  className="rounded border border-[color:var(--border)] bg-[color:var(--bg)] px-2 py-1 text-sm"
-                  value={newType}
-                  disabled={busy}
-                  onChange={(e) => setNewType(e.target.value)}
-                />
-              </label>
-              <label className="flex flex-1 flex-col text-xs">
-                <span className="mb-1 text-[color:var(--fg-muted)]">{t('channelKeyLabel')}</span>
-                <input
-                  className="min-w-64 rounded border border-[color:var(--border)] bg-[color:var(--bg)] px-2 py-1 text-sm"
-                  value={newKey}
-                  placeholder={t('channelKeyPlaceholder')}
-                  disabled={busy}
-                  onChange={(e) => setNewKey(e.target.value)}
-                />
-              </label>
-              <Button size="sm" busy={busy} busyLabel={t('adding')} disabled={!newKey.trim() || busy} onClick={addChannel}>
-                {t('add')}
-              </Button>
-            </div>
+            {channelTypes.length === 0 ? (
+              <p className="mt-3 text-xs text-[color:var(--fg-muted)]">{t('noBot')}</p>
+            ) : (
+              <div className="mt-3 flex flex-wrap items-end gap-2">
+                <label className="flex flex-col text-xs">
+                  <span className="mb-1 text-[color:var(--fg-muted)]">{t('channelTypeLabel')}</span>
+                  <select
+                    className="rounded border border-[color:var(--border)] bg-[color:var(--bg)] px-2 py-1 text-sm"
+                    value={effectiveType}
+                    disabled={busy || channelTypes.length < 2}
+                    onChange={(e) => {
+                      setNewType(e.target.value);
+                      setNewKey('');
+                    }}
+                  >
+                    {channelTypes.map((type) => (
+                      <option key={type} value={type}>
+                        {type}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="flex flex-1 flex-col text-xs">
+                  <span className="mb-1 text-[color:var(--fg-muted)]">{t('chatSelectLabel')}</span>
+                  <select
+                    className="min-w-64 rounded border border-[color:var(--border)] bg-[color:var(--bg)] px-2 py-1 text-sm"
+                    value={selectedKey}
+                    disabled={busy || candidates.length === 0}
+                    onChange={(e) => setNewKey(e.target.value)}
+                  >
+                    <option value="">
+                      {candidates.length === 0 ? t('chatSelectNone') : t('chatSelectPlaceholder')}
+                    </option>
+                    {candidates.map((c) => (
+                      <option key={c.channelKey} value={c.channelKey}>
+                        {describeChat(c)}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <Button size="sm" busy={busy} busyLabel={t('adding')} disabled={!selectedKey || busy} onClick={addChannel}>
+                  {t('add')}
+                </Button>
+                {candidates.length === 0 && (
+                  <p className="basis-full text-xs text-[color:var(--fg-muted)]">{t('noKnownChats')}</p>
+                )}
+              </div>
+            )}
           </div>
         </>
       )}

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -1982,8 +1982,12 @@
       "heading": "Modell",
       "hint": "Welches Modell unter dem Namen dieses Agenten antwortet — und welches einspringt, wenn es nicht verfügbar ist. Angeboten wird nur, was auf diesem Host installiert ist und unter Provider einen Key hat.",
       "loading": "Modell-Policy wird geladen…",
-      "primary": { "label": "Primär" },
-      "fallback": { "label": "Fallback" },
+      "primary": {
+        "label": "Primär"
+      },
+      "fallback": {
+        "label": "Fallback"
+      },
       "auto": "Auto",
       "autoResolves": "Was die Plattform heute auflöst: {model}",
       "autoUnknown": "Was die Plattform heute auflöst (noch nicht gebaut)",
@@ -2020,22 +2024,33 @@
       "loading": "Peer-Einstellungen werden geladen…",
       "stateUnknown": "Aktuell: unbekannt",
       "stateSummary": "Aktuell: {mode} · {chats, plural, =0 {kein Chat freigeschaltet} one {# Chat freigeschaltet} other {# Chats freigeschaltet}}",
-      "modes": { "off": "Aus", "on": "An" },
+      "modes": {
+        "off": "Aus",
+        "on": "An"
+      },
       "modeHints": {
         "off": "Der Agent spricht nie mit anderen Agenten. Der Standard.",
         "on": "Der Agent darf an Diskussionen mit anderen Agenten teilnehmen — in den unten freigeschalteten Chats."
       },
       "chatsHeading": "Freigeschaltete Chats",
-      "chatsHint": "Eine Zeile je Chat. Für Teams ist das die Conversation-ID des Gruppenchats (19:…@thread.skype). Eine Zeile für einen Chat, in dem der Bot nicht ist, schadet nicht — das Relay berücksichtigt nur Bots, die wirklich dort sind.",
+      "chatsHint": "Eine Zeile je Chat. Angeboten werden nur Chats, in denen der eigene Bot dieses Agenten wirklich ist — den Bot zuerst in Teams zum Gruppenchat hinzufügen, dann erscheint er hier. Das Relay berücksichtigt nur Bots, die anwesend sind.",
       "chatsEmpty": "Noch kein Chat freigeschaltet.",
       "chatEnabled": "freigeschaltet",
       "chatDisabled": "gesperrt",
       "remove": "Entfernen",
       "channelTypeLabel": "Channel",
-      "channelKeyLabel": "Conversation-ID",
-      "channelKeyPlaceholder": "19:…@thread.skype",
       "add": "Chat freischalten",
-      "adding": "Wird hinzugefügt"
+      "adding": "Wird hinzugefügt",
+      "chatSelectLabel": "Chat",
+      "chatSelectPlaceholder": "Chat wählen…",
+      "chatSelectNone": "Kein Chat verfügbar",
+      "noKnownChats": "Dieser Bot ist in keinem Gruppenchat, der nicht schon gelistet ist. Den Bot in Teams zu einem Gruppenchat hinzufügen — dann taucht er hier auf.",
+      "noBot": "Dieser Agent hat noch keinen eigenen Bot. Zuerst eine Teams-Identität bereitstellen — ohne Bot gibt es keinen Chat zum Freischalten.",
+      "chatOption": "{chat} · mit {partners}",
+      "chatOptionNoPartners": "{chat} · kein weiterer Bot anwesend",
+      "chatPartners": "Anwesende Bots: {partners}",
+      "chatPartnersNone": "Kein weiterer Bot anwesend — eine Diskussion braucht einen zweiten.",
+      "chatNotPresent": "Der Bot ist nicht (mehr) in diesem Chat; die Zeile wirkt nicht."
     },
     "contextMemory": {
       "heading": "Chat-Kontext-Memory",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -1982,8 +1982,12 @@
       "heading": "Model",
       "hint": "Which model answers under this agent's name, and which one steps in when it is unavailable. Everything offered here comes from the providers installed on this host and the keys configured under Providers.",
       "loading": "Loading the model policy…",
-      "primary": { "label": "Primary" },
-      "fallback": { "label": "Fallback" },
+      "primary": {
+        "label": "Primary"
+      },
+      "fallback": {
+        "label": "Fallback"
+      },
       "auto": "Auto",
       "autoResolves": "What the platform resolves today: {model}",
       "autoUnknown": "What the platform resolves today (not built yet)",
@@ -2020,22 +2024,33 @@
       "loading": "Loading the peer settings…",
       "stateUnknown": "Current: unknown",
       "stateSummary": "Current: {mode} · {chats, plural, =0 {no chats enabled} one {# chat enabled} other {# chats enabled}}",
-      "modes": { "off": "Off", "on": "On" },
+      "modes": {
+        "off": "Off",
+        "on": "On"
+      },
       "modeHints": {
         "off": "The agent never talks to other agents. The default.",
         "on": "The agent may join discussions with other agents — in the chats enabled below."
       },
       "chatsHeading": "Enabled chats",
-      "chatsHint": "One row per chat. For Teams this is the group chat's conversation id (19:…@thread.skype). A row for a chat the bot is not present in is harmless — the relay only ever considers bots that are actually there.",
+      "chatsHint": "One row per chat. Only chats this agent's own bot is actually in are offered — add the bot to a Teams group chat first and it appears here. The relay only ever considers bots that are present.",
       "chatsEmpty": "No chat enabled yet.",
       "chatEnabled": "enabled",
       "chatDisabled": "disabled",
       "remove": "Remove",
       "channelTypeLabel": "Channel",
-      "channelKeyLabel": "Conversation id",
-      "channelKeyPlaceholder": "19:…@thread.skype",
       "add": "Enable chat",
-      "adding": "Adding"
+      "adding": "Adding",
+      "chatSelectLabel": "Chat",
+      "chatSelectPlaceholder": "Choose a chat…",
+      "chatSelectNone": "No chat available",
+      "noKnownChats": "This bot is not in any group chat that is not already listed. Add the bot to a Teams group chat; it then shows up here.",
+      "noBot": "This agent has no bot of its own yet. Provision a Teams identity first — without a bot there is no chat to enable.",
+      "chatOption": "{chat} · with {partners}",
+      "chatOptionNoPartners": "{chat} · no other bot present",
+      "chatPartners": "Bots present: {partners}",
+      "chatPartnersNone": "No other bot present — a discussion needs a second one.",
+      "chatNotPresent": "The bot is not (or no longer) in this chat; the row has no effect."
     },
     "contextMemory": {
       "heading": "Chat-context memory",

--- a/web-ui/scripts/i18n-identical-allowlist.json
+++ b/web-ui/scripts/i18n-identical-allowlist.json
@@ -25,7 +25,6 @@
   "keys": {
     "operatorAgents.agentCardModelAuto": "loanword",
     "operatorAgents.modelPolicy.summaryAuto": "loanword",
-    "operatorAgents.peers.channelKeyPlaceholder": "placeholder",
     "adminDatasets.fields.nameOptional": "loanword",
     "dashboard.onboarding.cases.hr.name": "loanword",
     "conductor.graphLabel": "loanword",
@@ -92,6 +91,7 @@
     "memory.promote.openButton": "glossary",
     "memory.promote.targetCtxKeyPlaceholder": "placeholder",
     "memory.audit.mode.copy": "diagnostic",
-    "memory.audit.mode.move": "diagnostic"
+    "memory.audit.mode.move": "diagnostic",
+    "operatorAgents.peers.chatSelectLabel": "loanword"
   }
 }


### PR DESCRIPTION
**Feldtest-Befund (Marcel, Prod v0.154.0):** Die Sektion „Gespräche zwischen Agenten“ zeigte ein Freitextfeld für die Conversation-ID und einen Freitext-Channel. „Hier sollten nur die installierten angezeigt werden. Sonst macht das keinen Sinn!“ — richtig: der Operator müsste `19:…@thread.skype` aus Teams abschreiben, und eine Zeile für einen Chat, in dem der Bot nicht ist, wird angenommen und bleibt wirkungslos. Teil von #1018 (bleibt geschlossen; Nachtrag).

## Was sich ändert

| Schicht | Änderung |
|---|---|
| `conductor/botPresenceStore.ts` | `conversationsOf(appId)` — Umkehrung von `botAppIdsIn`: alle Konversationen mit Referenz dieses Bots (`teams_conversation_refs`, Graph-Migration 0031) inkl. Topic (`ref.conversation.name`), Typ und **allen dort anwesenden Bots**. Fehlende Tabelle / Fehler → leer + Log, wie beim Bestand |
| `routes/operatorAgents.ts` | `GET /:slug/peer-channels` liefert zusätzlich `channel_types` (Channel-Arten, auf denen der Agent einen **eigenen Bot** hat — aus den Channel-Identities, nicht aus Bindings) und `available` (Chats dieser Bots, **ohne 1:1-Chats**, je Chat die Partner-Agenten mit lebendem Owner). Neue Option `getPeerChatDirectory` |
| `index.ts` | Presence-Store über `graphPool` als `peerChatDirectoryFor` verdrahtet (benannt, damit der Wiring-Pin-Regex nicht abbricht); Pin ergänzt |
| `AgentPeers.tsx` | Channel-**Select** aus `channel_types`, Chat-**Select** aus `available` minus bereits gelisteter Zeilen; Option = Topic/ID + Partner. Bestehende Zeilen zeigen Topic + anwesende Bots bzw. „Bot ist nicht (mehr) in diesem Chat“. Ohne Bot → Hinweis auf Teams-Identität; ohne freien Chat → Hinweis, den Bot in Teams hinzuzufügen. **Kein Freitext mehr** |
| i18n | `channelKeyLabel`/`channelKeyPlaceholder` entfernt (+ Allowlist-Eintrag), 10 neue Keys en+de, `chatSelectLabel` als loanword |

## Bewusste Entscheidungen

- **Quelle ist die Referenz-Tabelle, nicht der Roster** — der Roster kennt keine Bots (siehe Kommentar in `botPresenceStore.ts`). Ein Chat erscheint, sobald der Bot in Teams hinzugefügt wurde (Membership-Event schreibt die Referenz).
- **1:1-Chats werden nicht angeboten** — eine Diskussion braucht einen zweiten Bot, den ein persönlicher Chat nie hat.
- **Bots ohne lebenden Owner** (deaktivierter/gelöschter Agent) erscheinen nicht als Partner — niemand kann sie benennen, und `identityForChannel` gibt genau diesen Unterschied her.
- Die PUT/DELETE-Routen bleiben unverändert: die API akzeptiert weiterhin jede ID; nur die **UI** bietet nur noch belegte Chats an.

## Verifikation

- `conductorBotPresence.test.ts` +2 (Case-Insensitivity, leere App-ID, Degradation), `operatorAgentsRouter.test.ts` +2 (Kandidaten mit Partnern / ohne Bot / ohne Directory; Wiring-Pin) — **124/124**
- middleware `tsc --noEmit` ✅, Test-Typecheck-Ratchet ✅ (364 Baseline, keine Regression)
- web-ui `tsc` ✅, `i18n:check` ✅ (4501 Keys), `i18n-parity` ✅
- ESLint: nur die pre-existing `no-regex-spaces`-Meldung in einem fremden Wiring-Pin, nicht aus diesem Diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PuMKaZh4XDEmKts5y34Uhb

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/1055"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791363435&installation_model_id=428086&pr_number=1055&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F1055&signature=1f6e62e02efe2524063c7c13f05e1e4facc3d9a2a7f6ca6a17b93e4b3432257a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->