### PR TITLE
fix(cli): Runde 5 W0 hotfix (OM-85/86/94/104)

### DIFF
--- a/.github/workflows/desktop-apps.yml
+++ b/.github/workflows/desktop-apps.yml
@@ -284,6 +284,17 @@ jobs:
           cp "$PV/lib/postgresql@17/vector.dylib" "$NATIVE/lib/postgresql/vector.dylib"
           cp "$PV/share/postgresql@17/extension/vector.control" "$NATIVE/share/postgresql/extension/"
           cp "$PV"/share/postgresql@17/extension/vector--*.sql "$NATIVE/share/postgresql/extension/"
+          # OM-86 (beta round 5): Homebrew keeps its keg read-only and `cp`
+          # preserves the mode, so vector.dylib shipped as 0444 — the ONE file
+          # out of 25,895 in the update archive without owner-write. Squirrel
+          # strips the quarantine xattr from every file before swapping an
+          # update in; on a read-only file that write fails with EACCES and the
+          # whole install is aborted, so no macOS install could self-update
+          # from 0.152.0 on. stage-runtime normalises the whole tree as a
+          # second layer; this keeps the fix next to its cause.
+          chmod u+w "$NATIVE/lib/postgresql/vector.dylib" \
+            "$NATIVE/share/postgresql/extension/vector.control" \
+            "$NATIVE"/share/postgresql/extension/vector--*.sql
           # Prove the dylib really is this runner's architecture — a silently
           # mismatched vector.dylib would only fail at CREATE EXTENSION, inside
           # the shipped app, on a user's machine.
@@ -465,6 +476,42 @@ jobs:
           # cause. Re-run this step with `DEBUG=electron-builder` to see the
           # actual command and its stderr.
           npx electron-builder ${{ matrix.args }} ${EB_NOTARIZE:-} --publish never
+
+      # OM-86 (beta round 5): the update archive is what Squirrel installs, and
+      # Squirrel strips the quarantine xattr from EVERY entry before swapping
+      # the app in. One entry without owner-write (0444) fails that write with
+      # EACCES and aborts the whole update — which is how every macOS install
+      # lost self-update from 0.152.0 on, with the CI green throughout. The
+      # arch check above already argues "a fault that only fails on a user's
+      # machine must fail here instead"; this is the same argument for mode
+      # bits. Reads the archive's own central directory, not the staged tree,
+      # so a packaging step that re-introduces the bit is caught too.
+      - name: Verify no read-only entries in the macOS update archives (OM-86)
+        if: ${{ startsWith(matrix.os, 'macos') }}
+        working-directory: desktop
+        run: |
+          set -e
+          shopt -s nullglob
+          zips=(release/*.zip)
+          if [ ${#zips[@]} -eq 0 ]; then
+            echo "FAIL: no update .zip produced under release/ — nothing to verify" >&2
+            exit 1
+          fi
+          status=0
+          for z in "${zips[@]}"; do
+            # zipinfo's first column is the unix mode string (-rw-r--r--); the
+            # third character is the owner-write bit. Header/trailer lines do
+            # not start with a mode string and are skipped by the regex.
+            offenders="$(zipinfo "$z" | awk '$1 ~ /^[-dl][-r][-w]/ && substr($1,3,1) != "w" { print $NF " (" $1 ")" }')"
+            if [ -n "$offenders" ]; then
+              echo "FAIL: $z carries entries without owner-write — Squirrel cannot install it:" >&2
+              echo "$offenders" >&2
+              status=1
+            else
+              echo "✓ $z: every entry is owner-writable ($(zipinfo -1 "$z" | wc -l | tr -d ' ') entries)"
+            fi
+          done
+          exit $status
 
       # ALWAYS runs on macOS — signed or not. Without it, a build whose signature
       # macOS considers corrupt sails through CI green and ships an app that

--- a/.github/workflows/desktop-apps.yml
+++ b/.github/workflows/desktop-apps.yml
@@ -490,7 +490,11 @@ jobs:
         if: ${{ startsWith(matrix.os, 'macos') }}
         working-directory: desktop
         run: |
-          set -e
+          # pipefail matters here: without it a missing or corrupt archive makes
+          # `zipinfo | awk` exit 0 with empty output, and the gate would print a
+          # green tick over nothing — the silent-pass shape this step exists to
+          # remove. The entry count is asserted for the same reason.
+          set -eo pipefail
           shopt -s nullglob
           zips=(release/*.zip)
           if [ ${#zips[@]} -eq 0 ]; then
@@ -499,16 +503,24 @@ jobs:
           fi
           status=0
           for z in "${zips[@]}"; do
+            entries="$(zipinfo -1 "$z" | wc -l | tr -d ' ')"
+            if [ "$entries" -eq 0 ]; then
+              echo "FAIL: $z lists no entries — corrupt archive or zipinfo failure" >&2
+              status=1
+              continue
+            fi
             # zipinfo's first column is the unix mode string (-rw-r--r--); the
             # third character is the owner-write bit. Header/trailer lines do
-            # not start with a mode string and are skipped by the regex.
-            offenders="$(zipinfo "$z" | awk '$1 ~ /^[-dl][-r][-w]/ && substr($1,3,1) != "w" { print $NF " (" $1 ")" }')"
+            # not start with a mode string and are skipped by the regex. The
+            # path is everything from the 9th field on, so names with spaces
+            # ("Omadia Helper (GPU).app/…") are printed whole.
+            offenders="$(zipinfo "$z" | awk '$1 ~ /^[-dl][-r][-w]/ && substr($1,3,1) != "w" { mode=$1; $1=$2=$3=$4=$5=$6=$7=$8=""; sub(/^ +/, ""); print $0 " (" mode ")" }')"
             if [ -n "$offenders" ]; then
               echo "FAIL: $z carries entries without owner-write — Squirrel cannot install it:" >&2
               echo "$offenders" >&2
               status=1
             else
-              echo "✓ $z: every entry is owner-writable ($(zipinfo -1 "$z" | wc -l | tr -d ' ') entries)"
+              echo "✓ $z: every entry is owner-writable ($entries entries)"
             fi
           done
           exit $status

--- a/desktop/scripts/normalize-file-modes.mjs
+++ b/desktop/scripts/normalize-file-modes.mjs
@@ -1,0 +1,82 @@
+// Makes every regular file and directory in a staged tree writable by its
+// owner (OM-86, beta round 5).
+//
+// Why this exists: on macOS the release archive shipped exactly ONE file out
+// of 25,895 without the owner-write bit — `omadia-pg/lib/postgresql/vector.dylib`,
+// mode 0444. Homebrew keeps its keg read-only and the CI `cp` preserved the
+// mode. Squirrel/ShipIt strips the quarantine xattr from EVERY file of a
+// downloaded update before swapping it in; removing an xattr is a write, so on
+// that one file it failed with EACCES ("Couldn't remove quarantine attribute …
+// This most likely means the file is read-only"), and no macOS install could
+// self-update from 0.152.0 to anything newer. The fix that healed the boot
+// crash of those versions (0.154.1) existed for three days and was unreachable.
+//
+// The CI step that copies pgvector now chmods its files too; this pass is the
+// second layer, over the WHOLE staged tree, so the next read-only file from a
+// package tarball or a keg cannot reproduce the failure. Symlinks are skipped:
+// chmod follows them, and the engine's relative dylib chain must stay untouched.
+//
+// Runs on every platform for simplicity; on Windows `fs.chmodSync` only toggles
+// the read-only attribute, which is exactly the intent.
+import fs from 'node:fs';
+import path from 'node:path';
+
+const OWNER_WRITE = 0o200;
+
+/**
+ * Walk `root` and add the owner-write bit wherever it is missing.
+ *
+ * @param {string} root
+ * @returns {{ fixed: string[] }} the paths (relative to root) that were changed
+ */
+export function ensureOwnerWritable(root) {
+  const fixed = [];
+  const walk = (dir) => {
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const p = path.join(dir, entry.name);
+      // Dirent flags are lstat-based, so a symlink is never followed here.
+      if (entry.isSymbolicLink()) continue;
+      const mode = fs.lstatSync(p).mode;
+      if ((mode & OWNER_WRITE) === 0) {
+        fs.chmodSync(p, (mode & 0o7777) | OWNER_WRITE);
+        fixed.push(path.relative(root, p));
+      }
+      if (entry.isDirectory()) walk(p);
+    }
+  };
+  walk(root);
+  return { fixed };
+}
+
+/**
+ * The gate: after {@link ensureOwnerWritable}, nothing may be left read-only.
+ * Returns the offending paths so the caller can print them and refuse to ship.
+ *
+ * @param {string} root
+ * @returns {string[]}
+ */
+export function findReadOnlyEntries(root) {
+  const offenders = [];
+  const walk = (dir) => {
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const p = path.join(dir, entry.name);
+      if (entry.isSymbolicLink()) continue;
+      if ((fs.lstatSync(p).mode & OWNER_WRITE) === 0) offenders.push(path.relative(root, p));
+      if (entry.isDirectory()) walk(p);
+    }
+  };
+  walk(root);
+  return offenders;
+}

--- a/desktop/scripts/normalize-file-modes.test.mjs
+++ b/desktop/scripts/normalize-file-modes.test.mjs
@@ -1,0 +1,74 @@
+// Tests for the staged-tree mode normalisation (OM-86, beta round 5).
+//
+// One 0444 file out of 25,895 was enough to make every macOS self-update fail
+// in Squirrel's quarantine strip. These tests pin the two halves of the guard:
+// the pass that adds the owner-write bit, and the scan that must find nothing
+// afterwards. Symlinks are deliberately left alone — chmod follows them, and
+// the Postgres engine's relative dylib chain must survive staging untouched.
+//
+// Run: node --test desktop/scripts/*.test.mjs
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { ensureOwnerWritable, findReadOnlyEntries } from './normalize-file-modes.mjs';
+
+const OWNER_WRITE = 0o200;
+
+function makeTree() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'omadia-modes-'));
+  const libDir = path.join(root, 'omadia-pg', 'lib', 'postgresql');
+  fs.mkdirSync(libDir, { recursive: true });
+  const dylib = path.join(libDir, 'vector.dylib');
+  fs.writeFileSync(dylib, 'not really a dylib');
+  fs.chmodSync(dylib, 0o444);
+  const normal = path.join(root, 'omadia-pg', 'lib', 'libpq.dylib');
+  fs.writeFileSync(normal, 'writable');
+  fs.chmodSync(normal, 0o644);
+  return { root, dylib, normal, libDir };
+}
+
+test('finds the one read-only file the release archive shipped', () => {
+  const { root } = makeTree();
+  assert.deepEqual(findReadOnlyEntries(root), [
+    path.join('omadia-pg', 'lib', 'postgresql', 'vector.dylib'),
+  ]);
+});
+
+test('adds the owner-write bit and keeps every other permission bit', () => {
+  const { root, dylib, normal } = makeTree();
+  const { fixed } = ensureOwnerWritable(root);
+
+  assert.deepEqual(fixed, [path.join('omadia-pg', 'lib', 'postgresql', 'vector.dylib')]);
+  assert.equal(fs.statSync(dylib).mode & 0o777, 0o644, 'r--r--r-- becomes rw-r--r--');
+  assert.equal(fs.statSync(normal).mode & 0o777, 0o644, 'already-writable files are untouched');
+  assert.deepEqual(findReadOnlyEntries(root), [], 'the scan finds nothing afterwards');
+});
+
+test('fixes a read-only directory as well as a file', () => {
+  const { root } = makeTree();
+  const dir = path.join(root, 'share');
+  fs.mkdirSync(dir);
+  fs.writeFileSync(path.join(dir, 'a.txt'), 'x');
+  fs.chmodSync(dir, 0o555);
+
+  const { fixed } = ensureOwnerWritable(root);
+  assert.ok(fixed.includes('share'), `expected 'share' in ${JSON.stringify(fixed)}`);
+  assert.ok((fs.statSync(dir).mode & OWNER_WRITE) !== 0);
+});
+
+test('never follows or touches a symlink', { skip: process.platform === 'win32' }, () => {
+  const { root, libDir } = makeTree();
+  const target = path.join(libDir, 'libicudata.68.2.dylib');
+  fs.writeFileSync(target, 'icu');
+  fs.chmodSync(target, 0o444);
+  const link = path.join(libDir, 'libicudata.68.dylib');
+  fs.symlinkSync('libicudata.68.2.dylib', link);
+
+  const { fixed } = ensureOwnerWritable(root);
+  assert.ok(fs.lstatSync(link).isSymbolicLink(), 'the link survives');
+  assert.ok(!fixed.includes(path.relative(root, link)), 'the link is not reported');
+  assert.ok(fixed.includes(path.relative(root, target)), 'the target is fixed via its own entry');
+});

--- a/desktop/scripts/stage-runtime.mjs
+++ b/desktop/scripts/stage-runtime.mjs
@@ -16,6 +16,7 @@ import {
   hostTriple,
   pruneUnloadableOnnxPayloads,
 } from './prune-onnx-payloads.mjs';
+import { ensureOwnerWritable, findReadOnlyEntries } from './normalize-file-modes.mjs';
 import { fileURLToPath } from 'node:url';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
@@ -281,6 +282,29 @@ if (stillDangling !== 0) {
   console.error(
     `[stage-runtime] FATAL: ${stillDangling} escaping symlink(s) survived the prune — ` +
       'refusing to stage a tree that macOS codesign cannot walk.',
+  );
+  process.exit(1);
+}
+
+// --- no read-only entries may ship (OM-86) ------------------------------
+// Squirrel strips the quarantine xattr from every file of a downloaded update;
+// on a 0444 file that write fails with EACCES and the WHOLE update is aborted.
+// One such file (Homebrew's pgvector dylib, copied mode-preserving) blocked
+// every macOS self-update from 0.152.0 on. Add the owner-write bit wherever it
+// is missing, then gate on a clean re-scan — the same shape as the symlink
+// gate above, for the same reason: a guard that only fixes cannot notice when
+// the fix stopped working.
+const { fixed } = ensureOwnerWritable(runtime);
+if (fixed.length > 0) {
+  console.log(`[stage-runtime] made ${fixed.length} read-only entr${fixed.length === 1 ? 'y' : 'ies'} owner-writable:`);
+  for (const rel of fixed) console.log(`  ${rel}`);
+}
+const stillReadOnly = findReadOnlyEntries(runtime);
+if (stillReadOnly.length !== 0) {
+  console.error(
+    `[stage-runtime] FATAL: ${stillReadOnly.length} read-only entr${stillReadOnly.length === 1 ? 'y' : 'ies'} ` +
+      `survived normalisation (${stillReadOnly.slice(0, 5).join(', ')}) — refusing to stage a tree ` +
+      'the macOS updater cannot install.',
   );
   process.exit(1);
 }

--- a/docs/middleware-agent-handoff.md
+++ b/docs/middleware-agent-handoff.md
@@ -1903,6 +1903,16 @@ AGENTS.md jede Env-Variable an einer Stelle dokumentiert haben will:
 | `OMADIA_CLI_LIVE_PROBE=1` | Startet die Live-Probe: echte `claude`-CLI mit dem Produktions-argv, die einen Shell-Befehl ablehnen muss. Kostet Abo-Kontingent und braucht eine eingeloggte CLI, daher opt-in. |
 | `OMADIA_CLI_NEGATIVE_CONTROL=1` | Ergänzt die Probe um die Gegenprobe mit dem argv von vor #991, das erwartungsgemäß ein Built-in-Tool erreicht. Lässt die CLI dabei bewusst einen Shell-Befehl auf dieser Maschine ausführen, deshalb ein eigener Schalter. |
 
+### Abo-CLI-Turn-Budget (OM-104, Beta-Runde 5)
+
+Wird vom `@omadia/orchestrator`-Package gelesen (`resolveCliSpawnTimeoutMs()` in
+`cliChatAgent.ts`), nicht über `config.ts`, weil das Package die Middleware-Config
+nicht importieren kann.
+
+| Variable | Wirkung |
+|---|---|
+| `OMADIA_CLI_SPAWN_TIMEOUT_MS` | Wanduhr-Budget **eines** CLI-geführten Chat-Turns (Shape 3) in Millisekunden, Default `600000`. Vorher fest 120 s ohne Override, während ein einzelner Aufruf des eigenen `query_seo_analyst`-Sub-Agenten 69–75 s dauert — zwei davon waren garantiert über dem Limit. Das Leerlauf-Limit (60 s ohne Ausgabe) bleibt getrennt bestehen. Nicht-numerische oder nicht-positive Werte werden ignoriert. Priorität: explizite `spawnTimeoutMs`-Dependency > ENV > Default. |
+
 ### `middleware/config.ts` — alle Env-Variablen mit zod-Schema
 
 ```

--- a/docs/security-architecture.md
+++ b/docs/security-architecture.md
@@ -98,7 +98,7 @@ The gate, asserted by `test/cliBridge/cliSpawnGate.test.ts` and
 | `--strict-mcp-config --mcp-config <0600 file>` | Only omadia's loopback server; no MCP servers from the user's own config. |
 | `--allowedTools mcp__omadia__*` | Pre-approves omadia's tools so the turn does not stall on a prompt. |
 | `--system-prompt <omadia prompt>` | Replaces the CLI's default prompt. With `--append-system-prompt` the model kept Claude Code's identity, treated the CLI toolbox as its own and told users in the omadia chat to "go to omadia" (#992). `composeCliSystemPrompt()` always states the runtime and the only toolset the model has. |
-| `--restricted` (#1014) | Removes the code-running built-ins and WebFetch unless `--tools` names them, ignores user/project/local settings files, and confines the file tools. Additive belt over `--tools ""`. Chosen over `--bare`, which also skips `CLAUDE.md` discovery but reads neither OAuth nor the keychain — it would break the keyless subscription login outright. |
+| `--restricted` (#1014, version-gated since OM-85) | Removes the code-running built-ins and WebFetch unless `--tools` names them, ignores user/project/local settings files, and confines the file tools. Additive belt over `--tools ""`. Chosen over `--bare`, which also skips `CLAUDE.md` discovery but reads neither OAuth nor the keychain — it would break the keyless subscription login outright. **Passed only when the installed CLI is ≥ 2.1.248** (`resolveCliVersion()` probes `claude --version`, cached 5 min; `supportsRestrictedFlag()`): older CLIs do not ignore an unknown flag, they exit 1 with `unknown option`, which killed every turn on a 2.1.246 install (OM-85). On every spawn, regardless of version, the env twin `CLAUDE_CODE_RESTRICTED=1` is set — a CLI that knows it gets the same boundary, one that does not ignores the key. **Deliberate trade-off:** an unknown or unparsable version means the flag is left out, i.e. one protective layer fewer (the three layers `--tools ""`, `--disallowedTools`, `dontAsk` still hold), rather than a dead subscription path. A CLI that rejects one of *our* flags surfaces as `CliIncompatibleError` (`code: cli_incompatible`) with the update instruction, not as a failed answer. |
 | `cwd` = empty temp dir (#1014) | The CLI **hardcodes** `CLAUDE.md` / `AGENTS.md` discovery and only `--bare` skips it, so no flag closes this. Without a `cwd` the child inherited the middleware process's directory and any `CLAUDE.md` at or above it joined a prompt built from user content. Both sites now spawn in a per-turn temp dir holding nothing but the mcp-config. |
 | Env allowlist (#1014) | `buildGatedCliEnv()` passes only `PATH`, `HOME`, `CLAUDE_CONFIG_DIR`, `TMPDIR`, locale/`TZ`, proxy and CA vars, and `USER`/`LOGNAME`. It replaced a deny list that removed credentials and billing switches but passed `NODE_OPTIONS` (which can `--require` arbitrary code into the child) and the whole `CLAUDE_CODE_*` family. The deny list is kept as a second layer, and a test asserts the two never overlap. |
 
@@ -846,10 +846,13 @@ Before merging a PR that touches credentials, prompts, or proxy routes:
 - [ ] Any new sub-agent tool is scope-locked at construction time.
 - [ ] A change to either CLI spawn argv keeps the deny gate (`--tools ""`,
       `--disallowedTools`, `--permission-mode dontAsk`, `--setting-sources ""`,
-      `--restricted`, `--strict-mcp-config`, `--system-prompt`), the empty
-      `cwd`, the env allowlist, and their tests (§3a). Both sites build argv
-      from `cliSpawnGate.ts` — a new spawn site must use it too, not copy the
-      flags.
+      `--restricted` where the CLI version allows it plus the
+      `CLAUDE_CODE_RESTRICTED=1` env twin, `--strict-mcp-config`,
+      `--system-prompt`), the empty `cwd`, the env allowlist, and their tests
+      (§3a). Both sites build argv from `cliSpawnGate.ts` — a new spawn site
+      must use it too, not copy the flags — and pass the resolved CLI version
+      into it (OM-85): a new flag that an older CLI may not know needs the same
+      version gate, never an unconditional argv entry.
 - [ ] A new CLI version has been run against the deny-list drift guard
       (`cliSpawnGate.test.ts`) **on a machine where that version is installed**,
       and ideally the live probe (`OMADIA_CLI_LIVE_PROBE=1`), before the

--- a/middleware/.env.example
+++ b/middleware/.env.example
@@ -343,3 +343,13 @@ CONDUCTOR_EPHEMERAL_REAPER_INTERVAL_MS=60000
 # to reach a built-in tool. Deliberately lets the CLI run a shell command on
 # this machine, so it has its own switch.
 # OMADIA_CLI_NEGATIVE_CONTROL=1
+
+# --- Subscription-CLI turn budget (OM-104, beta round 5) ---------------------
+# Wall-clock budget of ONE CLI-owned chat turn (Shape 3, `CliChatAgent`), in
+# milliseconds. Default 600000 (10 min). It used to be a hard-coded 120 s with
+# no override, while a single call to omadia's own `query_seo_analyst` sub-agent
+# takes 69–75 s — two of those and the turn was guaranteed dead. The 60 s idle
+# timeout (no output from the CLI at all) is separate and stays; this one only
+# needs to be long enough for the tools a turn legitimately runs. Non-numeric
+# or non-positive values are ignored, never turned into a zero budget.
+# OMADIA_CLI_SPAWN_TIMEOUT_MS=600000

--- a/middleware/packages/harness-orchestrator/src/cliChatAgent.ts
+++ b/middleware/packages/harness-orchestrator/src/cliChatAgent.ts
@@ -22,12 +22,69 @@ import {
   OMADIA_MCP_TOOL_PREFIX,
   buildCliToolGateArgv,
   buildGatedCliEnv,
+  classifyUnknownOptionFailure,
+  resolveCliVersion,
 } from './cliSpawnGate.js';
 
 const DEFAULT_CLI_BINARY = 'claude';
 const DEFAULT_MODEL = 'sonnet';
-const DEFAULT_SPAWN_TIMEOUT_MS = 120_000;
+/**
+ * OM-104 — the wall-clock budget of one CLI-owned turn. It used to be a
+ * hard-coded 120 s with no way to raise it, while a single call to omadia's
+ * own `query_seo_analyst` sub-agent takes 69–75 s: two of those and the turn
+ * was guaranteed dead, on an agent loop configured for up to 100 iterations.
+ * 10 minutes is a budget the platform's own tools fit into; the idle timeout
+ * below still catches a CLI that stopped producing output.
+ */
+const DEFAULT_SPAWN_TIMEOUT_MS = 600_000;
 const DEFAULT_IDLE_TIMEOUT_MS = 60_000;
+/** Environment override for {@link DEFAULT_SPAWN_TIMEOUT_MS}, in milliseconds. */
+export const CLI_SPAWN_TIMEOUT_ENV_KEY = 'OMADIA_CLI_SPAWN_TIMEOUT_MS';
+
+/**
+ * The turn timeout to use: an explicit dependency wins, then a positive
+ * integer in {@link CLI_SPAWN_TIMEOUT_ENV_KEY}, then the default. Anything
+ * else in the variable (empty, `0`, `abc`) is ignored rather than turned
+ * into a zero-second budget.
+ */
+export function resolveCliSpawnTimeoutMs(
+  explicit: number | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  if (explicit !== undefined) {
+    return explicit;
+  }
+
+  const raw = env[CLI_SPAWN_TIMEOUT_ENV_KEY];
+  const parsed = raw === undefined ? Number.NaN : Number.parseInt(raw, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : DEFAULT_SPAWN_TIMEOUT_MS;
+}
+
+/**
+ * OM-94 — the sink for the three facts a failed turn used to keep to itself:
+ * that a CLI was spawned (argv shape, never the prompt), how it exited, and
+ * the first line it wrote to stderr. The reporter attached the log file the
+ * update dialog asks for, and it contained none of them.
+ */
+export interface CliSpawnLogger {
+  info(message: string, meta?: Readonly<Record<string, unknown>>): void;
+  warn(message: string, meta?: Readonly<Record<string, unknown>>): void;
+}
+
+const consoleSpawnLogger: CliSpawnLogger = {
+  info: (message, meta) =>
+    console.info(`[cli-chat-agent] ${message}${meta ? ` ${JSON.stringify(meta)}` : ''}`),
+  warn: (message, meta) =>
+    console.warn(`[cli-chat-agent] ${message}${meta ? ` ${JSON.stringify(meta)}` : ''}`),
+};
+
+/** First non-empty stderr line, for a log entry that stays one line. */
+function firstLine(text: string): string | undefined {
+  return text
+    .split('\n')
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+}
 const FORCE_KILL_DELAY_MS = 2_000;
 const DEFAULT_MAX_CONCURRENT_TURNS = 3;
 
@@ -447,9 +504,18 @@ export interface CliChatAgentDeps {
   readonly systemPrompt?: string;
   readonly buildEnv?: () => NodeJS.ProcessEnv;
   readonly spawnFn?: typeof nodeSpawn;
+  /** Overrides {@link CLI_SPAWN_TIMEOUT_ENV_KEY} and the default (OM-104). */
   readonly spawnTimeoutMs?: number;
   readonly idleTimeoutMs?: number;
   readonly maxConcurrentTurns?: number;
+  /**
+   * OM-85 — resolves the installed CLI's version before each spawn so the
+   * gate can leave `--restricted` off a CLI that would reject it. Defaults to
+   * a cached `claude --version` probe; a test injects a constant.
+   */
+  readonly resolveCliVersion?: (binary: string) => Promise<string | undefined>;
+  /** OM-94 — where spawn, exit code and first stderr line are recorded. */
+  readonly logger?: CliSpawnLogger;
 }
 
 /**
@@ -691,6 +757,12 @@ export class CliChatAgent implements ChatAgent {
       const configPath = join(tempDir, 'mcp-config.json');
       await writeFile(configPath, this.buildMcpConfig(handle.url, bearer), { mode: 0o600 });
 
+      const cliBinary = this.deps.cliBinary ?? DEFAULT_CLI_BINARY;
+      // OM-85 — probe (cached) before building argv; unknown → no `--restricted`.
+      const cliVersion = await (this.deps.resolveCliVersion ?? resolveCliVersion)(cliBinary);
+      const spawnTimeoutMs = resolveCliSpawnTimeoutMs(this.deps.spawnTimeoutMs);
+      const logger = this.deps.logger ?? consoleSpawnLogger;
+
       const argv = [
         '-p',
         '--output-format',
@@ -704,6 +776,7 @@ export class CliChatAgent implements ChatAgent {
         ...buildCliToolGateArgv({
           mcpConfigPath: configPath,
           allowedTools: `${OMADIA_MCP_TOOL_PREFIX}*`,
+          ...(cliVersion !== undefined ? { cliVersion } : {}),
         }),
         '--model',
         this.deps.model ?? DEFAULT_MODEL,
@@ -715,8 +788,20 @@ export class CliChatAgent implements ChatAgent {
         composeCliSystemPrompt(this.deps.systemPrompt),
       ];
 
+      // OM-94 — the argv shape without the prompt (which travels on stdin) and
+      // without the deny list (104 names that never change between turns).
+      logger.info('spawning claude CLI', {
+        binary: cliBinary,
+        cliVersion: cliVersion ?? 'unknown',
+        restrictedFlag: argv.includes('--restricted'),
+        model: this.deps.model ?? DEFAULT_MODEL,
+        spawnTimeoutMs,
+        idleTimeoutMs: this.deps.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS,
+        tools: tools.length,
+      });
+
       child = (this.deps.spawnFn ?? nodeSpawn)(
-        this.deps.cliBinary ?? DEFAULT_CLI_BINARY,
+        cliBinary,
         argv,
         {
           env: this.buildEnv(),
@@ -770,10 +855,14 @@ export class CliChatAgent implements ChatAgent {
       });
 
       overallTimer = setTimeout(() => {
+        logger.warn('claude CLI turn timed out', { spawnTimeoutMs, stderr: firstLine(stderr) });
         failRuntime(
-          new Error(`CLI timed out after ${this.deps.spawnTimeoutMs ?? DEFAULT_SPAWN_TIMEOUT_MS}ms`),
+          new Error(
+            `CLI timed out after ${spawnTimeoutMs}ms ` +
+              `(raise ${CLI_SPAWN_TIMEOUT_ENV_KEY} for turns that run several tools)`,
+          ),
         );
-      }, this.deps.spawnTimeoutMs ?? DEFAULT_SPAWN_TIMEOUT_MS);
+      }, spawnTimeoutMs);
 
       resetIdleTimer();
 
@@ -815,10 +904,25 @@ export class CliChatAgent implements ChatAgent {
       }
 
       if (closeInfo?.signal !== null && closeInfo?.signal !== undefined) {
+        logger.warn('claude CLI exited with signal', {
+          signal: closeInfo.signal,
+          stderr: firstLine(stderr),
+        });
         throw new Error(`CLI exited with signal ${closeInfo.signal}`);
       }
 
       if ((closeInfo?.code ?? 0) !== 0) {
+        // OM-94 — this is the line the log file never had.
+        logger.warn('claude CLI exited with non-zero code', {
+          code: closeInfo?.code,
+          cliVersion: cliVersion ?? 'unknown',
+          stderr: firstLine(stderr),
+        });
+        // OM-85 — say what to do, not just what happened.
+        const incompatible = classifyUnknownOptionFailure(stderr, cliVersion);
+        if (incompatible !== undefined) {
+          throw incompatible;
+        }
         const stderrSuffix = stderr.trim().length > 0 ? `: ${stderr.trim()}` : '';
         throw new Error(`CLI exited with code ${String(closeInfo?.code)}${stderrSuffix}`);
       }

--- a/middleware/packages/harness-orchestrator/src/cliSpawnGate.ts
+++ b/middleware/packages/harness-orchestrator/src/cliSpawnGate.ts
@@ -579,6 +579,12 @@ function defaultVersionExec(
  * to `undefined`, which {@link supportsRestrictedFlag} treats as "do not pass
  * the flag". The spawn that follows then fails (or succeeds) on its own
  * terms, with its own error message — the probe must not add a failure mode.
+ *
+ * A failed probe is cached like a successful one: a CLI installed inside the
+ * TTL window runs flag-less (still behind `--tools ""`, the deny list,
+ * `dontAsk` and the env twin) for at most five minutes. That is the cheaper
+ * side of the trade — re-probing a missing binary on every turn would spawn a
+ * failing process per message for as long as the CLI stays absent.
  */
 export async function resolveCliVersion(
   binary: string,

--- a/middleware/packages/harness-orchestrator/src/cliSpawnGate.ts
+++ b/middleware/packages/harness-orchestrator/src/cliSpawnGate.ts
@@ -43,6 +43,18 @@
  *                          touch authentication (unlike `--bare`, which reads
  *                          neither OAuth nor keychain and would break the
  *                          keyless subscription login outright).
+ *                          OM-85: the flag only exists from CLI 2.1.248
+ *                          (2026-08-27). An older CLI does not ignore an
+ *                          unknown flag — it prints `error: unknown option`
+ *                          and exits 1, which killed EVERY turn on a 2.1.246
+ *                          install. The flag is therefore passed only when
+ *                          the resolved CLI version supports it
+ *                          ({@link supportsRestrictedFlag}); on every version
+ *                          its environment twin `CLAUDE_CODE_RESTRICTED=1`
+ *                          is set as well, because an unknown environment
+ *                          key IS ignored by an older CLI. The other flags
+ *                          hold the boundary on their own — `--restricted` is
+ *                          the third layer, not the first.
  *   --strict-mcp-config    Only the MCP servers in `--mcp-config` — never the
  *                          operator's own.
  *
@@ -59,6 +71,7 @@
  * with the built-ins gone that is instruction injection rather than code
  * execution, but it is a residual, not a solved problem.
  */
+import { execFile } from 'node:child_process';
 
 /**
  * The CLI's built-in tool inventory, denied by name at spawn time.
@@ -335,6 +348,62 @@ export const CLI_ENV_SCRUB_KEYS: readonly string[] = [
   'NODE_OPTIONS',
 ];
 
+/**
+ * The first Claude CLI release that understands `--restricted` (its changelog
+ * entry for 2.1.248: "Added `--restricted` (or `CLAUDE_CODE_RESTRICTED=1`)").
+ * OM-85: 2.1.246 — two days older — rejects it with exit code 1.
+ */
+export const RESTRICTED_FLAG_MIN_CLI_VERSION = '2.1.248';
+
+/**
+ * The environment form of `--restricted`, documented in the same 2.1.248
+ * changelog entry. Set on every spawn: a CLI that predates it ignores the key,
+ * one that knows it gets the same boundary the flag would give.
+ */
+export const CLI_RESTRICTED_ENV_KEY = 'CLAUDE_CODE_RESTRICTED';
+
+const VERSION_TRIPLE = /(\d+)\.(\d+)\.(\d+)/;
+
+/**
+ * The `x.y.z` triple out of `claude --version` output (`2.1.246 (Claude Code)`),
+ * or undefined when there is none. Pure, so a test can feed it any string.
+ */
+export function parseCliVersion(output: string | undefined): string | undefined {
+  if (output === undefined) {
+    return undefined;
+  }
+
+  const match = VERSION_TRIPLE.exec(output);
+  return match === null ? undefined : `${match[1]}.${match[2]}.${match[3]}`;
+}
+
+/** Numeric compare of two `x.y.z` strings; non-numeric input sorts lowest. */
+function compareVersions(a: string, b: string): number {
+  const left = a.split('.').map(Number);
+  const right = b.split('.').map(Number);
+  for (let i = 0; i < 3; i += 1) {
+    const diff = (left[i] ?? 0) - (right[i] ?? 0);
+    if (diff !== 0) {
+      return diff;
+    }
+  }
+  return 0;
+}
+
+/**
+ * Whether a CLI of the given version accepts `--restricted`.
+ *
+ * Unknown (undefined or unparsable) means NO: the failure mode of passing the
+ * flag to a CLI that lacks it is a dead subscription path, while the failure
+ * mode of leaving it out is one protective layer fewer behind `--tools ""`,
+ * the deny list and `dontAsk` — and {@link CLI_RESTRICTED_ENV_KEY} still
+ * reaches a CLI that knows it.
+ */
+export function supportsRestrictedFlag(cliVersion: string | undefined): boolean {
+  const parsed = parseCliVersion(cliVersion);
+  return parsed !== undefined && compareVersions(parsed, RESTRICTED_FLAG_MIN_CLI_VERSION) >= 0;
+}
+
 export interface CliToolGateOptions {
   /**
    * Path to the mcp-config this spawn should use. Both call sites pass one:
@@ -347,6 +416,12 @@ export interface CliToolGateOptions {
    * serves no tools, so nothing is pre-approved.
    */
   readonly allowedTools?: string;
+  /**
+   * The installed CLI's version (`2.1.259`), as resolved by
+   * {@link resolveCliVersion}. Decides whether `--restricted` is passed
+   * (OM-85). Omit or pass undefined when unknown — the flag is then left out.
+   */
+  readonly cliVersion?: string;
 }
 
 /**
@@ -361,7 +436,8 @@ export function buildCliToolGateArgv(options: CliToolGateOptions): string[] {
     '--strict-mcp-config',
     '--mcp-config',
     options.mcpConfigPath,
-    '--restricted',
+    // OM-85 — only where the CLI knows the flag; see the module comment.
+    ...(supportsRestrictedFlag(options.cliVersion) ? ['--restricted'] : []),
     '--tools',
     '',
     '--permission-mode',
@@ -386,6 +462,8 @@ export interface CompletionCliArgvOptions {
   readonly mcpConfigPath: string;
   /** System prompt, or undefined to leave the CLI's default in place. */
   readonly systemPrompt?: string;
+  /** See {@link CliToolGateOptions.cliVersion}. */
+  readonly cliVersion?: string;
 }
 
 /**
@@ -404,7 +482,10 @@ export function buildCompletionCliArgv(options: CompletionCliArgvOptions): strin
     'json',
     '--model',
     options.model,
-    ...buildCliToolGateArgv({ mcpConfigPath: options.mcpConfigPath }),
+    ...buildCliToolGateArgv({
+      mcpConfigPath: options.mcpConfigPath,
+      ...(options.cliVersion !== undefined ? { cliVersion: options.cliVersion } : {}),
+    }),
   ];
 
   // Replace rather than append, for the same reason as OM-83 (#992) on the
@@ -440,5 +521,135 @@ export function buildGatedCliEnv(
     delete env[key];
   }
 
+  // OM-85 — the environment twin of `--restricted`, set unconditionally: a
+  // CLI older than 2.1.248 ignores the key, a newer one honours it, and the
+  // flag itself is only passed where the version is known to accept it.
+  env[CLI_RESTRICTED_ENV_KEY] = '1';
+
   return env;
+}
+
+/** The `execFile` shape {@link resolveCliVersion} needs; a test injects a fake. */
+export type CliVersionExec = (
+  binary: string,
+  args: readonly string[],
+  callback: (error: Error | null, stdout: string) => void,
+) => unknown;
+
+interface CliVersionCacheEntry {
+  readonly version: string | undefined;
+  readonly resolvedAt: number;
+}
+
+/**
+ * How long a resolved version is trusted. Short on purpose: the CLI updates
+ * itself independently of omadia (the OM-85 reporter ran `claude update` with
+ * the kernel still running), and a stale "2.1.246" would keep the flag off
+ * one turn longer — harmless — while a stale "2.1.259" after a downgrade
+ * would break turns until restart, so we re-probe every few minutes.
+ */
+const CLI_VERSION_CACHE_TTL_MS = 5 * 60_000;
+const CLI_VERSION_PROBE_TIMEOUT_MS = 10_000;
+
+const cliVersionCache = new Map<string, CliVersionCacheEntry>();
+
+/** Test seam: forget every cached probe. */
+export function clearCliVersionCache(): void {
+  cliVersionCache.clear();
+}
+
+function defaultVersionExec(
+  binary: string,
+  args: readonly string[],
+  callback: (error: Error | null, stdout: string) => void,
+): unknown {
+  return execFile(
+    binary,
+    [...args],
+    { timeout: CLI_VERSION_PROBE_TIMEOUT_MS, env: buildGatedCliEnv(), windowsHide: true },
+    (error, stdout) => callback(error, typeof stdout === 'string' ? stdout : String(stdout)),
+  );
+}
+
+/**
+ * The installed CLI's version, read once from `<binary> --version` and cached
+ * per binary for {@link CLI_VERSION_CACHE_TTL_MS}.
+ *
+ * Never throws: a missing binary, a timeout or unparsable output all resolve
+ * to `undefined`, which {@link supportsRestrictedFlag} treats as "do not pass
+ * the flag". The spawn that follows then fails (or succeeds) on its own
+ * terms, with its own error message — the probe must not add a failure mode.
+ */
+export async function resolveCliVersion(
+  binary: string,
+  options: { readonly exec?: CliVersionExec; readonly now?: () => number } = {},
+): Promise<string | undefined> {
+  const now = options.now ?? Date.now;
+  const cached = cliVersionCache.get(binary);
+  if (cached !== undefined && now() - cached.resolvedAt < CLI_VERSION_CACHE_TTL_MS) {
+    return cached.version;
+  }
+
+  const exec = options.exec ?? defaultVersionExec;
+  const version = await new Promise<string | undefined>((resolve) => {
+    try {
+      exec(binary, ['--version'], (error, stdout) => {
+        resolve(error === null ? parseCliVersion(stdout) : undefined);
+      });
+    } catch {
+      resolve(undefined);
+    }
+  });
+
+  cliVersionCache.set(binary, { version, resolvedAt: now() });
+  return version;
+}
+
+const UNKNOWN_OPTION = /unknown option '([^']+)'/;
+
+/**
+ * Raised when the spawned CLI rejected the gate's own argv — an installed CLI
+ * older than the flags omadia passes. Carries a stable `code` so a route can
+ * present it as a configuration problem (update the CLI) rather than as a
+ * failed answer.
+ */
+export class CliIncompatibleError extends Error {
+  readonly code = 'cli_incompatible' as const;
+
+  constructor(
+    message: string,
+    readonly flag: string,
+    readonly cliVersion: string | undefined,
+  ) {
+    super(message);
+    this.name = 'CliIncompatibleError';
+  }
+}
+
+/**
+ * Turn a non-zero CLI exit into a {@link CliIncompatibleError} when stderr
+ * shows the CLI did not understand one of OUR flags; undefined otherwise.
+ *
+ * OM-85: the reporter's chat showed the raw `error: unknown option
+ * '--restricted'` and nothing about what to do. This is the sentence that was
+ * missing.
+ */
+export function classifyUnknownOptionFailure(
+  stderr: string,
+  cliVersion: string | undefined,
+): CliIncompatibleError | undefined {
+  const match = UNKNOWN_OPTION.exec(stderr);
+  if (match === null || match[1] === undefined) {
+    return undefined;
+  }
+
+  const flag = match[1];
+  const installed = cliVersion === undefined ? 'an unknown version' : `version ${cliVersion}`;
+  return new CliIncompatibleError(
+    `The installed Claude CLI (${installed}) does not support ${flag}, which omadia's ` +
+      `security gate requires. Update the CLI to ${RESTRICTED_FLAG_MIN_CLI_VERSION} or ` +
+      `newer (\`claude update\`, or ADMIN → LLM access) and try again. CLI said: ${stderr.trim()}`,
+    flag,
+    cliVersion,
+  );
 }

--- a/middleware/packages/harness-orchestrator/src/index.ts
+++ b/middleware/packages/harness-orchestrator/src/index.ts
@@ -485,9 +485,23 @@ export {
   buildCompletionCliArgv,
   buildGatedCliEnv,
   cliEnvAllowlistFor,
+  // OM-85 — version-gated `--restricted` and the "CLI too old" classification.
+  CLI_RESTRICTED_ENV_KEY,
+  CliIncompatibleError,
+  RESTRICTED_FLAG_MIN_CLI_VERSION,
+  classifyUnknownOptionFailure,
+  clearCliVersionCache,
+  parseCliVersion,
+  resolveCliVersion,
+  supportsRestrictedFlag,
 } from './cliSpawnGate.js';
-export type { CliToolGateOptions, CompletionCliArgvOptions } from './cliSpawnGate.js';
-export type { CliChatAgentDeps, CliUsage } from './cliChatAgent.js';
+export type {
+  CliToolGateOptions,
+  CliVersionExec,
+  CompletionCliArgvOptions,
+} from './cliSpawnGate.js';
+export type { CliChatAgentDeps, CliSpawnLogger, CliUsage } from './cliChatAgent.js';
+export { resolveCliSpawnTimeoutMs, CLI_SPAWN_TIMEOUT_ENV_KEY } from './cliChatAgent.js';
 export { createCliSubAgent } from './cliSubAgent.js';
 export type { CliSubAgentOptions } from './cliSubAgent.js';
 

--- a/middleware/src/platform/claudeCliAdapter.ts
+++ b/middleware/src/platform/claudeCliAdapter.ts
@@ -266,10 +266,12 @@ function spawnClaude(
       if (code !== 0) {
         // OM-94 — record the exit here too; the completion path serves the
         // summariser, fact extractor and verifier judge, whose failures reach
-        // no chat bubble at all.
+        // no chat bubble at all. stderr ONLY: on this path stdout is the
+        // model's answer, i.e. conversation-derived text, and the log must not
+        // become a second copy of it.
         console.warn(
           `[claude-cli] completion exited ${code} (cli ${cliVersion ?? 'unknown'}): ` +
-            `${(stderr || stdout).split('\n')[0]?.trim() ?? ''}`,
+            `${stderr.split('\n')[0]?.trim() ?? ''}`,
         );
         // OM-85 — a CLI that rejects the gate's own flags is a config error.
         reject(

--- a/middleware/src/platform/claudeCliAdapter.ts
+++ b/middleware/src/platform/claudeCliAdapter.ts
@@ -47,7 +47,12 @@ import type {
   ToolSpec,
 } from '@omadia/llm-provider';
 
-import { buildCompletionCliArgv, buildGatedCliEnv } from '@omadia/orchestrator';
+import {
+  buildCompletionCliArgv,
+  buildGatedCliEnv,
+  classifyUnknownOptionFailure,
+  resolveCliVersion,
+} from '@omadia/orchestrator';
 
 
 const CLI_BIN = 'claude';
@@ -187,7 +192,11 @@ async function runClaude(req: LlmRequest): Promise<LlmResponse> {
   try {
     const mcpConfigPath = join(workDir, 'mcp-config.json');
     await writeFile(mcpConfigPath, JSON.stringify({ mcpServers: {} }), { mode: 0o600 });
-    return await spawnClaude(req, forced, mcpConfigPath, workDir);
+    // OM-85 — same version gate as the chat path: `--restricted` only where
+    // the installed CLI accepts it. The probe is cached, so this is one
+    // `claude --version` per five minutes, not one per completion.
+    const cliVersion = await resolveCliVersion(CLI_BIN);
+    return await spawnClaude(req, forced, mcpConfigPath, workDir, cliVersion);
   } finally {
     await rm(workDir, { recursive: true, force: true });
   }
@@ -198,6 +207,7 @@ function spawnClaude(
   forced: ToolSpec | undefined,
   mcpConfigPath: string,
   workDir: string,
+  cliVersion: string | undefined,
 ): Promise<LlmResponse> {
   // #1007 — argv and gate come from the orchestrator package, the same source
   // the chat path uses, so a flag cannot be present on one spawn site and
@@ -207,6 +217,7 @@ function spawnClaude(
     model: toCliModel(req.model),
     mcpConfigPath,
     ...(systemText(req.system) ? { systemPrompt: systemText(req.system) } : {}),
+    ...(cliVersion !== undefined ? { cliVersion } : {}),
   });
   const prompt = forced
     ? `${buildPrompt(req.messages)}\n${structuredSuffix(forced)}`
@@ -253,7 +264,18 @@ function spawnClaude(
         return;
       }
       if (code !== 0) {
-        reject(new Error(`claude-cli exited ${code}: ${(stderr || stdout).slice(0, 500).trim()}`));
+        // OM-94 — record the exit here too; the completion path serves the
+        // summariser, fact extractor and verifier judge, whose failures reach
+        // no chat bubble at all.
+        console.warn(
+          `[claude-cli] completion exited ${code} (cli ${cliVersion ?? 'unknown'}): ` +
+            `${(stderr || stdout).split('\n')[0]?.trim() ?? ''}`,
+        );
+        // OM-85 — a CLI that rejects the gate's own flags is a config error.
+        reject(
+          classifyUnknownOptionFailure(stderr, cliVersion) ??
+            new Error(`claude-cli exited ${code}: ${(stderr || stdout).slice(0, 500).trim()}`),
+        );
         return;
       }
       // Be tolerant of a stray progress/warning line on stdout: parse the first

--- a/middleware/test/cliBridge/cliChatAgent.test.ts
+++ b/middleware/test/cliBridge/cliChatAgent.test.ts
@@ -5,11 +5,17 @@ import { PassThrough } from 'node:stream';
 
 import {
   CLI_BUILTIN_TOOL_DENYLIST,
+  CLI_SPAWN_TIMEOUT_ENV_KEY,
   CliChatAgent,
   StreamJsonParser,
   composeCliSystemPrompt,
+  resolveCliSpawnTimeoutMs,
 } from '../../packages/harness-orchestrator/src/cliChatAgent.js';
-import type { CliChatAgentDeps } from '../../packages/harness-orchestrator/src/cliChatAgent.js';
+import type {
+  CliChatAgentDeps,
+  CliSpawnLogger,
+} from '../../packages/harness-orchestrator/src/cliChatAgent.js';
+import { CliIncompatibleError } from '../../packages/harness-orchestrator/src/cliSpawnGate.js';
 
 // Unit tests for the M2 stream-json → omadia mapping. The `claude -p
 // --output-format stream-json` terminal `result` line is the authoritative
@@ -130,13 +136,27 @@ describe('StreamJsonParser (M2 stream-json mapping)', () => {
  */
 describe('CliChatAgent CLI process boundary (OM-81, OM-83)', () => {
   /** Spawn a fake child that exits cleanly with a terminal result, capturing argv. */
-  function makeAgent(opts: { readonly systemPrompt?: string } = {}): {
+  function makeAgent(
+    opts: {
+      readonly systemPrompt?: string;
+      /** OM-85 — what the fake `claude --version` probe reports. */
+      readonly cliVersion?: string | undefined;
+      /** Exit the child with this code and stderr instead of a clean result. */
+      readonly fail?: { readonly code: number; readonly stderr: string };
+    } = {},
+  ): {
     readonly agent: CliChatAgent;
     readonly argv: () => readonly string[];
     readonly spawnOptions: () => { readonly cwd?: string; readonly env?: NodeJS.ProcessEnv };
+    readonly logged: readonly { level: 'info' | 'warn'; message: string; meta?: Record<string, unknown> }[];
   } {
     let captured: readonly string[] = [];
     let capturedOptions: { readonly cwd?: string; readonly env?: NodeJS.ProcessEnv } = {};
+    const logged: { level: 'info' | 'warn'; message: string; meta?: Record<string, unknown> }[] = [];
+    const logger: CliSpawnLogger = {
+      info: (message, meta) => logged.push({ level: 'info', message, ...(meta ? { meta: { ...meta } } : {}) }),
+      warn: (message, meta) => logged.push({ level: 'warn', message, ...(meta ? { meta: { ...meta } } : {}) }),
+    };
     const agent = new CliChatAgent({
       dispatch: {
         listDispatchableToolSpecs: () => [],
@@ -150,6 +170,10 @@ describe('CliChatAgent CLI process boundary (OM-81, OM-83)', () => {
           }),
           stop: async () => {},
         }) as never,
+      // Default to a CLI that knows `--restricted`, so the pre-OM-85 assertions
+      // below keep testing the full gate.
+      resolveCliVersion: async () => ('cliVersion' in opts ? opts.cliVersion : '2.1.259'),
+      logger,
       ...(opts.systemPrompt !== undefined ? { systemPrompt: opts.systemPrompt } : {}),
       buildEnv: () => ({
         PATH: '/usr/bin',
@@ -178,6 +202,13 @@ describe('CliChatAgent CLI process boundary (OM-81, OM-83)', () => {
           kill: () => true,
         });
         stdin.on('finish', () => {
+          if (opts.fail !== undefined) {
+            stderr.end(opts.fail.stderr);
+            stdout.end();
+            child.exitCode = opts.fail.code;
+            child.emit('close', opts.fail.code, null);
+            return;
+          }
           stdout.end(
             JSON.stringify({ type: 'result', is_error: false, result: 'ok', num_turns: 1 }) + '\n',
           );
@@ -187,7 +218,7 @@ describe('CliChatAgent CLI process boundary (OM-81, OM-83)', () => {
         return child;
       }) as unknown as CliChatAgentDeps['spawnFn'],
     });
-    return { agent, argv: () => captured, spawnOptions: () => capturedOptions };
+    return { agent, argv: () => captured, spawnOptions: () => capturedOptions, logged };
   }
 
   function valueAfter(argv: readonly string[], flag: string): string | undefined {
@@ -415,6 +446,86 @@ describe('CliChatAgent CLI process boundary (OM-81, OM-83)', () => {
     assert.ok(composed.startsWith('Persona text.'));
     assert.equal(composed.split('mcp__omadia__').length, 2);
     assert.equal(composeCliSystemPrompt(undefined), composeCliSystemPrompt(''));
+  });
+
+/**
+ * Beta round 5. OM-85: a 2.1.246 CLI killed every turn with `unknown option
+ * '--restricted'`. OM-94: that failure never reached the log file. OM-104: the
+ * 120 s wall clock was shorter than two of omadia's own sub-agent calls and
+ * could not be raised.
+ */
+describe('CliChatAgent CLI version gate, spawn log and turn budget (OM-85, OM-94, OM-104)', () => {
+  it('passes --restricted to a CLI that knows it', async () => {
+    const { agent, argv, spawnOptions } = makeAgent({ cliVersion: '2.1.259' });
+    await agent.chat({ userMessage: 'hi' });
+    assert.ok(argv().includes('--restricted'));
+    assert.equal(spawnOptions().env?.CLAUDE_CODE_RESTRICTED, '1');
+  });
+
+  it('leaves --restricted off a 2.1.246 CLI and relies on the env twin', async () => {
+    const { agent, argv, spawnOptions } = makeAgent({ cliVersion: '2.1.246' });
+    await agent.chat({ userMessage: 'hi' });
+    assert.equal(argv().includes('--restricted'), false);
+    // Every other layer of the gate is still there.
+    assert.ok(argv().includes('--disallowedTools'));
+    assert.equal(valueAfter(argv(), '--tools'), '');
+    assert.equal(valueAfter(argv(), '--permission-mode'), 'dontAsk');
+    assert.equal(spawnOptions().env?.CLAUDE_CODE_RESTRICTED, '1');
+  });
+
+  it('leaves --restricted off when the version probe fails', async () => {
+    const { agent, argv } = makeAgent({ cliVersion: undefined });
+    await agent.chat({ userMessage: 'hi' });
+    assert.equal(argv().includes('--restricted'), false);
+  });
+
+  it('turns `unknown option` into a config error that names the fix', async () => {
+    const { agent, logged } = makeAgent({
+      cliVersion: '2.1.246',
+      fail: { code: 1, stderr: "error: unknown option '--setting-sources'\n" },
+    });
+    await assert.rejects(agent.chat({ userMessage: 'hi' }), (error: unknown) => {
+      assert.ok(error instanceof CliIncompatibleError);
+      assert.equal(error.code, 'cli_incompatible');
+      assert.match(error.message, /2\.1\.246/);
+      assert.match(error.message, /claude update/);
+      return true;
+    });
+    const exit = logged.find((entry) => entry.message === 'claude CLI exited with non-zero code');
+    assert.ok(exit, 'the non-zero exit is logged (OM-94)');
+    assert.equal(exit.level, 'warn');
+    assert.equal(exit.meta?.code, 1);
+    assert.equal(exit.meta?.stderr, "error: unknown option '--setting-sources'");
+  });
+
+  it('logs the spawn without the prompt and the exit code of an ordinary failure', async () => {
+    const { agent, logged } = makeAgent({ fail: { code: 2, stderr: 'Not logged in\nsecond line' } });
+    await assert.rejects(agent.chat({ userMessage: 'SECRET PROMPT TEXT' }), /CLI exited with code 2: Not logged in/);
+
+    const spawned = logged.find((entry) => entry.message === 'spawning claude CLI');
+    assert.ok(spawned, 'the spawn is logged');
+    assert.equal(spawned.level, 'info');
+    assert.equal(spawned.meta?.cliVersion, '2.1.259');
+    assert.equal(spawned.meta?.restrictedFlag, true);
+    assert.equal(typeof spawned.meta?.spawnTimeoutMs, 'number');
+    assert.equal(JSON.stringify(logged).includes('SECRET PROMPT TEXT'), false, 'never the prompt');
+
+    const exit = logged.find((entry) => entry.message === 'claude CLI exited with non-zero code');
+    assert.ok(exit);
+    assert.equal(exit.meta?.code, 2);
+    assert.equal(exit.meta?.stderr, 'Not logged in', 'first stderr line only');
+  });
+
+  it('reads the turn budget from the environment, with a sane default', () => {
+    assert.equal(CLI_SPAWN_TIMEOUT_ENV_KEY, 'OMADIA_CLI_SPAWN_TIMEOUT_MS');
+    assert.equal(resolveCliSpawnTimeoutMs(undefined, {}), 600_000, 'default fits several 70 s tool calls');
+    assert.equal(resolveCliSpawnTimeoutMs(undefined, { OMADIA_CLI_SPAWN_TIMEOUT_MS: '900000' }), 900_000);
+    assert.equal(resolveCliSpawnTimeoutMs(5_000, { OMADIA_CLI_SPAWN_TIMEOUT_MS: '900000' }), 5_000, 'explicit wins');
+    assert.equal(resolveCliSpawnTimeoutMs(undefined, { OMADIA_CLI_SPAWN_TIMEOUT_MS: '0' }), 600_000);
+    assert.equal(resolveCliSpawnTimeoutMs(undefined, { OMADIA_CLI_SPAWN_TIMEOUT_MS: '-5' }), 600_000);
+    assert.equal(resolveCliSpawnTimeoutMs(undefined, { OMADIA_CLI_SPAWN_TIMEOUT_MS: 'soon' }), 600_000);
+    assert.equal(resolveCliSpawnTimeoutMs(undefined, { OMADIA_CLI_SPAWN_TIMEOUT_MS: '' }), 600_000);
+  });
   });
 });
 

--- a/middleware/test/cliBridge/cliSpawnGate.test.ts
+++ b/middleware/test/cliBridge/cliSpawnGate.test.ts
@@ -8,11 +8,20 @@ import {
   CLI_BUILTIN_TOOL_DENYLIST,
   CLI_ENV_ALLOWLIST_KEYS,
   CLI_ENV_SCRUB_KEYS,
+  CLI_RESTRICTED_ENV_KEY,
+  CliIncompatibleError,
+  RESTRICTED_FLAG_MIN_CLI_VERSION,
   buildCliToolGateArgv,
   buildCompletionCliArgv,
   buildGatedCliEnv,
+  classifyUnknownOptionFailure,
+  clearCliVersionCache,
   cliEnvAllowlistFor,
+  parseCliVersion,
+  resolveCliVersion,
+  supportsRestrictedFlag,
 } from '../../packages/harness-orchestrator/src/cliSpawnGate.js';
+import type { CliVersionExec } from '../../packages/harness-orchestrator/src/cliSpawnGate.js';
 
 /**
  * The gate that keeps a spawned `claude` CLI away from its own built-in tools
@@ -51,6 +60,7 @@ describe('cliSpawnGate', () => {
     const argv = buildCliToolGateArgv({
       mcpConfigPath: '/tmp/x/mcp-config.json',
       allowedTools: 'mcp__omadia__*',
+      cliVersion: '2.1.259',
     });
 
     assert.deepEqual(argv, [
@@ -72,7 +82,7 @@ describe('cliSpawnGate', () => {
   });
 
   it('pre-approves nothing when the caller serves no tools', () => {
-    const argv = buildCliToolGateArgv({ mcpConfigPath: '/tmp/x/mcp-config.json' });
+    const argv = buildCliToolGateArgv({ mcpConfigPath: '/tmp/x/mcp-config.json', cliVersion: '2.1.259' });
     assert.equal(argv.includes('--allowedTools'), false);
     // The rest of the gate is unchanged: a tool-less spawn is not a laxer one.
     assert.equal(valueAfter(argv, '--tools'), '');
@@ -80,6 +90,133 @@ describe('cliSpawnGate', () => {
     assert.equal(valueAfter(argv, '--setting-sources'), '');
     assert.ok(argv.includes('--restricted'));
     assert.ok(argv.includes('--strict-mcp-config'));
+  });
+
+  /**
+   * OM-85 (beta round 5). `--restricted` exists from CLI 2.1.248; the reporter
+   * ran 2.1.246, which answers an unknown flag with `error: unknown option`
+   * and exit code 1 — every turn on the subscription path died in 0.1 s. The
+   * flag is the third protective layer, not the first, so an older CLI gets
+   * the gate without it (plus the env twin) rather than no gate at all.
+   */
+  describe('OM-85 — `--restricted` only where the CLI knows it', () => {
+    it('parses the version triple out of `claude --version` output', () => {
+      assert.equal(parseCliVersion('2.1.246 (Claude Code)'), '2.1.246');
+      assert.equal(parseCliVersion('2.1.267\n'), '2.1.267');
+      assert.equal(parseCliVersion(''), undefined);
+      assert.equal(parseCliVersion(undefined), undefined);
+      assert.equal(parseCliVersion('command not found'), undefined);
+    });
+
+    it('draws the line at 2.1.248, numerically, not lexically', () => {
+      assert.equal(RESTRICTED_FLAG_MIN_CLI_VERSION, '2.1.248');
+      assert.equal(supportsRestrictedFlag('2.1.246'), false);
+      assert.equal(supportsRestrictedFlag('2.1.247'), false);
+      assert.equal(supportsRestrictedFlag('2.1.248'), true);
+      assert.equal(supportsRestrictedFlag('2.1.259'), true);
+      assert.equal(supportsRestrictedFlag('2.1.1000'), true, 'not a string compare');
+      assert.equal(supportsRestrictedFlag('2.2.0'), true);
+      assert.equal(supportsRestrictedFlag('3.0.0'), true);
+      assert.equal(supportsRestrictedFlag('1.9.999'), false);
+      assert.equal(supportsRestrictedFlag(undefined), false, 'unknown means leave it out');
+      assert.equal(supportsRestrictedFlag('garbage'), false);
+    });
+
+    it('leaves the flag out for 2.1.246 and keeps every other layer', () => {
+      const argv = buildCliToolGateArgv({ mcpConfigPath: '/tmp/x.json', cliVersion: '2.1.246' });
+      assert.equal(argv.includes('--restricted'), false);
+      assert.equal(valueAfter(argv, '--tools'), '');
+      assert.equal(valueAfter(argv, '--permission-mode'), 'dontAsk');
+      assert.equal(valueAfter(argv, '--setting-sources'), '');
+      assert.ok(argv.includes('--strict-mcp-config'));
+      assert.deepEqual(deniedNames(argv), [...CLI_BUILTIN_TOOL_DENYLIST]);
+    });
+
+    it('leaves the flag out when the version is unknown', () => {
+      const argv = buildCliToolGateArgv({ mcpConfigPath: '/tmp/x.json' });
+      assert.equal(argv.includes('--restricted'), false);
+    });
+
+    it('passes the flag from 2.1.248 on, in its stable position', () => {
+      const argv = buildCliToolGateArgv({ mcpConfigPath: '/tmp/x.json', cliVersion: '2.1.248' });
+      assert.deepEqual(argv.slice(0, 4), ['--strict-mcp-config', '--mcp-config', '/tmp/x.json', '--restricted']);
+    });
+
+    it('threads the version through the completion argv too', () => {
+      const old = buildCompletionCliArgv({ model: 'haiku', mcpConfigPath: '/tmp/n.json', cliVersion: '2.1.246' });
+      const fresh = buildCompletionCliArgv({ model: 'haiku', mcpConfigPath: '/tmp/n.json', cliVersion: '2.1.259' });
+      assert.equal(old.includes('--restricted'), false);
+      assert.equal(fresh.includes('--restricted'), true);
+    });
+
+    it('sets the environment twin on every spawn', () => {
+      assert.equal(CLI_RESTRICTED_ENV_KEY, 'CLAUDE_CODE_RESTRICTED');
+      const env = buildGatedCliEnv({ PATH: '/usr/bin' });
+      assert.equal(env.CLAUDE_CODE_RESTRICTED, '1');
+      // The scrub list must never take it back out.
+      assert.equal(CLI_ENV_SCRUB_KEYS.includes(CLI_RESTRICTED_ENV_KEY), false);
+    });
+
+    it('resolves the version through an injected probe and caches it', async () => {
+      clearCliVersionCache();
+      let calls = 0;
+      const exec: CliVersionExec = (_bin, args, cb) => {
+        calls += 1;
+        assert.deepEqual(args, ['--version']);
+        cb(null, '2.1.246 (Claude Code)\n');
+        return undefined;
+      };
+      assert.equal(await resolveCliVersion('claude-test', { exec }), '2.1.246');
+      assert.equal(await resolveCliVersion('claude-test', { exec }), '2.1.246');
+      assert.equal(calls, 1, 'second call is served from the cache');
+    });
+
+    it('re-probes once the cache entry is older than its TTL', async () => {
+      clearCliVersionCache();
+      let calls = 0;
+      let clock = 1_000;
+      const exec: CliVersionExec = (_bin, _args, cb) => {
+        calls += 1;
+        cb(null, calls === 1 ? '2.1.246' : '2.1.267');
+        return undefined;
+      };
+      const now = (): number => clock;
+      assert.equal(await resolveCliVersion('claude-ttl', { exec, now }), '2.1.246');
+      clock += 6 * 60_000;
+      assert.equal(await resolveCliVersion('claude-ttl', { exec, now }), '2.1.267');
+      assert.equal(calls, 2);
+    });
+
+    it('resolves to undefined — never throws — when the probe fails', async () => {
+      clearCliVersionCache();
+      const failing: CliVersionExec = (_bin, _args, cb) => {
+        cb(new Error('spawn ENOENT'), '');
+        return undefined;
+      };
+      assert.equal(await resolveCliVersion('claude-missing', { exec: failing }), undefined);
+      const throwing: CliVersionExec = () => {
+        throw new Error('sync boom');
+      };
+      clearCliVersionCache();
+      assert.equal(await resolveCliVersion('claude-throwing', { exec: throwing }), undefined);
+    });
+
+    it('turns `unknown option` into a config error that says what to do', () => {
+      const error = classifyUnknownOptionFailure("error: unknown option '--restricted'\n", '2.1.246');
+      assert.ok(error instanceof CliIncompatibleError);
+      assert.equal(error.code, 'cli_incompatible');
+      assert.equal(error.flag, '--restricted');
+      assert.equal(error.cliVersion, '2.1.246');
+      assert.match(error.message, /2\.1\.246/);
+      assert.match(error.message, /2\.1\.248/);
+      assert.match(error.message, /claude update/);
+      assert.match(error.message, /unknown option '--restricted'/, 'keeps the CLI line for the log');
+    });
+
+    it('does not classify unrelated failures as incompatibility', () => {
+      assert.equal(classifyUnknownOptionFailure('Error: not logged in', '2.1.259'), undefined);
+      assert.equal(classifyUnknownOptionFailure('', undefined), undefined);
+    });
   });
 
   it('carries the deny list into argv in full', () => {
@@ -195,6 +332,7 @@ describe('cliSpawnGate', () => {
         model: 'sonnet',
         mcpConfigPath: '/tmp/none.json',
         systemPrompt: 'Extract facts.',
+        cliVersion: '2.1.259',
       });
 
       assert.deepEqual(argv.slice(0, 5), ['-p', '--output-format', 'json', '--model', 'sonnet']);

--- a/middleware/test/cliBridge/cliSpawnGate.test.ts
+++ b/middleware/test/cliBridge/cliSpawnGate.test.ts
@@ -187,6 +187,33 @@ describe('cliSpawnGate', () => {
       assert.equal(calls, 2);
     });
 
+    it('takes the first version triple, so a banner line before it does not matter', () => {
+      assert.equal(parseCliVersion('Claude Code CLI\n2.1.259 (Claude Code)\n'), '2.1.259');
+      assert.equal(parseCliVersion('v2.1.248 build 2026.08.27'), '2.1.248', 'first triple wins');
+    });
+
+    it('caches a failed probe for the TTL as well, then re-probes', async () => {
+      clearCliVersionCache();
+      let calls = 0;
+      let clock = 1_000;
+      const exec: CliVersionExec = (_bin, _args, cb) => {
+        calls += 1;
+        if (calls === 1) {
+          cb(new Error('spawn ENOENT'), '');
+        } else {
+          cb(null, '2.1.267');
+        }
+        return undefined;
+      };
+      const now = (): number => clock;
+      assert.equal(await resolveCliVersion('claude-later', { exec, now }), undefined);
+      assert.equal(await resolveCliVersion('claude-later', { exec, now }), undefined);
+      assert.equal(calls, 1, 'a missing binary is not re-probed on every turn');
+      clock += 6 * 60_000;
+      assert.equal(await resolveCliVersion('claude-later', { exec, now }), '2.1.267');
+      assert.equal(calls, 2, 'after the TTL the freshly installed CLI is seen');
+    });
+
     it('resolves to undefined — never throws — when the probe fails', async () => {
       clearCliVersionCache();
       const failing: CliVersionExec = (_bin, _args, cb) => {


### PR DESCRIPTION
Beta round 5 (Silvio Lange, TE Printline, 2026-09-10) — **Wave 0 hotfix**. Ships the two blockers that locked every macOS install out of updating and the two that killed the subscription path. A fixed archive is installable from 0.152.0–0.154.0 (the updater runs in the Electron shell, not in the dead kernel), so this release is what rescues those installs.

## OM-86 — update archive had one `0444` file, every macOS self-update failed
- `desktop-apps.yml`: `chmod u+w` on the pgvector files right after the mode-preserving `cp` from the Homebrew keg.
- `stage-runtime.mjs`: `ensureOwnerWritable()` over the whole staged tree + a hard gate that refuses to stage a tree with any read-only entry (new `desktop/scripts/normalize-file-modes.mjs`, 4 tests).
- New CI step scans the produced `release/*.zip` with `zipinfo` and fails on any entry without owner-write — reads the archive's own central directory, so a packaging step that reintroduces the bit is caught too.

## OM-85 — `--restricted` unknown to CLI < 2.1.248 → every turn `exit 1`
- `cliSpawnGate.ts`: `resolveCliVersion()` probes `claude --version` (cached 5 min), `supportsRestrictedFlag()` gates the flag at **2.1.248** (numeric compare). Unknown version → flag left out.
- `CLAUDE_CODE_RESTRICTED=1` set on every spawn as the env twin (ignored by older CLIs, honoured by newer ones).
- `classifyUnknownOptionFailure()` → `CliIncompatibleError` (`code: cli_incompatible`) whose message names the installed version, the minimum and `claude update`.
- Both spawn sites (`cliChatAgent.ts` Shape 3, `claudeCliAdapter.ts` Shape 2) use it.

## OM-94 — failed turn left no trace in the log
- `CliSpawnLogger` dep (default console): spawn (binary, version, flag state, budgets, tool count — never the prompt), non-zero exit with first stderr line, signal, timeout. Completion adapter logs its exits too.

## OM-104 — 120 s wall clock shorter than two of omadia's own sub-agent calls
- Default turn budget 600 s, overridable via `OMADIA_CLI_SPAWN_TIMEOUT_MS` (`resolveCliSpawnTimeoutMs`); idle timeout stays 60 s. Timeout message says which variable to raise. UI field follows in Wave 3.

## Verification
- `test/cliBridge/cliSpawnGate.test.ts` + `cliChatAgent.test.ts`: 48/48 (15 new: version parse/compare, flag omission for 2.1.246 and unknown, env twin, cache + TTL, probe failure, unknown-option classification, spawn/exit logging without prompt, env timeout parsing).
- `cliEnvScrub`, `cliSubAgent`, `loopbackMcpServer`: 17/17.
- `desktop/scripts/normalize-file-modes.test.mjs`: 4/4; desktop typecheck clean.
- middleware `tsc --noEmit` (app + orchestrator package) clean, eslint clean, test-tree ratchet 364/364 no regression.

Related: Runde-5-Befunde OM-85, OM-86, OM-94, OM-104. Waves 1–4 follow in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J7sBWSEtQ4RnWAHxoD3Y2s

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/1061"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791636405&installation_model_id=428086&pr_number=1061&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F1061&signature=41f03686da1c0c333aab519350c615b1c275b45eb4e4844664893ffbc1e5d346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->