### PR TITLE
feat(agents): Peer-Chat-Picker zeigt Chat-Namen statt Conversation-IDs (#1018)

### DIFF
--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -3520,6 +3520,10 @@ async function main(): Promise<void> {
       getPluginCatalog: () => pluginCatalog,
       getInstalledRegistry: () => installedRegistry,
       getPeerChatDirectory: peerChatDirectoryFor,
+      // …and how those chats get a name: the plugin's directory (topic /
+      // member-derived label) and the live roster as post-restart fallback.
+      getChannelDirectory: () => channelDirectoryRegistry,
+      getConversationRosters: () => conversationRosterRegistry,
       // OM-75 / OM-78 (#1000, #1001) — decorate the 503 with WHY the runtime
       // is down, so the readiness banner can tell "no access at all" from
       // "access exists, orchestrator not assigned to it". Same credential

--- a/middleware/src/routes/operatorAgents.ts
+++ b/middleware/src/routes/operatorAgents.ts
@@ -50,6 +50,8 @@ import {
 import type { DelegatedTokenSet } from '../platform/teamsDelegatedSignIn.js';
 import type { RuntimeReadinessCause } from '../platform/pluginLlmReadiness.js';
 import type { BotPresenceStore } from '../conductor/botPresenceStore.js';
+import type { ChannelDirectoryRegistry } from '../channels/channelDirectoryRegistry.js';
+import type { ConversationRosterRegistry } from '../channels/rosterRegistry.js';
 import { loadTeamsTargetDirectory } from '../services/teamsTargetDirectoryService.js';
 import {
   resetTeamsIdentity,
@@ -1662,16 +1664,31 @@ export interface OperatorAgentsRouterOptions {
    * candidates (tests / minimal mounts, no DATABASE_URL).
    */
   readonly getPeerChatDirectory?: () => BotPresenceStore | undefined;
+  /**
+   * How a candidate chat gets a NAME instead of its id. Two sources, both
+   * owned by the channel plugin: the channel-key directory (group-chat topic
+   * via Graph, or the "A, B, +n" label the Teams plugin derives from the
+   * roster) and the live conversation roster (participant display names,
+   * backed by the persisted reference — so it answers right after a
+   * restart, when the in-memory directory is still empty). Optional: without
+   * either the picker shows the id.
+   */
+  readonly getChannelDirectory?: () => ChannelDirectoryRegistry | undefined;
+  readonly getConversationRosters?: () => ConversationRosterRegistry | undefined;
 }
 
 /** One chat the agent's own bot is present in — a candidate for enabling. */
 export interface PeerChatCandidate {
   readonly channelType: string;
   readonly channelKey: string;
-  /** The chat's topic when the channel captured one; null otherwise. */
+  /** What the operator knows the chat as: the topic, or the Teams-style
+   *  "A, B, +n" derived from its members. Null only when no source can name
+   *  it — the UI then shows the id. */
   readonly label: string | null;
   /** Channel-specific chat kind (`groupChat`, `channel`, …); null if unknown. */
   readonly kind: string | null;
+  /** Human participants' display names (capped), for the row detail. */
+  readonly members: readonly string[];
   /** The OTHER agents whose bots are present — the possible discussion
    *  partners. Bots without a live owning agent are not listed. */
   readonly partners: readonly { slug: string; name: string }[];
@@ -1680,6 +1697,71 @@ export interface PeerChatCandidate {
 /** `28:<app id>` — the Teams bot identity key; the app id is what the
  *  reference table is keyed on. */
 const TEAMS_BOT_KEY = /^28:([0-9a-f-]+)$/i;
+
+/** Names shown per chat before the list collapses into "+n". Teams itself
+ *  names an untitled group chat after its first few members. */
+const CHAT_NAME_MEMBERS = 3;
+const CHAT_MEMBERS_CAP = 8;
+
+/** "Anna Meier, Ben Ott, +3" — the label Teams shows for an untitled group. */
+export function chatLabelFromMembers(members: readonly string[]): string | null {
+  const names = members.filter((m) => m.trim().length > 0);
+  if (names.length === 0) return null;
+  const head = names.slice(0, CHAT_NAME_MEMBERS).join(', ');
+  const rest = names.length - CHAT_NAME_MEMBERS;
+  return rest > 0 ? `${head}, +${rest}` : head;
+}
+
+interface ChatNameSources {
+  readonly directory?: ChannelDirectoryRegistry;
+  readonly rosters?: ConversationRosterRegistry;
+}
+
+/**
+ * Name one chat. Directory first — it carries the Graph topic and the
+ * plugin's own member-derived label, i.e. exactly what `/operator/channels`
+ * shows, so the two pages never disagree. The live roster is the fallback
+ * for the window after a restart in which the directory has not observed
+ * the chat yet: it reads the persisted reference and asks Teams for the
+ * members. Bots are dropped from the member list; they are the partners,
+ * listed separately.
+ */
+async function resolveChatName(
+  sources: ChatNameSources,
+  channelType: string,
+  conversationId: string,
+  directoryEntries: ReadonlyMap<string, { label: string; members?: readonly string[] }>,
+): Promise<{ label: string | null; members: readonly string[] }> {
+  const fromDirectory = directoryEntries.get(`${channelType}|${conversationId}`);
+  if (fromDirectory) {
+    return {
+      label: fromDirectory.label,
+      members: (fromDirectory.members ?? []).slice(0, CHAT_MEMBERS_CAP),
+    };
+  }
+  const roster = await sources.rosters?.getRoster(channelType, conversationId);
+  const members = (roster?.participants ?? [])
+    .filter((p) => !p.isBot)
+    .map((p) => p.userRef.displayName?.trim() ?? '')
+    .filter((n) => n.length > 0)
+    .slice(0, CHAT_MEMBERS_CAP);
+  return { label: chatLabelFromMembers(members), members };
+}
+
+/** The directory, read once per request and keyed like the candidates. */
+async function loadDirectoryEntries(
+  directory: ChannelDirectoryRegistry | undefined,
+): Promise<ReadonlyMap<string, { label: string; members?: readonly string[] }>> {
+  const out = new Map<string, { label: string; members?: readonly string[] }>();
+  if (!directory) return out;
+  for (const entry of await directory.listAll()) {
+    out.set(`${entry.channelType}|${entry.key}`, {
+      label: entry.label,
+      ...(entry.members !== undefined ? { members: entry.members } : {}),
+    });
+  }
+  return out;
+}
 
 /**
  * #1018 — the chats an operator may pick for agent-to-agent talk. Derived,
@@ -1693,10 +1775,12 @@ async function listPeerChatCandidates(
   live: { store: ConfigStore; registry: OrchestratorRegistry },
   agentId: string,
   directory: BotPresenceStore | undefined,
+  names: ChatNameSources = {},
 ): Promise<{ channelTypes: string[]; available: PeerChatCandidate[] }> {
   const identities = (await live.store.listChannelIdentities()).filter((i) => i.agentId === agentId);
   const channelTypes = Array.from(new Set(identities.map((i) => i.channelType))).sort();
   if (!directory) return { channelTypes, available: [] };
+  const directoryEntries = await loadDirectoryEntries(names.directory);
   const available: PeerChatCandidate[] = [];
   const seen = new Set<string>();
   for (const identity of identities) {
@@ -1712,11 +1796,15 @@ async function listPeerChatCandidates(
         if (!owner || owner.agent.id === agentId || partners.some((p) => p.slug === owner.agent.slug)) continue;
         partners.push({ slug: owner.agent.slug, name: owner.agent.name ?? owner.agent.slug });
       }
+      // The reference's own `conversation.name` is the cheapest source (a
+      // titled chat), then the plugin's directory / roster — see resolveChatName.
+      const named = await resolveChatName(names, identity.channelType, conv.conversationId, directoryEntries);
       available.push({
         channelType: identity.channelType,
         channelKey: conv.conversationId,
-        label: conv.name,
+        label: conv.name ?? named.label,
         kind: conv.teamsType,
+        members: named.members,
         partners,
       });
     }
@@ -2234,7 +2322,10 @@ export function createOperatorAgentsRouter(
       }
       const [policies, candidates] = await Promise.all([
         live.store.listAgentChannelPolicies(agent.id),
-        listPeerChatCandidates(live, agent.id, options.getPeerChatDirectory?.()),
+        listPeerChatCandidates(live, agent.id, options.getPeerChatDirectory?.(), {
+          directory: options.getChannelDirectory?.(),
+          rosters: options.getConversationRosters?.(),
+        }),
       ]);
       res.json({
         slug: agent.slug,

--- a/middleware/test/operatorAgentsRouter.test.ts
+++ b/middleware/test/operatorAgentsRouter.test.ts
@@ -52,6 +52,7 @@ import {
 } from '@omadia/orchestrator';
 import {
   CONTEXT_MEMORY_MODES,
+  chatLabelFromMembers,
   createOperatorAgentsRouter,
   defaultTeamsBotSecretRef,
   projectInstalledTeams,
@@ -65,6 +66,9 @@ import {
 } from '../src/routes/operatorAgents.js';
 import type { TeamsProvisionerAccessor } from '../src/platform/teamsProvisionerService.js';
 import type { BotPresenceStore } from '../src/conductor/botPresenceStore.js';
+import type { ChannelDirectoryRegistry } from '../src/channels/channelDirectoryRegistry.js';
+import type { ConversationRosterRegistry } from '../src/channels/rosterRegistry.js';
+import type { ConversationParticipant, ConversationRoster } from '@omadia/channel-sdk';
 import type { TeamsTargetKind } from '../src/platform/teamsInstallTarget.js';
 import {
   armNotConfiguredDetail,
@@ -680,6 +684,10 @@ describe('createOperatorAgentsRouter', () => {
   /** #1018 — the presence directory the peer-chat picker reads. `undefined`
    *  models no DATABASE_URL: the list then carries no candidates. */
   let peerChats: BotPresenceStore | undefined;
+  /** Chat names: what the channel directory lists, and what the live roster
+   *  answers per `channelType|conversationId`. `undefined` = source absent. */
+  let chatDirectory: Array<{ channelType: string; key: string; label: string; members?: string[] }> | undefined;
+  let chatRosters: Record<string, ConversationRoster | undefined> | undefined;
 
   before(async () => {
     store = new FakeConfigStore();
@@ -704,6 +712,15 @@ describe('createOperatorAgentsRouter', () => {
         getInstalledRegistry: () => installedPlugins,
         // #1018 — the chats each bot is in; per-test fixture, undefined = no DB.
         getPeerChatDirectory: () => peerChats,
+        // …and their names: directory entries + live rosters, both per test.
+        getChannelDirectory: () =>
+          chatDirectory ? ({ listAll: async () => chatDirectory } as unknown as ChannelDirectoryRegistry) : undefined,
+        getConversationRosters: () =>
+          chatRosters
+            ? ({
+                getRoster: async (channelType: string, id: string) => chatRosters?.[`${channelType}|${id}`],
+              } as unknown as ConversationRosterRegistry)
+            : undefined,
         // #1033 — a two-provider catalogue; only anthropic holds a key.
         getModelPolicyContext: () => ({
           resolveModel: (provider: string, model: string) => POLICY_CATALOG[`${provider}:${model}`],
@@ -739,6 +756,8 @@ describe('createOperatorAgentsRouter', () => {
     registry.invalidateCalls = [];
     registry.owners = new Map();
     peerChats = undefined;
+    chatDirectory = undefined;
+    chatRosters = undefined;
     teamsStore = new FakeTeamsIdentityStore();
     teamsRunner = new FakeTeamsRunner();
     provisionerInstalled = true;
@@ -951,14 +970,14 @@ describe('createOperatorAgentsRouter', () => {
       assert.equal(res.status, 200);
       const body = (await res.json()) as {
         channel_types: string[];
-        available: Array<{ channelType: string; channelKey: string; label: string | null; kind: string | null; partners: Array<{ slug: string; name: string }> }>;
+        available: Array<{ channelType: string; channelKey: string; label: string | null; kind: string | null; members: string[]; partners: Array<{ slug: string; name: string }> }>;
       };
       assert.deepEqual(asked, ['aaaa'], 'only the agent\'s own bot is looked up');
       assert.deepEqual(body.channel_types, ['teams']);
       assert.deepEqual(body.available, [
         // `cccc` has no live owner — an unowned bot is not a partner anyone can name.
-        { channelType: 'teams', channelKey: '19:sales@thread.skype', label: 'Sales sync', kind: 'groupChat', partners: [{ slug: 'messias', name: 'Messias' }] },
-        { channelType: 'teams', channelKey: '19:ops@thread.tacv2', label: null, kind: 'channel', partners: [] },
+        { channelType: 'teams', channelKey: '19:sales@thread.skype', label: 'Sales sync', kind: 'groupChat', members: [], partners: [{ slug: 'messias', name: 'Messias' }] },
+        { channelType: 'teams', channelKey: '19:ops@thread.tacv2', label: null, kind: 'channel', members: [], partners: [] },
       ]);
 
       // No bot of its own → no channel kind, no candidate: the UI says so
@@ -970,6 +989,67 @@ describe('createOperatorAgentsRouter', () => {
       store.identities = [];
       const noBot = (await (await fetch(`${baseUrl}/hr/peer-channels`)).json()) as { channel_types: string[]; available: unknown[] };
       assert.deepEqual(noBot, { ...noBot, channel_types: [], available: [] });
+    });
+
+    it('peer-channels: an untitled chat is named from the directory, else from the live roster — never left as an id when a name exists', async () => {
+      // Marcel's field test: the picker showed `19:9cdb0cd5…@thread.skype`
+      // although /operator/channels names that chat. The name lives with
+      // the channel plugin; the picker must ask it — directory first (same
+      // label the channels page shows), roster as the post-restart fallback.
+      const hr = await store.createAgent({ slug: 'hr', name: 'Karen' });
+      store.identities = [{ channelType: 'teams', channelKey: '28:aaaa', agentId: hr.id }];
+      const at = new Date('2026-09-07T10:00:00Z');
+      peerChats = {
+        botAppIdsIn: async () => [],
+        conversationsOf: async () => [
+          { conversationId: '19:dir@thread.skype', teamsType: 'groupChat', name: null, updatedAt: at, botAppIds: ['aaaa'] },
+          { conversationId: '19:roster@thread.skype', teamsType: 'groupChat', name: null, updatedAt: at, botAppIds: ['aaaa'] },
+          { conversationId: '19:titled@thread.skype', teamsType: 'groupChat', name: 'Budget 2027', updatedAt: at, botAppIds: ['aaaa'] },
+          { conversationId: '19:unknown@thread.skype', teamsType: 'groupChat', name: null, updatedAt: at, botAppIds: ['aaaa'] },
+        ],
+      };
+      chatDirectory = [
+        { channelType: 'teams', key: '19:dir@thread.skype', label: 'Teams · Sales sync', members: ['Anna Meier', 'Ben Ott'] },
+        // Same key on another channel type must not leak across.
+        { channelType: 'telegram', key: '19:roster@thread.skype', label: 'wrong channel' },
+      ];
+      const person = (id: string, displayName: string, isBot = false): ConversationParticipant => ({
+        userRef: { kind: 'teams' as ConversationParticipant['userRef']['kind'], id, displayName },
+        isBot,
+      });
+      chatRosters = {
+        'teams|19:roster@thread.skype': {
+          conversationType: 'group',
+          partial: false,
+          participants: [person('u1', 'Carla Diaz'), person('u2', 'Dieter Fink'), person('b1', 'Karen', true), person('u3', 'Eva Gross'), person('u4', 'Finn Hahn')],
+        },
+      };
+
+      const body = (await (await fetch(`${baseUrl}/hr/peer-channels`)).json()) as {
+        available: Array<{ channelKey: string; label: string | null; members: string[] }>;
+      };
+      const byKey = new Map(body.available.map((c) => [c.channelKey, c]));
+      // Directory wins and carries its members verbatim.
+      assert.deepEqual(byKey.get('19:dir@thread.skype'), { ...byKey.get('19:dir@thread.skype'), label: 'Teams · Sales sync', members: ['Anna Meier', 'Ben Ott'] });
+      // Roster fallback: humans only (the bot is a partner, not a member),
+      // Teams-style "first three, +rest" label.
+      assert.deepEqual(byKey.get('19:roster@thread.skype'), {
+        ...byKey.get('19:roster@thread.skype'),
+        label: 'Carla Diaz, Dieter Fink, Eva Gross, +1',
+        members: ['Carla Diaz', 'Dieter Fink', 'Eva Gross', 'Finn Hahn'],
+      });
+      // A titled chat keeps its own title.
+      assert.equal(byKey.get('19:titled@thread.skype')?.label, 'Budget 2027');
+      // Nothing knows this one: id it is, and the UI says so.
+      assert.deepEqual(byKey.get('19:unknown@thread.skype'), { ...byKey.get('19:unknown@thread.skype'), label: null, members: [] });
+    });
+
+    it('chatLabelFromMembers mirrors how Teams names an untitled group chat', () => {
+      assert.equal(chatLabelFromMembers([]), null);
+      assert.equal(chatLabelFromMembers(['  ']), null);
+      assert.equal(chatLabelFromMembers(['Anna']), 'Anna');
+      assert.equal(chatLabelFromMembers(['Anna', 'Ben', 'Cid']), 'Anna, Ben, Cid');
+      assert.equal(chatLabelFromMembers(['Anna', 'Ben', 'Cid', 'Dan', 'Eve']), 'Anna, Ben, Cid, +2');
     });
 
     it('peer-channels: GET without a presence directory still lists the enabled rows, just no candidates', async () => {
@@ -1566,6 +1646,10 @@ describe('createOperatorAgentsRouter', () => {
       /createBotPresenceStore\(graphPool/,
       'the peer-chat directory must be the real presence store over graphPool',
     );
+    // Without these the picker names chats by id — the very thing the field
+    // test rejected — because the names live with the channel plugin.
+    assert.match(mount, /getChannelDirectory:\s*\(\)\s*=>\s*channelDirectoryRegistry/, 'index.ts must hand the channel directory to the peer-chat picker');
+    assert.match(mount, /getConversationRosters:\s*\(\)\s*=>\s*conversationRosterRegistry/, 'index.ts must hand the roster registry to the peer-chat picker');
   });
 
   it('index.ts wires syncBotConfig into the provisioning runner (wiring pin, #910)', async () => {

--- a/web-ui/app/_lib/agents.ts
+++ b/web-ui/app/_lib/agents.ts
@@ -375,6 +375,8 @@ export interface PeerChatCandidateDto {
   label: string | null;
   /** Channel-specific chat kind (`groupChat`, `channel`, …); null if unknown. */
   kind: string | null;
+  /** Human participants' display names (capped server-side). */
+  members: string[];
   /** The other agents whose bots are present — possible partners. */
   partners: { slug: string; name: string }[];
 }
@@ -412,6 +414,7 @@ function parsePeerChatCandidate(raw: unknown): PeerChatCandidateDto | null {
     channelKey: r['channelKey'],
     label: typeof r['label'] === 'string' && r['label'].length > 0 ? r['label'] : null,
     kind: typeof r['kind'] === 'string' ? r['kind'] : null,
+    members: Array.isArray(r['members']) ? r['members'].filter((m): m is string => typeof m === 'string') : [],
     partners,
   };
 }

--- a/web-ui/app/operator/agents/[slug]/_components/AgentPeers.tsx
+++ b/web-ui/app/operator/agents/[slug]/_components/AgentPeers.tsx
@@ -209,6 +209,18 @@ export function AgentPeers(props: AgentPeersProps): React.ReactElement {
                             : t('chatPartnersNone');
                         })()}
                       </span>
+                      {(() => {
+                        const known = candidateByKey.get(`${c.channelType}|${c.channelKey}`);
+                        if (!known || known.members.length === 0) return null;
+                        return (
+                          <span className="text-xs text-[color:var(--fg-muted)]">
+                            {t('chatMembers', { members: known.members.join(', ') })}
+                          </span>
+                        );
+                      })()}
+                      {candidateByKey.get(`${c.channelType}|${c.channelKey}`)?.label && (
+                        <code className="break-all text-[10px] text-[color:var(--fg-muted)]">{c.channelKey}</code>
+                      )}
                     </span>
                     <span className="flex items-center gap-2">
                       <label className="flex cursor-pointer items-center gap-1 text-xs">

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -2050,7 +2050,8 @@
       "chatOptionNoPartners": "{chat} · kein weiterer Bot anwesend",
       "chatPartners": "Anwesende Bots: {partners}",
       "chatPartnersNone": "Kein weiterer Bot anwesend — eine Diskussion braucht einen zweiten.",
-      "chatNotPresent": "Der Bot ist nicht (mehr) in diesem Chat; die Zeile wirkt nicht."
+      "chatNotPresent": "Der Bot ist nicht (mehr) in diesem Chat; die Zeile wirkt nicht.",
+      "chatMembers": "Teilnehmer: {members}"
     },
     "contextMemory": {
       "heading": "Chat-Kontext-Memory",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -2050,7 +2050,8 @@
       "chatOptionNoPartners": "{chat} · no other bot present",
       "chatPartners": "Bots present: {partners}",
       "chatPartnersNone": "No other bot present — a discussion needs a second one.",
-      "chatNotPresent": "The bot is not (or no longer) in this chat; the row has no effect."
+      "chatNotPresent": "The bot is not (or no longer) in this chat; the row has no effect.",
+      "chatMembers": "Participants: {members}"
     },
     "contextMemory": {
       "heading": "Chat-context memory",


### PR DESCRIPTION
**Feldtest-Befund (Marcel, direkt nach #1055):** „Warum hier keine Namensauflösung?!“ — der Picker zeigte `19:9cdb0cd5…@thread.skype · mit Messias, Dark Clippy`, obwohl `/operator/channels` denselben Chat längst benennt. Die Namen leben beim Channel-Plugin (Graph-Topic, Roster); der Picker hat sie nicht abgefragt.

## Auflösungskette je Kandidat

| Reihenfolge | Quelle | Wann |
|---|---|---|
| 1 | `ref.conversation.name` aus `teams_conversation_refs` | betitelter Chat |
| 2 | **Channel-Key-Directory** (`channelDirectoryRegistry.listAll()`) — Graph-Topic bzw. das „A, B, +n“-Label, das der Teams-Plugin aus dem Roster ableitet | Chat wurde seit dem letzten Start beobachtet — **dieselbe Zeile wie auf `/operator/channels`**, die beiden Seiten können nicht auseinanderlaufen |
| 3 | **Live-Roster** (`conversationRosterRegistry.getRoster()`) — Teilnehmer ohne Bots, Teams-Schema „erste drei, +Rest“ | direkt nach einem Neustart, wenn das In-Memory-Directory noch leer ist; die Referenz ist persistiert |
| — | `null` → UI zeigt die ID | keine Quelle kennt den Chat |

Neues Feld `members` je Kandidat (gecappt). Router-Optionen `getChannelDirectory` / `getConversationRosters`, in `index.ts` verdrahtet, Wiring-Pin ergänzt. UI: Option und Zeile zeigen den Namen, die ID nur noch klein darunter, plus „Teilnehmer: …“.

## Verifikation

- `operatorAgentsRouter.test.ts` +2 — Directory gewinnt und trägt Members; Roster-Fallback lässt den Bot weg und baut „Carla Diaz, Dieter Fink, Eva Gross, +1“; Titel bleibt; unbekannt bleibt `null`; gleicher Key auf anderem Channel-Typ leakt nicht; `chatLabelFromMembers` — **117/117**
- middleware `tsc` ✅, Test-Ratchet ✅ (364, keine Regression), ESLint ✅
- web-ui `tsc` ✅, `i18n:check` ✅ (4502 Keys), `i18n-parity` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PuMKaZh4XDEmKts5y34Uhb

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/1056"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791367834&installation_model_id=428086&pr_number=1056&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F1056&signature=2de5814bfe243e2e6fe9c1923e3e1aa4d95c761142d5b3108e65ff82716a8f30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->