### PR TITLE
fix(web-ui): pass explicit now to relativeTime on providers page

### DIFF
--- a/web-ui/app/admin/providers/_components/ProvidersPanel.tsx
+++ b/web-ui/app/admin/providers/_components/ProvidersPanel.tsx
@@ -80,7 +80,12 @@ type Status = 'idle' | 'saving' | 'saved' | 'error';
 
 type State =
   | { kind: 'loading' }
-  | { kind: 'ready'; data: ProvidersResponse }
+  // `fetchedAt` is the reference point for the relative timestamps in
+  // ConnectionChip. next-intl requires an explicit `now` for `relativeTime`,
+  // and reading the clock during render is impure — so the clock is read once
+  // here, in `load`, which is also the honest answer: "verified 3 minutes ago"
+  // means 3 minutes before this data was read.
+  | { kind: 'ready'; data: ProvidersResponse; fetchedAt: number }
   // The thrown error itself, for the same reason `errors` below keeps it: a
   // pre-flattened string is already past the point where the code is readable.
   | { kind: 'error'; error: unknown };
@@ -102,7 +107,7 @@ export function ProvidersPanel({
   const load = useCallback(async (): Promise<void> => {
     try {
       const data = await getProviders();
-      setState({ kind: 'ready', data });
+      setState({ kind: 'ready', data, fetchedAt: Date.now() });
     } catch (err) {
       setState({ kind: 'error', error: err });
     }
@@ -182,6 +187,7 @@ export function ProvidersPanel({
                 <ProviderRow
                   key={p.id}
                   provider={p}
+                  now={state.fetchedAt}
                   t={t}
                   onReload={load}
                   onSwitchToSubscriptions={onSwitchToSubscriptions}
@@ -225,11 +231,13 @@ type T = ReturnType<typeof useTranslations>;
 
 function ProviderRow({
   provider: p,
+  now,
   t,
   onReload,
   onSwitchToSubscriptions,
 }: {
   provider: AdminProvider;
+  now: number;
   t: T;
   /** Re-fetch the providers list after a key save so `connected` flips. */
   onReload: () => Promise<void>;
@@ -330,7 +338,7 @@ function ProviderRow({
           </span>
         </span>
         <span className="flex items-center gap-3">
-          <ConnectionChip provider={p} t={t} />
+          <ConnectionChip provider={p} now={now} t={t} />
           {/* Explicit re-probe. Only offered where there is a credential to
               probe — the CLI provider authenticates on the Subscriptions tab,
               and an OAuth provider has no key to probe. */}
@@ -569,9 +577,11 @@ const UNVERIFIED_REASON_KEYS: Record<string, string | undefined> = {
  */
 function ConnectionChip({
   provider: p,
+  now,
   t,
 }: {
   provider: AdminProvider;
+  now: number;
   t: T;
 }): React.ReactElement {
   const format = useFormatter();
@@ -588,7 +598,7 @@ function ConnectionChip({
       {p.status === 'verified' && p.verifiedAt && (
         <span className="text-[11px] text-[color:var(--fg-muted)]">
           {t('providers.verifiedAt', {
-            time: format.relativeTime(new Date(p.verifiedAt)),
+            time: format.relativeTime(new Date(p.verifiedAt), now),
           })}
         </span>
       )}
@@ -602,7 +612,7 @@ function ConnectionChip({
           title={t('providers.cooldownTitle', { reason: p.cooldown.reason })}
         >
           {t('providers.cooldown', {
-            time: format.relativeTime(new Date(p.cooldown.until)),
+            time: format.relativeTime(new Date(p.cooldown.until), now),
           })}
         </span>
       )}


### PR DESCRIPTION
## What

Fix the `ENVIRONMENT_FALLBACK` IntlError that `/admin/providers` logged once per
provider row: `format.relativeTime` was called without a `now` argument, and
`i18n/request.ts` configures no global default. `State` now carries a
`fetchedAt` timestamp read in `load()`, threaded to `ConnectionChip` as a `now`
prop.

## Why

next-intl demands an explicit `now` because a server-rendered component's "now"
differs from the client's, which hydrates wrong. Reading the clock in
`ConnectionChip`'s render body is the obvious fix but `react-hooks/purity`
rejects it (`Date.now` is impure — the React Compiler may repeat renders).
`load()` is an async callback, not a render, so the clock read is legal there —
and it is the more honest reference point anyway: "verified 3 minutes ago" now
means 3 minutes before this data was read. It also preserves the old behaviour
across `onReload()` (Test key / key save), which a bare `useNow()` would not:
that freezes on mount, so a just-verified provider would read "verified 20
minutes ago" on a long-open tab.

## Test plan

- [x] `npm run typecheck` in `web-ui` — clean
- [x] `npx eslint app/admin/providers/_components/ProvidersPanel.tsx` — clean
      (this is the check that rejected the in-render `Date.now()`)
- [x] `npx vitest run app/admin/providers` — 3 files, 32 tests passed
- [x] manual: `npm run dev`, open `http://localhost:3300/admin/providers`,
      confirm the console error is gone and both chips still render a relative
      time; click "Test key" and confirm the timestamp resets to "just now"

## Risk / blast radius

Low — one client component, no schema, no public API, no env-var, no CI change.
`fetchedAt` is added to a local `State` union that does not leave the file. The
optimistic assignment update in `apply()` spreads `prev`, so it keeps
`fetchedAt`; correct, since no fresh server data arrives there.

The same `relativeTime`-without-`now` pattern does not exist elsewhere —
`AgentTeamsProvisioningTimeline.tsx` already passes `now` explicitly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/1060"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791443519&installation_model_id=428086&pr_number=1060&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F1060&signature=fa61b3f6b2c579ef14b5cde307bf375b48f0de0e539397f0a0043f0d276bb02a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->