### PR TITLE
feat(web-ui): Agent-Detailseite als Tabs statt One-Pager

### DIFF
--- a/web-ui/app/admin/builder/panels/InspectorPanel.tsx
+++ b/web-ui/app/admin/builder/panels/InspectorPanel.tsx
@@ -179,7 +179,7 @@ function AgentEditor({
                   : `${agent.modelPolicy.fallback.provider}:${agent.modelPolicy.fallback.model}`,
           })}{' '}
           <a
-            href={`/operator/agents/${encodeURIComponent(slug)}`}
+            href={`/operator/agents/${encodeURIComponent(slug)}?tab=model`}
             className="text-[color:var(--accent)] hover:underline"
           >
             {t('inspector.modelPolicyEdit')}

--- a/web-ui/app/operator/agents/[slug]/__tests__/AgentDetail.test.tsx
+++ b/web-ui/app/operator/agents/[slug]/__tests__/AgentDetail.test.tsx
@@ -84,6 +84,32 @@ vi.mock('../_components/AgentTeamsInstalls', () => ({
   AgentTeamsInstalls: () => <div data-testid="agent-teams-installs" />,
 }));
 
+// The tabs host mounts one panel at a time; these sections live on their
+// own tabs now and are covered by their own suites — stubbed like the rest.
+vi.mock('../_components/AgentModelPolicy', () => ({
+  AgentModelPolicy: () => <div data-testid="agent-model-policy" />,
+}));
+vi.mock('../_components/AgentPeers', () => ({
+  AgentPeers: () => <div data-testid="agent-peers" />,
+}));
+vi.mock('../_components/AgentToolGrants', () => ({
+  AgentToolGrants: () => <div data-testid="agent-tool-grants" />,
+}));
+vi.mock('../_components/AgentMcpServers', () => ({
+  AgentMcpServers: () => <div data-testid="agent-mcp-servers" />,
+}));
+vi.mock('../_components/AgentContextMemory', () => ({
+  AgentContextMemory: () => <div data-testid="agent-context-memory" />,
+}));
+
+/** Render the page and open the Plugins tab — where every plugin
+ *  assertion below lives since the page became tab-based. */
+async function renderOnPluginsTab(ui: React.ReactElement): Promise<ReturnType<typeof renderWithIntl>> {
+  const rendered = renderWithIntl(ui);
+  await userEvent.click(await screen.findByTestId('agent-detail-tab-plugins'));
+  return rendered;
+}
+
 vi.mock('../../_components/PluginsDnd', async () => {
   const { useState } = await import('react');
   return {
@@ -186,6 +212,9 @@ beforeEach(() => {
   mockToggle.mockReset();
   mockReplace.mockReset();
   mockRefresh.mockReset();
+  // The tab strip writes `?tab=` into the shared jsdom URL; start every
+  // case on the bare route so a previous case's tab does not leak in.
+  window.history.replaceState(null, '', '/operator/agents/hr');
   mockCatalog.mockResolvedValue({
     items: [
       catalogEntry({}),
@@ -202,7 +231,7 @@ beforeEach(() => {
 
 describe('AgentDetail plugin assignment', () => {
   it('renders one row per assigned plugin with its enabled state', async () => {
-    renderWithIntl(<AgentDetail agent={agent()} isFallback={false} />);
+    await renderOnPluginsTab(<AgentDetail agent={agent()} isFallback={false} />);
 
     // Catalog names join in after the async catalog load.
     const odoo = await screen.findByRole('checkbox', {
@@ -216,7 +245,7 @@ describe('AgentDetail plugin assignment', () => {
   });
 
   it('renders the empty state when the agent has no plugins assigned', async () => {
-    renderWithIntl(
+    await renderOnPluginsTab(
       <AgentDetail agent={agent({ plugins: [] })} isFallback={false} />,
     );
     expect(
@@ -226,7 +255,7 @@ describe('AgentDetail plugin assignment', () => {
 
   it('toggling a row calls toggleAgentPlugin with the inverted flag and refreshes', async () => {
     const user = userEvent.setup();
-    renderWithIntl(<AgentDetail agent={agent()} isFallback={false} />);
+    await renderOnPluginsTab(<AgentDetail agent={agent()} isFallback={false} />);
 
     const odoo = await screen.findByRole('checkbox', {
       name: 'Enable or disable Odoo',
@@ -246,7 +275,7 @@ describe('AgentDetail plugin assignment', () => {
       ),
     );
     const user = userEvent.setup();
-    renderWithIntl(<AgentDetail agent={agent()} isFallback={false} />);
+    await renderOnPluginsTab(<AgentDetail agent={agent()} isFallback={false} />);
 
     await user.click(
       await screen.findByRole('checkbox', { name: 'Enable or disable Odoo' }),
@@ -263,7 +292,7 @@ describe('AgentDetail plugin assignment', () => {
   });
 
   it('shows the store-config notice only for the fallback agent', async () => {
-    const { unmount } = renderWithIntl(
+    const { unmount } = await renderOnPluginsTab(
       <AgentDetail agent={agent()} isFallback />,
     );
     expect(
@@ -271,7 +300,7 @@ describe('AgentDetail plugin assignment', () => {
     ).toBeInTheDocument();
     unmount();
 
-    renderWithIntl(<AgentDetail agent={agent()} isFallback={false} />);
+    await renderOnPluginsTab(<AgentDetail agent={agent()} isFallback={false} />);
     await screen.findByTestId('plugins-dnd-save');
     expect(
       screen.queryByText(/always runs plugins with the global store config/),
@@ -280,7 +309,7 @@ describe('AgentDetail plugin assignment', () => {
 
   it('forwards PluginsDnd saves to replaceAgentPlugins for this slug', async () => {
     const user = userEvent.setup();
-    renderWithIntl(<AgentDetail agent={agent()} isFallback={false} />);
+    await renderOnPluginsTab(<AgentDetail agent={agent()} isFallback={false} />);
 
     await user.click(await screen.findByTestId('plugins-dnd-save'));
 
@@ -297,7 +326,7 @@ describe('AgentDetail plugin assignment', () => {
     // edit below it. The stub's mount-local "dirty" flag stands in for that
     // unsaved state.
     const user = userEvent.setup();
-    renderWithIntl(<AgentDetail agent={agent()} isFallback={false} />);
+    await renderOnPluginsTab(<AgentDetail agent={agent()} isFallback={false} />);
 
     await user.click(await screen.findByTestId('plugins-dnd-edit'));
     expect(screen.getByTestId('plugins-dnd-state').textContent).toBe('dirty');
@@ -312,7 +341,7 @@ describe('AgentDetail plugin assignment', () => {
 
   it("the editor's own save DOES remount it so it reseeds from fresh props", async () => {
     const user = userEvent.setup();
-    renderWithIntl(<AgentDetail agent={agent()} isFallback={false} />);
+    await renderOnPluginsTab(<AgentDetail agent={agent()} isFallback={false} />);
 
     await user.click(await screen.findByTestId('plugins-dnd-edit'));
     expect(screen.getByTestId('plugins-dnd-state').textContent).toBe('dirty');
@@ -349,5 +378,67 @@ describe('AgentDetail identity section (#914)', () => {
 
     expect(container.querySelectorAll('a[href*="builder"]').length).toBe(0);
     expect(screen.queryByText(/Agent Builder/)).toBeNull();
+  });
+});
+
+describe('AgentDetail tabs', () => {
+  beforeEach(() => {
+    mockCatalog.mockResolvedValue({ items: [] });
+    window.history.replaceState(null, '', '/operator/agents/hr');
+  });
+
+  it('opens on Identity and mounts only that panel', async () => {
+    renderWithIntl(<AgentDetail agent={agent()} isFallback={false} />);
+    expect(await screen.findByTestId('agent-identity')).toBeTruthy();
+    expect(screen.getByRole('tab', { name: 'Identity' })).toHaveAttribute('aria-selected', 'true');
+    // The other panels are not in the tree — a tab fetches when opened, not
+    // seven sections at once.
+    for (const id of ['agent-model-policy', 'agent-peers', 'agent-teams-identity', 'agent-tool-grants', 'agent-context-memory']) {
+      expect(screen.queryByTestId(id)).toBeNull();
+    }
+    expect(screen.queryByText(/Assigned plugins/)).toBeNull();
+  });
+
+  it('switches panels and writes the tab into the URL without navigating', async () => {
+    const user = userEvent.setup();
+    renderWithIntl(<AgentDetail agent={agent()} isFallback={false} />);
+    await screen.findByTestId('agent-identity');
+
+    await user.click(screen.getByRole('tab', { name: 'Conversations' }));
+    expect(await screen.findByTestId('agent-peers')).toBeTruthy();
+    expect(screen.queryByTestId('agent-identity')).toBeNull();
+    expect(new URL(window.location.href).searchParams.get('tab')).toBe('peers');
+    expect(mockRefresh).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('tab', { name: 'Tools' }));
+    expect(await screen.findByTestId('agent-tool-grants')).toBeTruthy();
+    expect(screen.getByTestId('agent-mcp-servers')).toBeTruthy();
+
+    // Back to the default clears the parameter — a plain link stays plain.
+    await user.click(screen.getByRole('tab', { name: 'Identity' }));
+    expect(new URL(window.location.href).searchParams.get('tab')).toBeNull();
+  });
+
+  it('a ?tab= deep link lands on that tab; an unknown value falls back to Identity', async () => {
+    window.history.replaceState(null, '', '/operator/agents/hr?tab=model');
+    const first = renderWithIntl(<AgentDetail agent={agent()} isFallback={false} />);
+    expect(await screen.findByTestId('agent-model-policy')).toBeTruthy();
+    expect(screen.getByRole('tab', { name: 'Model' })).toHaveAttribute('aria-selected', 'true');
+    first.unmount();
+
+    window.history.replaceState(null, '', '/operator/agents/hr?tab=nope');
+    renderWithIntl(<AgentDetail agent={agent()} isFallback={false} />);
+    expect(await screen.findByTestId('agent-identity')).toBeTruthy();
+  });
+
+  it('arrow keys move between tabs', async () => {
+    const user = userEvent.setup();
+    renderWithIntl(<AgentDetail agent={agent()} isFallback={false} />);
+    await screen.findByTestId('agent-identity');
+    screen.getByRole('tab', { name: 'Identity' }).focus();
+    await user.keyboard('{ArrowRight}');
+    expect(await screen.findByTestId('agent-model-policy')).toBeTruthy();
+    await user.keyboard('{ArrowLeft}');
+    expect(await screen.findByTestId('agent-identity')).toBeTruthy();
   });
 });

--- a/web-ui/app/operator/agents/[slug]/_components/AgentDetail.tsx
+++ b/web-ui/app/operator/agents/[slug]/_components/AgentDetail.tsx
@@ -14,11 +14,15 @@ import {
 } from '../../../../_lib/agents';
 import { humanizeApiError } from '../../_components/AgentsDashboard';
 import { PluginsDnd } from '../../_components/PluginsDnd';
+import { AgentContextMemory } from './AgentContextMemory';
+import { AgentDetailTabs } from './AgentDetailTabs';
 import { AgentIdentity } from './AgentIdentity';
+import { AgentMcpServers } from './AgentMcpServers';
 import { AgentModelPolicy } from './AgentModelPolicy';
 import { AgentPeers } from './AgentPeers';
 import { AgentTeamsIdentity } from './AgentTeamsIdentity';
 import { AgentTeamsInstalls } from './AgentTeamsInstalls';
+import { AgentToolGrants } from './AgentToolGrants';
 
 /**
  * #914 — the Agent Builder deep link that used to live here is GONE, along
@@ -148,44 +152,11 @@ export function AgentDetail(props: AgentDetailProps): React.ReactElement {
       .finally(() => setBusy(null));
   }
 
-  return (
-    <div className="space-y-8">
-      {error && (
-        <div
-          role="alert"
-          className="rounded border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 p-3 text-sm text-[color:var(--danger)]"
-        >
-          {error}
-        </div>
-      )}
-      {catalogError && (
-        <div className="rounded border border-[color:var(--warning)] bg-[color:var(--warning)]/10 p-3 text-sm text-[color:var(--warning)]">
-          {t('catalogError', { message: catalogError })}
-        </div>
-      )}
-
-      {/* #914 — identity first: who this agent is comes before what it is
-          allowed to do. Fetches its own read model by slug, so it is safe to
-          mount for an agent that has neither an identity row nor a Teams
-          bot. */}
-      <AgentIdentity slug={props.agent.slug} />
-
-      {/* #1033 — how the agent THINKS comes right after who it is: which
-          model answers under its name, and which one steps in when that is
-          unavailable. Then (#1018) with whom it may converse. Both fetch
-          their own read models by slug. */}
-      <AgentModelPolicy slug={props.agent.slug} />
-      <AgentPeers slug={props.agent.slug} />
-
-      {/* Teams sections (epic #860, wave W2a). This component is the single
-          composition point for them, so the sibling Teams units (config
-          block, installs panel) extend one file instead of racing over the
-          page shell. The assignment panel fetches its own read model by slug
-          and disables what the platform cannot do, so it is safe to mount
-          before an identity exists. */}
-      <AgentTeamsIdentity slug={props.agent.slug} />
-      <AgentTeamsInstalls slug={props.agent.slug} />
-
+  // The plugin tab: the assigned list (instant toggle) above the dnd editor
+  // (replace-set save). Built as a value so the tab host can mount it lazily
+  // like every other panel while its state stays in this component.
+  const pluginsPanel = (
+    <>
       <section className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-4">
         <h2 className="mb-1 text-lg font-medium">
           {t('detailAssignedHeading')}
@@ -267,6 +238,52 @@ export function AgentDetail(props: AgentDetailProps): React.ReactElement {
           )
         )}
       </section>
+    </>
+  );
+
+  return (
+    <div className="space-y-8">
+      {error && (
+        <div
+          role="alert"
+          className="rounded border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 p-3 text-sm text-[color:var(--danger)]"
+        >
+          {error}
+        </div>
+      )}
+      {catalogError && (
+        <div className="rounded border border-[color:var(--warning)] bg-[color:var(--warning)]/10 p-3 text-sm text-[color:var(--warning)]">
+          {t('catalogError', { message: catalogError })}
+        </div>
+      )}
+
+      {/* One tab per concern; the order follows the operator's questions:
+          who is this agent (#914), how does it think (#1033), with whom may
+          it talk (#1018), where does it live (#860 Teams), what can it do
+          (plugins, #861/#862 grants + MCP), what does it remember (#899).
+          Every section fetches its own read model by slug and is safe to
+          mount on its own — which is exactly what a tab does. */}
+      <AgentDetailTabs
+        panels={{
+          identity: () => <AgentIdentity slug={props.agent.slug} />,
+          model: () => <AgentModelPolicy slug={props.agent.slug} />,
+          peers: () => <AgentPeers slug={props.agent.slug} />,
+          teams: () => (
+            <>
+              <AgentTeamsIdentity slug={props.agent.slug} />
+              <AgentTeamsInstalls slug={props.agent.slug} />
+            </>
+          ),
+          plugins: () => pluginsPanel,
+          tools: () => (
+            <>
+              <AgentToolGrants slug={props.agent.slug} />
+              <AgentMcpServers slug={props.agent.slug} />
+            </>
+          ),
+          memory: () => <AgentContextMemory slug={props.agent.slug} />,
+        }}
+      />
     </div>
   );
 }

--- a/web-ui/app/operator/agents/[slug]/_components/AgentDetailTabs.tsx
+++ b/web-ui/app/operator/agents/[slug]/_components/AgentDetailTabs.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+/**
+ * The agent detail page as tabs.
+ *
+ * The page grew one stacked section per wave (#860 Teams, #914 identity,
+ * #1018 peers, #1033 model, #861/#862 grants + MCP, #899 memory) until the
+ * one-pager stopped being navigable. Each tab groups the sections an
+ * operator works on together; only the active panel is mounted, so a tab
+ * fetches its read model when opened, not seven at once on page load.
+ *
+ * The active tab lives in `?tab=` so a link can land on a section (the
+ * dashboard, a runbook, a test script). It is written with
+ * `history.replaceState`, not the router: switching a tab is not a
+ * navigation and must not re-run the RSC fetch behind the page.
+ */
+export const AGENT_DETAIL_TABS = [
+  'identity',
+  'model',
+  'peers',
+  'teams',
+  'plugins',
+  'tools',
+  'memory',
+] as const;
+
+export type AgentDetailTab = (typeof AGENT_DETAIL_TABS)[number];
+
+const DEFAULT_TAB: AgentDetailTab = 'identity';
+const TAB_PARAM = 'tab';
+
+export function parseAgentDetailTab(raw: string | null | undefined): AgentDetailTab {
+  return (AGENT_DETAIL_TABS as readonly string[]).includes(raw ?? '')
+    ? (raw as AgentDetailTab)
+    : DEFAULT_TAB;
+}
+
+function readTabFromLocation(): AgentDetailTab {
+  if (typeof window === 'undefined') return DEFAULT_TAB;
+  try {
+    return parseAgentDetailTab(new URLSearchParams(window.location.search).get(TAB_PARAM));
+  } catch {
+    return DEFAULT_TAB;
+  }
+}
+
+function writeTabToLocation(tab: AgentDetailTab): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const url = new URL(window.location.href);
+    if (tab === DEFAULT_TAB) url.searchParams.delete(TAB_PARAM);
+    else url.searchParams.set(TAB_PARAM, tab);
+    window.history.replaceState(window.history.state, '', url);
+  } catch {
+    // A sandboxed frame without history access still gets a working page;
+    // only the deep link is lost.
+  }
+}
+
+interface AgentDetailTabsProps {
+  /** One render function per tab; only the active one is called. */
+  readonly panels: Readonly<Record<AgentDetailTab, () => React.ReactNode>>;
+  /** Tab to open when the URL names none. */
+  readonly initialTab?: AgentDetailTab;
+}
+
+export function AgentDetailTabs(props: AgentDetailTabsProps): React.ReactElement {
+  const t = useTranslations('operatorAgents.detailTabs');
+  // Lazy initial read: the server renders the default tab, the client picks
+  // the URL's tab on hydration. The effect below re-syncs if the URL is
+  // edited by hand (back/forward keeps the same document, so `popstate`).
+  const [tab, setTab] = useState<AgentDetailTab>(() => {
+    const fromUrl = readTabFromLocation();
+    return fromUrl !== DEFAULT_TAB ? fromUrl : (props.initialTab ?? DEFAULT_TAB);
+  });
+
+  useEffect(() => {
+    const onPop = (): void => setTab(readTabFromLocation());
+    window.addEventListener('popstate', onPop);
+    return () => window.removeEventListener('popstate', onPop);
+  }, []);
+
+  const select = useCallback((next: AgentDetailTab): void => {
+    setTab(next);
+    writeTabToLocation(next);
+  }, []);
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>): void => {
+    const idx = AGENT_DETAIL_TABS.indexOf(tab);
+    const delta = e.key === 'ArrowRight' ? 1 : e.key === 'ArrowLeft' ? -1 : 0;
+    if (delta === 0) return;
+    e.preventDefault();
+    const next = AGENT_DETAIL_TABS[(idx + delta + AGENT_DETAIL_TABS.length) % AGENT_DETAIL_TABS.length]!;
+    select(next);
+    document.getElementById(`agent-detail-tab-${next}`)?.focus();
+  };
+
+  return (
+    <div>
+      <div
+        role="tablist"
+        aria-label={t('aria')}
+        onKeyDown={onKeyDown}
+        className="sticky top-0 z-10 -mx-1 mb-6 flex flex-wrap gap-1 border-b border-[color:var(--border)] bg-[color:var(--bg)] px-1 pt-2"
+      >
+        {AGENT_DETAIL_TABS.map((id) => (
+          // eslint-disable-next-line no-restricted-syntax -- tab, not a §4.2 CTA
+          <button
+            key={id}
+            type="button"
+            role="tab"
+            id={`agent-detail-tab-${id}`}
+            aria-selected={tab === id}
+            aria-controls={`agent-detail-panel-${id}`}
+            tabIndex={tab === id ? 0 : -1}
+            data-testid={`agent-detail-tab-${id}`}
+            onClick={() => select(id)}
+            className={`-mb-px border-b-2 px-3 py-2 text-sm font-medium transition-colors ${
+              tab === id
+                ? 'border-[color:var(--accent)] text-[color:var(--accent)]'
+                : 'border-transparent text-[color:var(--fg-muted)] hover:text-[color:var(--fg)]'
+            }`}
+          >
+            {t(id)}
+          </button>
+        ))}
+      </div>
+      <div
+        role="tabpanel"
+        id={`agent-detail-panel-${tab}`}
+        aria-labelledby={`agent-detail-tab-${tab}`}
+        className="space-y-8"
+      >
+        {props.panels[tab]()}
+      </div>
+    </div>
+  );
+}

--- a/web-ui/app/operator/agents/[slug]/page.tsx
+++ b/web-ui/app/operator/agents/[slug]/page.tsx
@@ -9,10 +9,7 @@ import {
   listOperatorAgents,
   type OperatorAgentsListDto,
 } from '../../../_lib/agents';
-import { AgentContextMemory } from './_components/AgentContextMemory';
 import { AgentDetail } from './_components/AgentDetail';
-import { AgentMcpServers } from './_components/AgentMcpServers';
-import { AgentToolGrants } from './_components/AgentToolGrants';
 
 /**
  * Issue #861 — per-agent capability page (epic #860).
@@ -104,18 +101,9 @@ export default async function OperatorAgentDetailPage({
               agent.id === list.fallback_agent_id
             }
           />
-          {/* Wiring (#860): the sibling per-agent surfaces — read-only
-              tool-grant list (#861) and the MCP assignment / allowlist
-              editor (#862) — mount below the plugin editor. Both are
-              client components that fetch their own data by slug. */}
-          <div className="mt-8 space-y-8">
-            <AgentToolGrants slug={agent.slug} />
-            <AgentMcpServers slug={agent.slug} />
-            {/* #899 — the W5 memory-ACL rollout switch. Sits with the other
-                per-agent capability settings rather than in a global admin
-                page: the column is per agent, and so is the blast radius. */}
-            <AgentContextMemory slug={agent.slug} />
-          </div>
+          {/* The sibling per-agent surfaces (tool grants #861, MCP #862,
+              context memory #899) moved into AgentDetail's tabs — one
+              composition point, one tab strip. */}
         </>
       )}
     </main>

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -2548,6 +2548,16 @@
       "slugConfirmLabel": "Tippe zur Bestätigung den Bot-Slug „{slug}“ ein:",
       "slugMismatch": "Der eingegebene Bot-Slug stimmt nicht überein.",
       "resultCompleteIdentity": "Identität gelöscht. Der Orchestrator kann jetzt mit einem neuen Bot-Slug und Anzeigenamen angelegt werden."
+    },
+    "detailTabs": {
+      "aria": "Agent-Einstellungen",
+      "identity": "Identität",
+      "model": "Modell",
+      "peers": "Gespräche",
+      "teams": "Teams",
+      "plugins": "Plugins",
+      "tools": "Werkzeuge",
+      "memory": "Memory"
     }
   },
   "builder": {

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -2548,6 +2548,16 @@
       "slugConfirmLabel": "Type the bot slug \"{slug}\" to confirm:",
       "slugMismatch": "That is not the bot slug of this identity.",
       "resultCompleteIdentity": "Identity deleted. The orchestrator can be created again with a new bot slug and display name."
+    },
+    "detailTabs": {
+      "aria": "Agent settings",
+      "identity": "Identity",
+      "model": "Model",
+      "peers": "Conversations",
+      "teams": "Teams",
+      "plugins": "Plugins",
+      "tools": "Tools",
+      "memory": "Memory"
     }
   },
   "builder": {

--- a/web-ui/scripts/i18n-identical-allowlist.json
+++ b/web-ui/scripts/i18n-identical-allowlist.json
@@ -92,6 +92,9 @@
     "memory.promote.targetCtxKeyPlaceholder": "placeholder",
     "memory.audit.mode.copy": "diagnostic",
     "memory.audit.mode.move": "diagnostic",
-    "operatorAgents.peers.chatSelectLabel": "loanword"
+    "operatorAgents.peers.chatSelectLabel": "loanword",
+    "operatorAgents.detailTabs.teams": "brand",
+    "operatorAgents.detailTabs.plugins": "loanword",
+    "operatorAgents.detailTabs.memory": "glossary"
   }
 }


### PR DESCRIPTION
**Feldtest (Marcel):** „Die Seite gerne Tab-basiert bauen — aktuell ist der One-Pager nicht handlebar.“ Die Seite `/operator/agents/[slug]` ist mit jeder Welle um eine Sektion gewachsen (Teams #860, Identität #914, Grants/MCP #861/#862, Memory #899, Peers #1018, Modell #1033).

## Tabs

| Tab | Inhalt |
|---|---|
| Identität | `AgentIdentity` (Persona, Boundaries, Prompt-Vorschau) |
| Modell | `AgentModelPolicy` |
| Gespräche | `AgentPeers` |
| Teams | `AgentTeamsIdentity` + `AgentTeamsInstalls` |
| Plugins | Zugewiesene Liste + DnD-Editor (bisheriger Kern von `AgentDetail`) |
| Werkzeuge | `AgentToolGrants` + `AgentMcpServers` |
| Memory | `AgentContextMemory` |

## Mechanik

- **Nur das aktive Panel ist gemountet** — ein Tab lädt sein Read-Model beim Öffnen statt sieben Fetches beim Seitenaufruf.
- Aktiver Tab in **`?tab=`** (Deep-Link, z. B. `?tab=model` aus dem Builder-Inspector), geschrieben per `history.replaceState` — kein Router-Navigate, kein RSC-Refetch, `popstate` wird gehört.
- Tab-Leiste sticky, `role=tablist/tab/tabpanel`, `aria-selected`, Roving-Tabindex, Pfeiltasten.
- `AgentDetail` bleibt der einzige Kompositionspunkt: Tool-Grants, MCP und Context-Memory ziehen aus `page.tsx` hierher. Plugin-Remount-Vertrag (`editorRevision`) unverändert.

## Verifikation

- `AgentDetail.test.tsx` **14/14** — Plugin-Fälle laufen über den Plugins-Tab; neu: Default Identität + nur ein Panel im Baum, Wechsel + URL ohne `router.refresh`, Deep-Link `?tab=model` + unbekannter Wert → Identität, Pfeiltasten
- Geschwister-Suiten im `[slug]`-Ordner **165/165**
- `tsc` ✅ · `i18n:check` ✅ (4510 Keys) · `i18n-parity` ✅ · ESLint ✅ (2 pre-existing Warnings: ungenutzte Test-Fixtures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PuMKaZh4XDEmKts5y34Uhb

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/1057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791370185&installation_model_id=428086&pr_number=1057&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F1057&signature=febb916aa1a0fc98a753e53b5b287438fbfc0e502a9de3736f3c917c32a5712c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->