### PR TITLE
fix(boot): Runde 5 W1 boot robustness (OM-87/88/89/93/95)

### DIFF
--- a/desktop/src/supervisor.ts
+++ b/desktop/src/supervisor.ts
@@ -49,6 +49,11 @@ interface InFlightOp {
   readonly survivors: string[];
 }
 
+interface ChildErrorOutput {
+  readonly child: ChildProcess;
+  lastErrorLine: string;
+}
+
 /**
  * What a shutdown actually achieved.
  *
@@ -73,6 +78,7 @@ export class Supervisor extends EventEmitter {
   private kernel: ChildProcess | null = null;
   private ui: ChildProcess | null = null;
   private uiUrl: string | null = null;
+  private readonly childErrorOutput = new Map<string, ChildErrorOutput>();
   /** Single-flight guard: only one start/restart/stop runs at a time. */
   private state: 'idle' | 'starting' | 'running' | 'stopping' = 'idle';
   /**
@@ -242,14 +248,14 @@ export class Supervisor extends EventEmitter {
       this.kernel = ownKernel;
 
       this.progress('waiting-kernel', 'Waiting for the kernel to become healthy…');
-      await this.waitForKernel(kernelPort, gen);
+      await this.waitForKernel(kernelPort, gen, ownKernel);
 
       this.assertLiveGeneration(gen);
       this.progress('starting-ui', 'Starting the admin interface…');
       ownUi = this.forkNode(webUiEntry(), webUiCwd(), this.uiEnv(uiPort, kernelPort), 'web-ui', gen);
       this.ui = ownUi;
       this.uiUrl = `http://127.0.0.1:${uiPort}`;
-      await this.waitForHttp(`${this.uiUrl}/`, 30_000, 'web-ui', gen);
+      await this.waitForHttp(`${this.uiUrl}/`, 30_000, 'web-ui', gen, ownUi);
 
       // Nothing checks the generation between that poll resolving and the state
       // flip, and a stop() landing there would otherwise be overwritten.
@@ -428,8 +434,21 @@ export class Supervisor extends EventEmitter {
       env,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
-    child.stdout?.on('data', (d: Buffer) => log.info(`[${label}] ${d.toString().trimEnd()}`));
-    child.stderr?.on('data', (d: Buffer) => log.warn(`[${label}] ${d.toString().trimEnd()}`));
+    // OM-88: replace the record at spawn, not at wait time. A fast crash may
+    // already have printed its cause before the wait starts; conversely, late
+    // output from a replaced child must only update that child's old record.
+    const output: ChildErrorOutput = { child, lastErrorLine: '' };
+    this.childErrorOutput.set(label, output);
+    const captureStdout = captureErrorLines(output);
+    const captureStderr = captureErrorLines(output);
+    child.stdout?.on('data', (d: Buffer) => {
+      captureStdout(d);
+      log.info(`[${label}] ${d.toString().trimEnd()}`);
+    });
+    child.stderr?.on('data', (d: Buffer) => {
+      captureStderr(d);
+      log.warn(`[${label}] ${d.toString().trimEnd()}`);
+    });
     child.on('exit', (code, signal) => {
       log.warn(`[${label}] exited code=${code} signal=${signal}`);
       // Only a crash if this child belongs to the live generation AND we believed
@@ -444,12 +463,12 @@ export class Supervisor extends EventEmitter {
     return child;
   }
 
-  private async waitForKernel(port: number, gen: number): Promise<void> {
+  private async waitForKernel(port: number, gen: number, child: ChildProcess): Promise<void> {
     // Cold Windows boots / AV scanning / large migration sets can exceed the
     // default 90s; allow an override without a rebuild.
     const timeout =
       Number(process.env['OMADIA_BOOT_TIMEOUT_MS']) || Supervisor.KERNEL_BOOT_TIMEOUT_MS;
-    await this.waitForHttp(`http://127.0.0.1:${port}/health`, timeout, 'kernel', gen);
+    await this.waitForHttp(`http://127.0.0.1:${port}/health`, timeout, 'kernel', gen, child);
   }
 
   private async waitForHttp(
@@ -457,20 +476,92 @@ export class Supervisor extends EventEmitter {
     timeoutMs: number,
     label: string,
     gen: number,
+    child: ChildProcess,
+  ): Promise<void> {
+    // OM-88: boot owns this listener, not forkNode's running-state handler.
+    // That handler deliberately ignores exits while starting; broadening it
+    // would publish runtime crashes for intentional teardown. Race the whole
+    // poll outside its fetch catch, or the boot failure becomes a retryable
+    // network error and the spinner still lasts the full deadline.
+    const death = this.watchBootExit(child, label, gen);
+    const polling = new AbortController();
+    try {
+      await Promise.race([
+        death.exited,
+        this.pollForHttp(url, timeoutMs, label, gen, polling.signal),
+      ]);
+      this.assertLiveGeneration(gen);
+    } finally {
+      // OM-88: a race does not cancel its loser. Release the exit listener on
+      // EVERY outcome and abort the outstanding fetch/sleep so a failed boot
+      // cannot leave a poll running behind the next generation for 90 seconds.
+      death.dispose();
+      polling.abort();
+    }
+  }
+
+  private watchBootExit(
+    child: ChildProcess,
+    label: string,
+    gen: number,
+  ): { exited: Promise<never>; dispose: () => void } {
+    let onExit!: (code: number | null, signal: NodeJS.Signals | null) => void;
+    const exited = new Promise<never>((_resolve, reject) => {
+      onExit = (code, signal): void => {
+        // OM-88: generation wins even over a non-zero exit or SIGKILL. Teardown
+        // invalidates it BEFORE killing; treating that kill as a boot crash
+        // would turn every ordinary restart into a false failure dialog.
+        if (gen !== this.generation) {
+          reject(new Error('boot superseded'));
+        } else if (signal !== null || (code !== null && code !== 0)) {
+          const reason = signal !== null ? `signal ${signal}` : `code ${code}`;
+          const output = this.childErrorOutput.get(label);
+          const detail = output?.child === child ? output.lastErrorLine : '';
+          reject(new Error(
+            `${label} exited with ${reason} before becoming healthy: ` +
+              (detail || 'no error output captured'),
+          ));
+        }
+      };
+      child.on('exit', onExit);
+      // OM-88: subscribing alone misses a child that died before we got here.
+      // Subscribe first, then inspect the sticky exit fields; a clean exit
+      // intentionally leaves the health poll (and its deadline) in charge.
+      onExit(child.exitCode, child.signalCode);
+    });
+    return { exited, dispose: () => child.removeListener('exit', onExit) };
+  }
+
+  private async pollForHttp(
+    url: string,
+    timeoutMs: number,
+    label: string,
+    gen: number,
+    signal: AbortSignal,
   ): Promise<void> {
     const deadline = Date.now() + timeoutMs;
     let lastErr = '';
     while (Date.now() < deadline) {
-      if (gen !== this.generation) throw new Error('boot superseded');
+      this.assertLiveGeneration(gen);
+      let res: Response | undefined;
       try {
-        const res = await fetch(url, { signal: AbortSignal.timeout(4_000) });
-        if (res.ok) return;
-        lastErr = `HTTP ${res.status}`;
+        res = await fetch(url, {
+          signal: AbortSignal.any([
+            signal,
+            AbortSignal.timeout(Math.max(1, Math.min(4_000, deadline - Date.now()))),
+          ]),
+        });
       } catch (err) {
         lastErr = err instanceof Error ? err.message : String(err);
       }
-      await delay(750);
+      signal.throwIfAborted();
+      this.assertLiveGeneration(gen);
+      if (res?.ok) return;
+      if (res) lastErr = `HTTP ${res.status}`;
+      const remaining = deadline - Date.now();
+      if (remaining > 0) await delay(Math.min(750, remaining), undefined, { signal });
     }
+    this.assertLiveGeneration(gen);
     throw new Error(`${label} did not become healthy within ${timeoutMs}ms (${lastErr})`);
   }
 
@@ -613,6 +704,23 @@ export class Supervisor extends EventEmitter {
       return ['embedded-postgres'];
     }
   }
+}
+
+/**
+ * OM-88: pipes deliver chunks, not lines. Keep each stream's unfinished line
+ * separately, including a fatal message without a trailing newline, while
+ * sharing only the latest matching line across stdout and stderr. This extends
+ * the existing readers without changing the logger's chunk/level behaviour.
+ */
+function captureErrorLines(output: ChildErrorOutput): (data: Buffer) => void {
+  let pending = '';
+  return (data): void => {
+    const lines = (pending + data.toString()).split(/\r?\n/);
+    pending = lines.pop() ?? '';
+    for (const line of [...lines, pending]) {
+      if (/fatal|error/i.test(line)) output.lastErrorLine = line.trimEnd();
+    }
+  };
 }
 
 /** A rejected stop attempt counts as "did not stop", never as success. */

--- a/desktop/test/supervisorHealthWait.test.mts
+++ b/desktop/test/supervisorHealthWait.test.mts
@@ -1,0 +1,393 @@
+import { test, type TestContext } from 'node:test';
+import assert from 'node:assert/strict';
+import type { ChildProcess } from 'node:child_process';
+import { EventEmitter, once } from 'node:events';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { setImmediate as nextTurn } from 'node:timers/promises';
+import { Supervisor } from '../src/supervisor.ts';
+import { onLog, type LogLevel } from '../src/log.ts';
+
+/**
+ * OM-88: exercise the real boot wait and log readers without starting Postgres
+ * or Electron. As in supervisorRestartRace.test.mts, the typed private view
+ * describes lifecycle states the class already has; no production-only test
+ * seam is needed. Real children cover stdout/stderr capture, while an exit
+ * double makes the ordering of stop(), fetch and listener cleanup explicit.
+ */
+interface SupervisorInternals {
+  generation: number;
+  kernel: ChildProcess | null;
+  forkNode(
+    entry: string,
+    cwd: string,
+    env: NodeJS.ProcessEnv,
+    label: string,
+    gen: number,
+  ): ChildProcess;
+  waitForHttp(
+    url: string,
+    timeoutMs: number,
+    label: string,
+    gen: number,
+    child: ChildProcess,
+  ): Promise<void>;
+  teardownChildren(): Promise<string[]>;
+}
+
+function internals(sup: Supervisor): SupervisorInternals {
+  return sup as unknown as SupervisorInternals;
+}
+
+class ExitChild extends EventEmitter {
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+
+  constructor() {
+    super();
+    // Represents forkNode's permanent runtime-exit logger, which the wait must
+    // leave alone when it removes its own temporary boot listener.
+    this.on('exit', () => {});
+  }
+
+  exit(code: number | null, signal: NodeJS.Signals | null = null): void {
+    this.exitCode = code;
+    this.signalCode = signal;
+    this.emit('exit', code, signal);
+  }
+
+  kill(signal: NodeJS.Signals = 'SIGTERM'): boolean {
+    this.exit(null, signal);
+    return true;
+  }
+
+  asChild(): ChildProcess {
+    return this as unknown as ChildProcess;
+  }
+}
+
+function wait(
+  sup: Supervisor,
+  child: ChildProcess,
+  timeoutMs = 90_000,
+  label = 'kernel',
+): Promise<void> {
+  return internals(sup).waitForHttp(
+    'http://127.0.0.1:65535/health', timeoutMs, label, internals(sup).generation, child,
+  );
+}
+
+async function spawnFixture(
+  t: TestContext,
+  sup: Supervisor,
+  source: string,
+  label = 'kernel',
+): Promise<ChildProcess> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'omadia-health-wait-'));
+  const entry = path.join(dir, 'child.mjs');
+  await writeFile(entry, source);
+  const child = internals(sup).forkNode(entry, dir, process.env, label, internals(sup).generation);
+  const closed = once(child, 'close');
+  t.after(async () => {
+    if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+    await closed;
+    await rm(dir, { recursive: true, force: true });
+  });
+  return child;
+}
+
+function unavailable(t: TestContext): () => number {
+  const request = t.mock.method(globalThis, 'fetch', async (): Promise<Response> => new Response(null, { status: 503 }));
+  return () => request.mock.callCount();
+}
+
+function pendingFetch(t: TestContext): () => AbortSignal {
+  let observedSignal: AbortSignal | undefined;
+  t.mock.method(globalThis, 'fetch', (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const signal = init?.signal;
+    assert.ok(signal, 'the request must retain a bounded abort signal');
+    observedSignal = signal;
+    return new Promise<Response>((_resolve, reject) => {
+      // A real fetch observes its AbortSignal. Keep this double faithful, with
+      // a ref'ed backstop because AbortSignal.timeout itself does not keep Node
+      // alive while this test awaits the request deadline.
+      const backstop = setTimeout(() => {
+        signal.removeEventListener('abort', onAbort);
+        reject(new Error('test fetch did not receive cancellation'));
+      }, 2_000);
+      const onAbort = (): void => {
+        clearTimeout(backstop);
+        reject(signal.reason);
+      };
+      if (signal.aborted) onAbort();
+      else signal.addEventListener('abort', onAbort, { once: true });
+    });
+  });
+  return () => {
+    assert.ok(observedSignal, 'the request must have started');
+    return observedSignal;
+  };
+}
+
+test('OM-88: a real child crash rejects a 90s boot wait in under 2s with its last fatal line', async (t) => {
+  const requestSignal = pendingFetch(t);
+  const sup = new Supervisor();
+  const child = await spawnFixture(t, sup, `
+    import { setTimeout as delay } from 'node:timers/promises';
+    process.stdout.write('error: initial provider failure\\nordinary stdout\\n');
+    await delay(40);
+    process.stderr.write('ERROR: retry failed\\nFaTaL: duplicate provider registration\\nordinary stderr\\n');
+    await delay(40);
+    process.exitCode = 1;
+  `);
+  const baseline = child.listenerCount('exit');
+  const started = performance.now();
+
+  await assert.rejects(wait(sup, child), {
+    message: 'kernel exited with code 1 before becoming healthy: FaTaL: duplicate provider registration',
+  });
+
+  const elapsedMs = performance.now() - started;
+  t.diagnostic(`OM-88 headline elapsed: ${elapsedMs.toFixed(2)}ms (deadline: 90000ms)`);
+  assert.ok(elapsedMs < 2_000, `crash took ${elapsedMs.toFixed(2)}ms to reject`);
+  assert.equal(requestSignal().aborted, true, 'the losing HTTP request must be cancelled');
+  assert.equal(child.listenerCount('exit'), baseline);
+  assert.equal(child.stdout?.listenerCount('data'), 1, 'reuse the existing stdout reader');
+  assert.equal(child.stderr?.listenerCount('data'), 1, 'reuse the existing stderr reader');
+});
+
+test('OM-88: the last stdout error supersedes stderr fatal output captured before the wait', async (t) => {
+  unavailable(t);
+  const sup = new Supervisor();
+  const child = await spawnFixture(t, sup, `
+    import { setTimeout as delay } from 'node:timers/promises';
+    process.stderr.write('FATAL: earlier stderr failure\\n');
+    await delay(40);
+    process.stdout.write('ErRoR: final stdout failure\\nordinary output\\n');
+    process.exitCode = 1;
+  `);
+  await once(child, 'close');
+  assert.equal(child.exitCode, 1);
+  const baseline = child.listenerCount('exit');
+
+  await assert.rejects(wait(sup, child), {
+    message: 'kernel exited with code 1 before becoming healthy: ErRoR: final stdout failure',
+  });
+  assert.equal(child.listenerCount('exit'), baseline);
+});
+
+test('OM-88: a fatal line split across chunks is retained even without a final newline', async (t) => {
+  unavailable(t);
+  const sup = new Supervisor();
+  const child = await spawnFixture(t, sup, `
+    import { setTimeout as delay } from 'node:timers/promises';
+    process.stderr.write('Fa');
+    await delay(30);
+    process.stderr.write('TaL: split provider failure');
+    await delay(30);
+    process.exitCode = 1;
+  `);
+  await assert.rejects(wait(sup, child), {
+    message: 'kernel exited with code 1 before becoming healthy: FaTaL: split provider failure',
+  });
+});
+
+test('OM-88: logs stay per label and a replacement cannot inherit the previous child error', async (t) => {
+  unavailable(t);
+  const sup = new Supervisor();
+  const oldChild = await spawnFixture(t, sup, "console.error('FATAL: previous boot'); process.exitCode = 1;");
+  await assert.rejects(wait(sup, oldChild), /FATAL: previous boot$/);
+
+  const uiChild = await spawnFixture(t, sup, "console.log('ordinary startup'); process.exitCode = 1;", 'web-ui');
+  await assert.rejects(wait(sup, uiChild, 90_000, 'web-ui'), {
+    message: 'web-ui exited with code 1 before becoming healthy: no error output captured',
+  });
+
+  const newChild = await spawnFixture(t, sup, "console.log('ordinary startup'); process.exitCode = 1;");
+  // A stream may still deliver buffered data after its process exited. The
+  // replacement owns this label now, so the previous reader must not refill it.
+  const logged: Array<{ readonly level: LogLevel; readonly message: string }> = [];
+  const unsubscribe = onLog((level, message) => logged.push({ level, message }));
+  try {
+    oldChild.stdout?.emit('data', Buffer.from('first line\nsecond line\n'));
+    oldChild.stderr?.emit('data', Buffer.from('ERROR: late output from previous boot\n'));
+  } finally {
+    unsubscribe();
+  }
+  assert.deepEqual(logged, [
+    { level: 'INFO', message: '[kernel] first line\nsecond line' },
+    { level: 'WARN', message: '[kernel] ERROR: late output from previous boot' },
+  ], 'the original log levels, prefixes and chunk formatting remain unchanged');
+  await assert.rejects(wait(sup, newChild), {
+    message: 'kernel exited with code 1 before becoming healthy: no error output captured',
+  });
+});
+
+test('OM-88: a signal exit rejects while an HTTP request is still pending', async (t) => {
+  const requestSignal = pendingFetch(t);
+  const sup = new Supervisor();
+  const child = new ExitChild();
+  const baseline = child.listenerCount('exit');
+  const waiting = wait(sup, child.asChild());
+  const rejected = assert.rejects(waiting, {
+    message: 'kernel exited with signal SIGKILL before becoming healthy: no error output captured',
+  });
+  child.exit(null, 'SIGKILL');
+  await rejected;
+  assert.equal(requestSignal().aborted, true, 'the losing HTTP request must be cancelled');
+  assert.equal(child.listenerCount('exit'), baseline);
+});
+
+test('OM-88: a crash interrupts the interval between HTTP polls immediately', async (t) => {
+  const fetchCalls = unavailable(t);
+  const sup = new Supervisor();
+  const child = new ExitChild();
+  const baseline = child.listenerCount('exit');
+  const waiting = wait(sup, child.asChild());
+  const rejected = assert.rejects(waiting, /exited with code 2.*no error output captured/);
+  await nextTurn();
+  const started = performance.now();
+  child.exit(2);
+  await rejected;
+  assert.ok(performance.now() - started < 500, 'the exit must beat the next 750ms poll tick');
+  await nextTurn();
+  assert.equal(fetchCalls(), 1, 'the losing poll must not start another HTTP request');
+  assert.equal(child.listenerCount('exit'), baseline);
+});
+
+test('OM-88: teardown generation bump and kill retain boot superseded and remove the listener', async (t) => {
+  pendingFetch(t);
+  const sup = new Supervisor();
+  const child = new ExitChild();
+  const baseline = child.listenerCount('exit');
+  internals(sup).kernel = child.asChild();
+  const waiting = wait(sup, child.asChild());
+  const rejected = assert.rejects(waiting, { message: 'boot superseded' });
+
+  // Use the same lifecycle idiom as supervisorRestartRace: only the process is
+  // doubled; production teardown performs the generation bump before kill().
+  assert.deepEqual(await internals(sup).teardownChildren(), []);
+  await rejected;
+  assert.equal(child.signalCode, 'SIGTERM');
+  assert.equal(child.listenerCount('exit'), baseline);
+});
+
+test('OM-88: a superseded generation wins even if the child was already dead', async (t) => {
+  unavailable(t);
+  const sup = new Supervisor();
+  const child = new ExitChild();
+  const gen = internals(sup).generation;
+  const baseline = child.listenerCount('exit');
+  child.exit(1);
+  await internals(sup).teardownChildren();
+
+  await assert.rejects(internals(sup).waitForHttp(
+    'http://127.0.0.1:65535/health', 90_000, 'kernel', gen, child.asChild(),
+  ), { message: 'boot superseded' });
+  assert.equal(child.listenerCount('exit'), baseline);
+});
+
+test('OM-88: supersession during the final poll sleep wins over the health timeout', async (t) => {
+  unavailable(t);
+  const sup = new Supervisor();
+  const child = new ExitChild();
+  const baseline = child.listenerCount('exit');
+  const waiting = wait(sup, child.asChild(), 60);
+  const rejected = assert.rejects(waiting, { message: 'boot superseded' });
+  await nextTurn();
+  internals(sup).generation += 1;
+  await rejected;
+
+  assert.equal(child.exitCode, null);
+  assert.equal(child.signalCode, null);
+  assert.equal(child.listenerCount('exit'), baseline);
+});
+
+for (const exit of [
+  { code: 1, signal: null, reason: 'code 1' },
+  { code: null, signal: 'SIGTERM', reason: 'signal SIGTERM' },
+] satisfies ReadonlyArray<{ code: number | null; signal: NodeJS.Signals | null; reason: string }>) {
+  test(`OM-88: a child already exited with ${exit.reason} wins over a healthy HTTP reply`, async (t) => {
+    t.mock.method(globalThis, 'fetch', async (): Promise<Response> => new Response(null));
+    const sup = new Supervisor();
+    const child = new ExitChild();
+    child.exit(exit.code, exit.signal);
+    const baseline = child.listenerCount('exit');
+
+    await assert.rejects(wait(sup, child.asChild()), {
+      message: `kernel exited with ${exit.reason} before becoming healthy: no error output captured`,
+    });
+    assert.equal(child.listenerCount('exit'), baseline);
+  });
+}
+
+for (const alreadyExited of [false, true]) {
+  test(`OM-88: clean code 0 ${alreadyExited ? 'before' : 'during'} the wait preserves the HTTP deadline`, async (t) => {
+    unavailable(t);
+    const sup = new Supervisor();
+    const child = new ExitChild();
+    if (alreadyExited) child.exit(0);
+    const baseline = child.listenerCount('exit');
+    const started = performance.now();
+    const waiting = wait(sup, child.asChild(), 60);
+    const rejected = assert.rejects(waiting, { message: 'kernel did not become healthy within 60ms (HTTP 503)' });
+    if (!alreadyExited) child.exit(0);
+    await rejected;
+
+    assert.ok(performance.now() - started >= 50, 'a clean exit must not resolve or reject the wait early');
+    assert.equal(child.listenerCount('exit'), baseline);
+  });
+}
+
+test('OM-88: a clean exit during a request still allows a healthy response', async (t) => {
+  let respond!: (response: Response) => void;
+  t.mock.method(globalThis, 'fetch', (): Promise<Response> => new Promise<Response>((resolve) => {
+    respond = resolve;
+  }));
+  const sup = new Supervisor();
+  const child = new ExitChild();
+  const baseline = child.listenerCount('exit');
+  const waiting = wait(sup, child.asChild());
+  child.exit(0);
+  respond(new Response(null));
+  await waiting;
+  assert.equal(child.listenerCount('exit'), baseline);
+});
+
+test('OM-88: a successful wait removes its listener before any later child exit', async (t) => {
+  t.mock.method(globalThis, 'fetch', async (): Promise<Response> => new Response(null));
+  const sup = new Supervisor();
+  const child = new ExitChild();
+  const baseline = child.listenerCount('exit');
+  await wait(sup, child.asChild());
+  assert.equal(child.listenerCount('exit'), baseline);
+
+  child.exit(1);
+  await nextTurn();
+  assert.equal(child.listenerCount('exit'), baseline);
+});
+
+test('OM-88: the deadline still bounds a pending HTTP request and removes the listener', async (t) => {
+  pendingFetch(t);
+  const sup = new Supervisor();
+  const child = new ExitChild();
+  const baseline = child.listenerCount('exit');
+  const started = performance.now();
+  await assert.rejects(wait(sup, child.asChild(), 60), /kernel did not become healthy within 60ms/);
+  assert.ok(performance.now() - started < 2_000, 'the fetch cannot extend the health deadline');
+  assert.equal(child.listenerCount('exit'), baseline);
+});
+
+test('OM-88: the final HTTP error remains in the timeout message', async (t) => {
+  t.mock.method(globalThis, 'fetch', async (): Promise<Response> => {
+    throw new Error('ECONNREFUSED health endpoint');
+  });
+  const sup = new Supervisor();
+  const child = new ExitChild();
+  const baseline = child.listenerCount('exit');
+  await assert.rejects(wait(sup, child.asChild(), 40), {
+    message: 'kernel did not become healthy within 40ms (ECONNREFUSED health endpoint)',
+  });
+  assert.equal(child.listenerCount('exit'), baseline);
+});

--- a/middleware/packages/harness-orchestrator/src/registry/configStore.ts
+++ b/middleware/packages/harness-orchestrator/src/registry/configStore.ts
@@ -781,6 +781,18 @@ export class ConfigStore {
     );
   }
 
+  /**
+   * Uninstall revokes the plugin's bindings across every agent, including
+   * disabled grants. Reinstalling the same id must require fresh consent.
+   */
+  async deleteAgentPluginsForPlugin(pluginId: string): Promise<number> {
+    const result = await this.pool.query(
+      'DELETE FROM agent_plugins WHERE plugin_id = $1',
+      [pluginId],
+    );
+    return result.rowCount ?? 0;
+  }
+
   // ── channel_bindings ──────────────────────────────────────────────────
   async listChannelBindings(): Promise<readonly ChannelBindingRow[]> {
     const { rows } = await this.pool.query<ChannelBindingDbRow>(

--- a/middleware/packages/harness-orchestrator/src/registry/index.ts
+++ b/middleware/packages/harness-orchestrator/src/registry/index.ts
@@ -167,6 +167,9 @@ export interface ActiveAgent {
 
 export class OrchestratorRegistry {
   private readonly active = new Map<string, ActiveAgent>();
+  // JSON encodes the string tuple unambiguously, even when an id contains
+  // a separator, quote, or NUL. Replace per snapshot so recovery re-arms logs.
+  private quarantinedPluginBindings = new Set<string>();
   private platformSettings: PlatformSettingsRow = {
     fallbackAgentId: null,
     updatedAt: new Date(0),
@@ -248,10 +251,10 @@ export class OrchestratorRegistry {
    * (`multi_orchestrator_unavailable` 503) down with it.
    *
    * Instead we demote only the offending binding to `enabled: false` and log
-   * it loudly; the rest of the snapshot validates and publishes, and the
-   * Agent keeps all of its still-installed plugins. This mirrors the
-   * per-Agent build isolation (T022) one layer earlier — at the validation
-   * gate that runs before the diff.
+   * its transition into quarantine; the rest of the snapshot validates and
+   * publishes, and the Agent keeps all of its still-installed plugins. This
+   * mirrors the per-Agent build isolation (T022) one layer earlier — at the
+   * validation gate that runs before the diff.
    *
    * Only a definite `isInstalled === false` is quarantined. `undefined`
    * ("the platform has no opinion") and a missing `pluginLookup` are left
@@ -264,24 +267,45 @@ export class OrchestratorRegistry {
   ): ConfigSnapshot {
     const lookup = this.options.pluginLookup;
     const isInstalled = lookup?.isInstalled?.bind(lookup);
-    if (!isInstalled) return snap;
+    if (!isInstalled) {
+      this.quarantinedPluginBindings.clear();
+      return snap;
+    }
 
-    let demoted = 0;
+    const previous = this.quarantinedPluginBindings;
+    const quarantined = new Set<string>();
+    let newlyQuarantined = 0;
     const agentPlugins = snap.agentPlugins.map((row) => {
       if (!row.enabled) return row;
       if (isInstalled(row.pluginId) !== false) return row;
-      demoted += 1;
-      this.log(`registry: plugin not installed — disabling binding`, {
-        agentId: row.agentId,
-        pluginId: row.pluginId,
-      });
+      const key = JSON.stringify([row.agentId, row.pluginId]);
+      if (!previous.has(key) && !quarantined.has(key)) {
+        newlyQuarantined += 1;
+        this.log(`registry: plugin not installed — disabling binding`, {
+          agentId: row.agentId,
+          pluginId: row.pluginId,
+        });
+      }
+      quarantined.add(key);
       return { ...row, enabled: false };
     });
 
-    if (demoted === 0) return snap;
-    this.log(`registry: quarantined unsatisfiable plugin binding(s)`, {
-      count: demoted,
-    });
+    let noLongerQuarantined = 0;
+    for (const key of previous) {
+      if (!quarantined.has(key)) noLongerQuarantined += 1;
+    }
+    this.quarantinedPluginBindings = quarantined;
+    if (newlyQuarantined > 0 || noLongerQuarantined > 0) {
+      // "No longer" also covers removed/disabled bindings, not just plugins
+      // that recovered. A changed set can have the same total as before.
+      this.log(`registry: quarantined unsatisfiable plugin binding(s)`, {
+        newlyQuarantined,
+        noLongerQuarantined,
+        totalQuarantined: quarantined.size,
+      });
+    }
+
+    if (quarantined.size === 0) return snap;
     return { ...snap, agentPlugins };
   }
 

--- a/middleware/packages/plugin-api/src/pluginContext.ts
+++ b/middleware/packages/plugin-api/src/pluginContext.ts
@@ -76,7 +76,9 @@ export interface PluginContext {
   readonly smokeMode: boolean;
 
   /** Per-plugin scratch directory. Present only when the manifest declares
-   *  `filesystem.scratch: true`. Undefined otherwise — plugins that need
+   *  `permissions.filesystem.scratch: true` (OM-89; the legacy top-level
+   *  `filesystem.scratch` is tolerated only when the canonical block is absent).
+   *  Undefined otherwise — plugins that need
    *  temp files must declare the capability so the operator can see it in
    *  the permissions summary at install time. */
   readonly scratch?: ScratchDirAccessor;

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -1553,6 +1553,8 @@ async function main(): Promise<void> {
     // previous package's database and unauthenticated routes.
     publicPathGrantStore,
     sqlGrantStore,
+    agentPluginBindingStore: () =>
+      serviceRegistry.get<MultiOrchestratorConfigStore>('configStore'),
     onInstalled: async (agentId) => {
       // A plugin may contribute an `llm_provider` block regardless of its kind
       // (provider plugins ship as `extension`). Register it FIRST — mirroring
@@ -1589,7 +1591,7 @@ async function main(): Promise<void> {
           await propagatePluginInstall(agentId);
       }
     },
-    onUninstall: async (agentId) => {
+    onUninstall: async (agentId, reason) => {
       // Symmetric to onInstalled: drop a contributed provider + its models so
       // an uninstalled provider plugin disappears from the admin Providers page
       // without a restart. Runs BEFORE runtime deactivation/registry removal.
@@ -1613,7 +1615,12 @@ async function main(): Promise<void> {
           const removedToolName =
             dynamicAgentRuntime.domainToolFor(agentId)?.name;
           await dynamicAgentRuntime.deactivate(agentId);
-          await propagatePluginUninstall(agentId, removedToolName);
+          if (reason === 'uninstall') {
+            await propagatePluginUninstall(agentId, removedToolName);
+          } else {
+            // Reactivation tears down the runtime, but retains operator grants.
+            reconcileRuntimeDomainTool(agentId, removedToolName);
+          }
         }
       }
     },

--- a/middleware/src/platform/pluginContext.ts
+++ b/middleware/src/platform/pluginContext.ts
@@ -392,11 +392,11 @@ export function createPluginContext(
     },
   };
 
-  // Scratch-Dir accessor: gated on `manifest.filesystem.scratch: true`.
+  // Scratch-Dir accessor: gated on `permissions.filesystem.scratch: true`.
   // Created lazily on first path() call. Not isolated across restarts —
   // a plugin that needs durable state must use ctx.memory (Phase 0b/M4b)
   // or its own vault entry. Scratch is purely ephemeral working space.
-  const scratch = scratchEnabled(agentId, catalog)
+  const scratch = scratchEnabled(catalogEntry?.manifest)
     ? createScratchAccessor(agentId)
     : undefined;
 
@@ -1963,12 +1963,27 @@ function extractAuditConfig(
   };
 }
 
-function scratchEnabled(agentId: string, catalog: PluginCatalog): boolean {
-  const entry = catalog.get(agentId);
-  if (!entry) return false;
-  const manifest = entry.manifest as Record<string, unknown> | undefined;
-  const fsBlock = manifest?.['filesystem'] as Record<string, unknown> | undefined;
-  return fsBlock?.['scratch'] === true;
+/**
+ * OM-89 — permissions.filesystem is canonical: the catalog retains the raw
+ * YAML root, not its permissions block. Reading only root.filesystem left
+ * every built-in declaration ineffective. Tolerate that top-level form for
+ * legacy third-party manifests, but only when the canonical block is absent;
+ * legacy tolerance must not turn a current denial or malformed block into a
+ * grant. Only the literal boolean true enables the accessor.
+ */
+function scratchEnabled(manifest: unknown): boolean {
+  const root = manifestRecord(manifest);
+  const permissions = manifestRecord(root?.['permissions']);
+  const filesystem = permissions && Object.hasOwn(permissions, 'filesystem')
+    ? permissions['filesystem']
+    : root?.['filesystem'];
+  return manifestRecord(filesystem)?.['scratch'] === true;
+}
+
+function manifestRecord(value: unknown): Readonly<Record<string, unknown>> | undefined {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Readonly<Record<string, unknown>>
+    : undefined;
 }
 
 function createScratchAccessor(agentId: string): ScratchDirAccessor {

--- a/middleware/src/plugins/bootstrap.ts
+++ b/middleware/src/plugins/bootstrap.ts
@@ -33,14 +33,12 @@ const UI_ORCHESTRATOR_TOOL_ID = '@omadia/ui-orchestrator';
 /** Providers whose API keys are mirrored into the canvas plugin's scope. */
 const MIRRORED_PROVIDERS = ['anthropic', 'openai', 'mistral'] as const;
 
-// S+11-2b: KG providers are operator-managed (RequiresWizard / install UI).
-// Both sibling plugins declare `provides: knowledgeGraph@1` —
-// mutual exclusion, only one may live in installed.json at a time.
-// `bootstrapKnowledgeGraphFromEnv` picks one based on DATABASE_URL;
-// the catch-all `bootstrapBuiltInPackages` explicitly skips both sibling IDs
-// so it does not register the other provider with `config={}` alongside the
-// chosen one (which would blow up on the first activate step with a
-// "duplicate-provider" throw from `ctx.services.provide`).
+// S+11-2b / OM-87: KG providers are operator-managed (RequiresWizard / install
+// UI); `bootstrapKnowledgeGraphFromEnv` handles the initial backend selection.
+// This list is the opt-in policy, including when no provider is active: the
+// catch-all must not make that selection with `config={}`. Capability safety
+// belongs to its generic `findActiveProviderCollision` check, which applies to
+// every auto-install candidate, not to a list of known provider IDs (#1053).
 //
 // The legacy plugin ID `de.byte5.tool.knowledge-graph` (now a deprecated
 // shell, S+11-2b) is skipped by the catch-all too — `bootstrapKnowledgeGraphFromEnv`
@@ -55,16 +53,16 @@ const KNOWLEDGE_GRAPH_PROVIDER_IDS_SKIP_AUTO_INSTALL = new Set<string>([
 ]);
 
 /**
- * Both memoryStore providers — `@omadia/memory` (inmemory, DB-less fallback)
+ * OM-87: Both memoryStore providers — `@omadia/memory` (inmemory, DB-less fallback)
  * and `@omadia/memory-postgres` (Postgres, sharp default when DATABASE_URL is
  * set) — declare `provides:
  * memoryStore@1` (mutual exclusion). `bootstrapMemoryFromEnv` is the SOLE
  * authoritative installer for them: it selects the backend, installs the
- * chosen provider, and removes the other. The built-in catch-all must skip
- * BOTH — otherwise, when Postgres is selected, the catch-all would re-install
- * the just-removed `@omadia/memory` (it sees it as "not registered"), leaving
- * both active and crashing capability resolution with a duplicate-provider
- * error at activate time.
+ * chosen provider, and removes the other. The built-in catch-all skips BOTH
+ * as opt-in policy: backend choice belongs to this installer and the operator
+ * UI, even when neither provider is active. Its generic collision check is
+ * the safety net for all capabilities (#1053); this list does not implement
+ * a second, memoryStore-specific collision rule.
  */
 const MEMORY_STORE_PROVIDER_IDS_SKIP_AUTO_INSTALL = new Set<string>([
   MEMORY_TOOL_ID,
@@ -1277,27 +1275,25 @@ export async function bootstrapBuiltInPackages(
   const store = deps.builtInStore;
   if (!store) return;
 
-  // Note: memoryStore mutual exclusion (and self-heal of a prior both-active
-  // state) is handled authoritatively by `bootstrapMemoryFromEnv`, which runs
-  // before this catch-all and removes the non-selected provider. Here we only
-  // ensure the catch-all never auto-installs the opt-in Postgres provider
-  // (see the skip below).
+  // OM-87: `bootstrapMemoryFromEnv` owns backend selection and self-healing
+  // before this catch-all. Both skip-lists below preserve that operator-managed
+  // opt-in policy; every remaining auto-install candidate passes through the
+  // same generic capability collision check before registration.
 
   for (const pkg of store.list()) {
     if (deps.registry.has(pkg.id)) continue;
-    // S+11-2b: KG providers are operator-managed (mutual exclusion + Wizard);
-    // `bootstrapKnowledgeGraphFromEnv` has already installed the matching
-    // provider. The catch-all must not register the OTHER one alongside —
-    // otherwise duplicate-provider throw at activate time.
+    // S+11-2b / OM-87: The Wizard and `bootstrapKnowledgeGraphFromEnv` own KG
+    // selection. This opt-in policy applies even without an active provider;
+    // the generic check below owns capability collision safety.
     if (KNOWLEDGE_GRAPH_PROVIDER_IDS_SKIP_AUTO_INSTALL.has(pkg.id)) {
       log(
         `[bootstrap] built-in ${pkg.id} skipped — KG-Provider sind operator-managed (siehe bootstrapKnowledgeGraphFromEnv + RequiresWizard)`,
       );
       continue;
     }
-    // Opt-in memoryStore alternative: the selected provider is already
-    // installed by bootstrapMemoryFromEnv; auto-installing the other one
-    // too would collide on memoryStore@1. Operator opts in via UI.
+    // OM-87: Memory backend selection belongs to `bootstrapMemoryFromEnv`
+    // and the operator UI. Both alternatives stay outside catch-all policy
+    // even when the generic collision check would allow installation.
     if (MEMORY_STORE_PROVIDER_IDS_SKIP_AUTO_INSTALL.has(pkg.id)) {
       log(
         `[bootstrap] built-in ${pkg.id} skipped — opt-in memoryStore alternative (operator installs via UI for the inmemory→Postgres cutover)`,
@@ -1325,13 +1321,12 @@ export async function bootstrapBuiltInPackages(
       continue;
     }
 
-    // Never auto-install a SECOND provider of a capability that an active
-    // plugin already provides. The two skip-lists above are the hand-written
-    // instances of this rule for memoryStore and knowledgeGraph; this is the
-    // general one, and it is what keeps a new built-in provider (the keyless
-    // embedder of #1041 was the first to hit it) from turning a boot into a
-    // `capability … is provided by both` fatal. The operator can still install
-    // it from the admin page — that path runs the same check and answers 409.
+    // OM-87 / #1053: This is the sole capability-collision safety net for
+    // auto-install, reached by every built-in that survives the policy/setup
+    // guards above. The skip-lists express opt-in policy, not collision rules.
+    // New providers (the keyless embedder of #1041 was the first to hit this)
+    // therefore need no new ID-specific guard. The admin install path runs
+    // the same check and answers 409 until the active provider is uninstalled.
     const collision = findActiveProviderCollision(
       pkg.id,
       deps.catalog,

--- a/middleware/src/plugins/capabilityResolver.ts
+++ b/middleware/src/plugins/capabilityResolver.ts
@@ -16,17 +16,16 @@ import type { PluginCatalog, PluginCatalogEntry } from './manifestLoader.js';
  * picks the activation order. Two layers, two failure modes:
  *
  *   1. {@link resolveCapabilities} — single-pass over the eligible set.
- *      Returns `{ edges, unresolved }` instead of throwing on a missing
- *      provider; the caller decides whether boot-time soft-fail
+ *      Returns `{ edges, unresolved, duplicateProviders }` instead of
+ *      throwing on a missing provider; the caller decides whether boot-time soft-fail
  *      (mark errored, keep middleware up) or install-time hard-block
  *      (HTTP 409, surface available providers from the wider catalog) is
- *      the right response. Provider-collision (two eligible plugins
- *      claiming the same `<name>@<major>` slot) still throws — there is
- *      no policy for the kernel to pick a winner.
+ *      the right response. OM-87 / #1053 keeps provider collisions strict
+ *      by default; boot opts into reporting the younger provider instead.
  *
  *   2. {@link resolveEligiblePlugins} — iterative wrapper around (1) used
- *      by the runtime. Drops every unresolved consumer, re-runs the
- *      single-pass, and repeats until the eligible set stabilises. This
+ *      by the runtime. Drops duplicate providers and unresolved consumers,
+ *      re-runs the single-pass until the eligible set stabilises. This
  *      handles the cascade where consumer A requires cap X provided only
  *      by plugin B, B itself unresolved → A also unresolvable.
  *
@@ -71,6 +70,25 @@ export interface UnresolvedRequire {
   requires: string[];
 }
 
+export interface DuplicateProvider {
+  readonly droppedId: string;
+  /** OM-87: winner of this collision, not a promise of activation. It may
+   *  later lose a different slot or fail its own requires; the diagnostic
+   *  still names the installed manifest that caused this exclusion. */
+  readonly keptId: string;
+  /** Raw manifest `provides` entry at the collision, for the operator. */
+  readonly capability: string;
+  readonly message: string;
+}
+
+export interface CapabilityResolutionOptions {
+  readonly onDuplicate?: 'throw' | 'errored';
+  /** OM-87 keeps the pure resolver independent of registry storage. The
+   *  boot caller supplies the timestamps it already reads for eligibility;
+   *  callers without registry state retain deterministic input-order ties. */
+  readonly installedAtById?: ReadonlyMap<string, string>;
+}
+
 export interface CapabilityResolution {
   /** Implicit provider→consumer ordering edges, suitable for passing to
    *  {@link topoSortByDependsOn} as `extraEdges`. */
@@ -79,6 +97,9 @@ export interface CapabilityResolution {
    *  eligible set. The caller decides what to do (mark errored, throw,
    *  drop and retry). */
   unresolved: UnresolvedRequire[];
+  /** OM-87: provided capabilities must never enter `unresolved.requires`,
+   *  which bootstrap persists as a re-checkable dependency list (S+8.5). */
+  duplicateProviders: DuplicateProvider[];
 }
 
 /**
@@ -86,20 +107,29 @@ export interface CapabilityResolution {
  * matches against the rest's `provides`, and aggregates unresolved
  * entries instead of throwing.
  *
- * Throws on provider-collision (two plugins claim the same
- * `<name>@<major>` slot) — that is a kernel-level invariant the operator
- * must resolve by uninstalling one provider; there is no automatic
- * winner.
+ * OM-87 / #1053 leaves the single-pass default at `throw`: existing strict
+ * callers keep their contract without call-site churn. The boot wrapper
+ * defaults to `errored`, retaining the older provider and reporting the
+ * younger one separately from missing dependencies.
  */
 export function resolveCapabilities(
   eligibleIds: readonly string[],
   catalog: PluginCatalog,
+  options: CapabilityResolutionOptions = {},
 ): CapabilityResolution {
   const edges: CapabilityEdge[] = [];
   const unresolved: UnresolvedRequire[] = [];
-  const providerIndex = buildProviderIndex(eligibleIds, catalog);
+  const { index: providerIndex, duplicateProviders } = buildProviderIndex(
+    eligibleIds,
+    catalog,
+    options,
+  );
+  const dropped = new Set(duplicateProviders.map((d) => d.droppedId));
 
   for (const consumerId of eligibleIds) {
+    // OM-87: a duplicate is excluded as a whole plugin, including its
+    // requires. Reporting it twice would corrupt the dependency retry path.
+    if (dropped.has(consumerId)) continue;
     const consumer = catalog.get(consumerId);
     // `requires` ONLY. `optional_requires` (#795) is deliberately not read
     // here, and the omission is the whole feature: an optional capability
@@ -147,7 +177,7 @@ export function resolveCapabilities(
     }
   }
 
-  return { edges, unresolved };
+  return { edges, unresolved, duplicateProviders };
 }
 
 export interface EligibleResolution {
@@ -162,12 +192,14 @@ export interface EligibleResolution {
    *  plugin in the cascade was dropped — the array reflects the final
    *  state, suitable for `markActivationFailed`. */
   unresolved: UnresolvedRequire[];
+  /** Every duplicate provider dropped before resolving dependencies. */
+  duplicateProviders: DuplicateProvider[];
 }
 
 /**
  * Iterative wrapper around {@link resolveCapabilities}. Drops every
- * unresolved consumer, re-runs the single-pass on the smaller set, and
- * repeats until the result stabilises. Cascade-safe: if A requires X
+ * duplicate provider or unresolved consumer, re-runs the single-pass on the
+ * smaller set, and repeats until it stabilises. Cascade-safe: if A requires X
  * provided only by B, and B itself unresolved, the second pass drops A.
  *
  * Boot-time runtime callers should prefer this over the single-pass —
@@ -176,12 +208,14 @@ export interface EligibleResolution {
 export function resolveEligiblePlugins(
   eligibleIds: readonly string[],
   catalog: PluginCatalog,
+  options: CapabilityResolutionOptions = {},
 ): EligibleResolution {
   // Track the "final" unresolved entry per consumer — if a consumer is
   // dropped in pass N, that pass's `requires` list is the authoritative
   // one (it reflects what was missing once the eligible set already
   // shrank). We map by id to dedupe across passes.
   const finalUnresolved = new Map<string, string[]>();
+  const finalDuplicates: DuplicateProvider[] = [];
 
   let current: readonly string[] = [...eligibleIds];
   let lastEdges: CapabilityEdge[] = [];
@@ -190,20 +224,28 @@ export function resolveEligiblePlugins(
   // length+1 iterations is the worst case. Guards against any future
   // edge case where stabilisation isn't monotone.
   for (let i = 0; i <= eligibleIds.length; i++) {
-    const { edges, unresolved } = resolveCapabilities(current, catalog);
-    if (unresolved.length === 0) {
+    const { edges, unresolved, duplicateProviders } = resolveCapabilities(current, catalog, {
+      ...options,
+      onDuplicate: options.onDuplicate ?? 'errored',
+    });
+    if (unresolved.length === 0 && duplicateProviders.length === 0) {
       return {
         resolved: [...current],
         edges,
         unresolved: Array.from(finalUnresolved.entries()).map(
           ([consumerId, requires]) => ({ consumerId, requires }),
         ),
+        duplicateProviders: finalDuplicates,
       };
     }
     for (const u of unresolved) {
       finalUnresolved.set(u.consumerId, u.requires);
     }
-    const drop = new Set(unresolved.map((u) => u.consumerId));
+    finalDuplicates.push(...duplicateProviders);
+    const drop = new Set([
+      ...unresolved.map((u) => u.consumerId),
+      ...duplicateProviders.map((d) => d.droppedId),
+    ]);
     current = current.filter((id) => !drop.has(id));
     lastEdges = edges;
   }
@@ -217,6 +259,7 @@ export function resolveEligiblePlugins(
     unresolved: Array.from(finalUnresolved.entries()).map(
       ([consumerId, requires]) => ({ consumerId, requires }),
     ),
+    duplicateProviders: finalDuplicates,
   };
 }
 
@@ -392,13 +435,71 @@ export function walkCapabilityInstallChain(
 // Internals
 // ---------------------------------------------------------------------------
 
-/** Map `<name>@<major>` → pluginId. Within one eligible set, two plugins
- *  must not provide the same (name, major) — the kernel cannot pick a
- *  winner without operator intent. Throws on collision. */
+interface ProviderCollision {
+  readonly firstId: string;
+  readonly secondId: string;
+  readonly capability: string;
+}
+
+interface ProviderIndexScan {
+  readonly index: Map<string, string>;
+  readonly collision?: ProviderCollision;
+}
+
+/** OM-87 removes a losing plugin before rebuilding ALL provider slots.
+ *  Keeping its other capabilities would let consumers activate against a
+ *  plugin that never starts. Each collision removes one id, so this loop
+ *  terminates after at most eligibleIds.length removals. */
 function buildProviderIndex(
   eligibleIds: readonly string[],
   catalog: PluginCatalog,
-): Map<string, string> {
+  options: CapabilityResolutionOptions,
+): { index: Map<string, string>; duplicateProviders: DuplicateProvider[] } {
+  let current = eligibleIds;
+  const duplicateProviders: DuplicateProvider[] = [];
+  for (;;) {
+    const { index, collision } = scanProviderIndex(current, catalog);
+    if (!collision) return { index, duplicateProviders };
+    const { firstId, secondId, capability } = collision;
+    if ((options.onDuplicate ?? 'throw') === 'throw') {
+      throw new Error(
+        `capability '${capability}' is provided by both '${firstId}' and '${secondId}' — uninstall one`,
+      );
+    }
+    const droppedId = pickDuplicateLoser(collision, options.installedAtById);
+    const keptId = droppedId === firstId ? secondId : firstId;
+    duplicateProviders.push({
+      droppedId,
+      keptId,
+      capability,
+      message: `capability '${capability}' is also provided by '${keptId}' — uninstall one`,
+    });
+    current = current.filter((id) => id !== droppedId);
+  }
+}
+
+/** OM-87 compares actual instants, including ISO offsets. If either date
+ *  is absent/invalid or both are equal, the first eligible id wins. Scan
+ *  order survives filtering, making that fallback stable across boots.
+ *  Pairwise scanning also avoids a non-transitive sort comparator when
+ *  dated and undated entries are mixed. */
+function pickDuplicateLoser(
+  collision: ProviderCollision,
+  installedAtById: ReadonlyMap<string, string> | undefined,
+): string {
+  const first = Date.parse(installedAtById?.get(collision.firstId) ?? '');
+  const second = Date.parse(installedAtById?.get(collision.secondId) ?? '');
+  return Number.isFinite(first) && Number.isFinite(second) && first > second
+    ? collision.firstId
+    : collision.secondId;
+}
+
+/** Scan in eligible and manifest order so strict collisions retain their
+ *  existing message and boot has a deterministic first conflict to resolve. */
+function scanProviderIndex(
+  eligibleIds: readonly string[],
+  catalog: PluginCatalog,
+): ProviderIndexScan {
   const index = new Map<string, string>();
   for (const id of eligibleIds) {
     const entry = catalog.get(id);
@@ -408,19 +509,19 @@ function buildProviderIndex(
       try {
         ref = parseCapabilityRef(rawProv);
       } catch {
+        // OM-87 preserves manifestLoader's malformed-provides policy:
+        // it already warned, and an invalid declaration owns no slot.
         continue;
       }
       const key = capabilityKey(ref);
       const existing = index.get(key);
       if (existing && existing !== id) {
-        throw new Error(
-          `capability '${rawProv}' is provided by both '${existing}' and '${id}' — uninstall one`,
-        );
+        return { index, collision: { firstId: existing, secondId: id, capability: rawProv } };
       }
       index.set(key, id);
     }
   }
-  return index;
+  return { index };
 }
 
 function findProvider(
@@ -441,8 +542,8 @@ function capabilityKey(ref: CapabilityRef): string {
  * would not introduce a duplicate provider.
  *
  * Server-side install-time check: prevents the persisted registry from
- * drifting into a state where `buildProviderIndex` throws at the next
- * boot. Symmetric to the `requires`-chain walk in
+ * drifting into a state where boot must drop a duplicate provider
+ * (OM-87 / #1053). Symmetric to the `requires`-chain walk in
  * {@link walkCapabilityInstallChain} — that one rejects on missing
  * providers; this one rejects on duplicate providers.
  */

--- a/middleware/src/plugins/fileInstalledRegistry.ts
+++ b/middleware/src/plugins/fileInstalledRegistry.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 import type { AgentId } from '../api/admin-v1.js';
 import {
+  blockActivation,
   CIRCUIT_BREAKER_THRESHOLD,
   type InstalledAgent,
   type InstalledRegistry,
@@ -97,6 +98,14 @@ export class FileInstalledRegistry implements InstalledRegistry {
       next.status = 'errored';
     }
     this.agents.set(id, next);
+    await this.persist();
+  }
+
+  async markActivationBlocked(id: AgentId, error: string): Promise<void> {
+    this.ensureLoaded();
+    const current = this.agents.get(id);
+    if (!current) return;
+    this.agents.set(id, blockActivation(current, error, new Date().toISOString()));
     await this.persist();
   }
 

--- a/middleware/src/plugins/installService.ts
+++ b/middleware/src/plugins/installService.ts
@@ -40,6 +40,48 @@ import {
 } from './setupFieldPattern.js';
 import { normalizeLocalized, resolveLocalized } from './manifestLocalized.js';
 
+export interface AgentPluginBindingStore {
+  deleteAgentPluginsForPlugin(pluginId: string): Promise<number>;
+}
+
+/**
+ * OM-95 — agent bindings are operator consent and leave with the plugin.
+ * Runtime reactivation must NOT invoke it: `onUninstall` fires on that path
+ * too, and purging there would destroy grants the operator never revoked.
+ *
+ * Exported and store-injected so it can also be called from the bootstrap
+ * auto-removals (`bootstrap.ts` drops a losing provider at four `registry.remove`
+ * sites — the memory self-heal, the #1053 embeddings conflict, the legacy-KG
+ * migration and the KG conflict). Those sites are NOT wired yet, so a
+ * bootstrap-side removal still leaves its `agent_plugins` rows behind: the
+ * reconciler no longer re-logs them every minute, but the row survives until
+ * the operator uninstalls the plugin through `installService`. Wiring them
+ * needs a `BootstrapDeps.onPluginRemoved` hook plus a place to defer the purge
+ * until the orchestrator store exists, which is why it is deliberately a
+ * follow-up rather than a silent half-fix here.
+ * Resolve the store lazily because the orchestrator can become available after
+ * this service is constructed. Hosts without it have no binding store to clean;
+ * lookup/query failures are best-effort and must never abort plugin removal.
+ */
+export async function purgePluginAgentBindings(
+  pluginId: string,
+  getStore?: () => AgentPluginBindingStore | undefined,
+): Promise<void> {
+  try {
+    const removed = await getStore?.()?.deleteAgentPluginsForPlugin(pluginId);
+    if (removed) {
+      console.log(
+        `[install] removed ${String(removed)} agent-plugin binding(s) for ${pluginId}`,
+      );
+    }
+  } catch (err) {
+    console.error(
+      `[install] agent-plugin binding purge failed for ${pluginId}:`,
+      err instanceof Error ? err.message : err,
+    );
+  }
+}
+
 export interface InstallServiceDeps {
   catalog: PluginCatalog;
   registry: InstalledRegistry;
@@ -50,9 +92,12 @@ export interface InstallServiceDeps {
    *  persisted and the agent counts as installed. The caller must handle
    *  hook errors separately. */
   onInstalled?: (agentId: string) => Promise<void>;
-  /** Counterpart to `onInstalled`: called in the uninstall path BEFORE the
-   *  removal from registry/vault, so the runtime can deactivate cleanly. */
-  onUninstall?: (agentId: string) => Promise<void>;
+  /** Runtime teardown before uninstall or reactivation. The reason keeps
+   *  consent-removal hooks from deleting grants during a runtime restart. */
+  onUninstall?: (
+    agentId: string,
+    reason: 'uninstall' | 'reactivate',
+  ) => Promise<void>;
   /** #478 — plugin-borne workflow templates. Resolves the conductor's
    *  composite-catalog registrar LAZILY: the conductor wires long after this
    *  service is constructed (same late-binding pattern as channelRegistryRef
@@ -83,6 +128,9 @@ export interface InstallServiceDeps {
    */
   publicPathGrantStore?: PublicPathGrantStore;
   sqlGrantStore?: PluginSqlGrantStore;
+  /** OM-95 — late-resolved orchestrator config store. Bindings are purged only
+   *  on real uninstall; `onUninstall` also runs during `reactivate()`. */
+  agentPluginBindingStore?: () => AgentPluginBindingStore | undefined;
 }
 
 /**
@@ -544,9 +592,10 @@ export class InstallService {
 
   // -------------------------------------------------------------------------
   // Uninstall — reverses `configure()`:
-  //   1) onUninstall hook (runtime: close handle, unregister domain tool)
-  //   2) vault.purge (namespace deleted)
-  //   3) registry.remove (installed → available)
+  //   1) purge agent-plugin bindings while the orchestrator store is available
+  //   2) onUninstall hook (runtime: close handle, unregister domain tool)
+  //   3) vault.purge (namespace deleted), then purge operator grants
+  //   4) registry.remove (installed → available)
   //
   // Dependents check: if another installed agent points at this one via
   // `depends_on`, the call is rejected with 409. The caller (UI) must
@@ -593,7 +642,7 @@ export class InstallService {
     if (!this.deps.registry.has(agentId)) return undefined;
     if (this.deps.onUninstall) {
       try {
-        await this.deps.onUninstall(agentId);
+        await this.deps.onUninstall(agentId, 'reactivate');
       } catch (err) {
         console.error(
           `[install] reactivate.onUninstall hook failed for ${agentId}:`,
@@ -673,9 +722,13 @@ export class InstallService {
       }
     }
 
+    // The removed plugin may own the orchestrator store. Clean its bindings
+    // before runtime teardown makes that store unavailable.
+    await purgePluginAgentBindings(agentId, this.deps.agentPluginBindingStore);
+
     if (this.deps.onUninstall) {
       try {
-        await this.deps.onUninstall(agentId);
+        await this.deps.onUninstall(agentId, 'uninstall');
       } catch (err) {
         console.error(
           `[install] onUninstall hook failed for ${agentId}:`,

--- a/middleware/src/plugins/installedRegistry.ts
+++ b/middleware/src/plugins/installedRegistry.ts
@@ -23,7 +23,9 @@ export interface InstalledAgent {
    *  successful activation. Reset to 0 on success. When it reaches
    *  CIRCUIT_BREAKER_THRESHOLD the entry's status flips to 'errored' and
    *  `activateAllInstalled` will skip it on subsequent boots until manual
-   *  intervention (remove + reinstall, or dedicated /reactivate endpoint). */
+   *  intervention (remove + reinstall, or dedicated /reactivate endpoint).
+   *  A terminal activation block floors this count at the threshold without
+   *  counting another attempt; repeated blocks do not increase it. */
   activation_failure_count?: number;
   /** Human-readable tail of the last activation error. Populated only when
    *  activation_failure_count > 0. Trimmed to avoid unbounded growth. */
@@ -71,6 +73,15 @@ export interface InstalledRegistry {
     error: string,
     unresolvedRequires?: readonly string[],
   ): Promise<void>;
+  /** Record a deterministic configuration block: immediately sets 'errored',
+   *  stores the bounded error and timestamp, and clears unresolved_requires.
+   *  Floors the failure count at the threshold without incrementing it.
+   *  No-op if the agent is not in the registry.
+   *
+   *  OM-87 uses a distinct operation because a non-retryable conflict is not
+   *  a failed activation attempt. Keeping markActivationFailed unchanged also
+   *  preserves every existing two- and three-argument caller's retry policy. */
+  markActivationBlocked(id: AgentId, error: string): Promise<void>;
   /** Record a successful activation. Clears failure count + last error +
    *  unresolved_requires. */
   markActivationSucceeded(id: AgentId): Promise<void>;
@@ -118,6 +129,31 @@ function bumpFailure(
   if (nextCount >= CIRCUIT_BREAKER_THRESHOLD) {
     next.status = 'errored';
   }
+  return next;
+}
+
+/** Shared terminal transition for memory and file registries (OM-87). */
+export function blockActivation(
+  current: InstalledAgent,
+  error: string,
+  nowIso: string,
+): InstalledAgent {
+  const next: InstalledAgent = {
+    ...current,
+    status: 'errored',
+    // The count is exposed by the runtime API, but no reader enforces
+    // errored => count >= threshold. Preserve that convention here without
+    // reducing prior failures or growing the counter on repeated blocks.
+    activation_failure_count: Math.max(
+      current.activation_failure_count ?? 0,
+      CIRCUIT_BREAKER_THRESHOLD,
+    ),
+    last_activation_error: error.slice(0, ERROR_TAIL_MAX),
+    last_activation_error_at: nowIso,
+  };
+  // A provided capability must never become a re-checkable dependency,
+  // including a stale requires-list left by a previous activation attempt.
+  delete next.unresolved_requires;
   return next;
 }
 
@@ -183,6 +219,12 @@ export class InMemoryInstalledRegistry implements InstalledRegistry {
       id,
       bumpFailure(current, error, new Date().toISOString(), unresolvedRequires),
     );
+  }
+
+  async markActivationBlocked(id: AgentId, error: string): Promise<void> {
+    const current = this.agents.get(id);
+    if (!current) return;
+    this.agents.set(id, blockActivation(current, error, new Date().toISOString()));
   }
 
   async markActivationSucceeded(id: AgentId): Promise<void> {

--- a/middleware/src/plugins/manifestLoader.ts
+++ b/middleware/src/plugins/manifestLoader.ts
@@ -49,13 +49,22 @@ import { normalizeLocalized, resolveLocalized } from './manifestLocalized.js';
  */
 
 const REPO_ROOT = fileURLToPath(new URL('../../../', import.meta.url));
-// `PLUGIN_MANIFEST_DIR` is set in the Docker image so the loader does not
-// depend on the compiled-JS path resolving to the repo root (which it does in
-// dev, but not in the production container where `middleware/` has been
-// flattened into `/app/`). Falls back to the repo-root-relative path for dev.
-const DEFAULT_MANIFEST_DIR =
-  process.env['PLUGIN_MANIFEST_DIR'] ??
-  path.join(REPO_ROOT, 'docs', 'harness-platform', 'examples');
+// OM-93 — this gitignored, local-only source is optional. Keep the fallback
+// separate from PLUGIN_MANIFEST_DIR: the Docker image explicitly configures
+// its source because its compiled layout differs, and a missing configured
+// directory is an operator error worth warning about, not an optional source.
+const DEFAULT_MANIFEST_DIR = path.join(
+  REPO_ROOT, 'docs', 'harness-platform', 'examples',
+);
+
+export interface UnknownPermissionKeys {
+  readonly pluginId: string;
+  readonly keys: readonly string[];
+}
+
+export type UnknownPermissionReporter = (
+  diagnostics: readonly UnknownPermissionKeys[],
+) => void;
 
 /**
  * Where a catalog entry came from — issue #794.
@@ -79,6 +88,8 @@ export type PluginOrigin = 'bundled' | 'installed';
 
 export interface PluginCatalogOptions {
   manifestDir?: string;
+  /** OM-89 — receives one batch per build with unknown keys; absent means warn. */
+  reportUnknownPermissions?: UnknownPermissionReporter;
   /** Additional manifest sources (e.g. extracted zip uploads). Each entry
    *  points at a package-root directory that contains a `manifest.yaml`.
    *  On ID collision with the built-in catalog the uploaded version wins.
@@ -125,8 +136,20 @@ export class PluginCatalog {
   constructor(private readonly options: PluginCatalogOptions = {}) {}
 
   async load(): Promise<void> {
-    const manifestDir = this.options.manifestDir ?? DEFAULT_MANIFEST_DIR;
-    const manifestEntries = await loadManifestV1Entries(manifestDir);
+    const configuredDir =
+      this.options.manifestDir ?? process.env['PLUGIN_MANIFEST_DIR'];
+    const manifestDir = configuredDir ?? DEFAULT_MANIFEST_DIR;
+    // OM-89 — a build owns its diagnostics. A field or module-level accumulator
+    // would carry stale keys across reloads (and mix concurrent catalog builds).
+    const unknownPermissions: UnknownPermissionKeys[] = [];
+    const collectUnknownPermissions: UnknownPermissionReporter = (diagnostics) => {
+      unknownPermissions.push(...diagnostics);
+    };
+    const manifestEntries = await loadManifestV1Entries(
+      manifestDir,
+      { optional: configuredDir === undefined },
+      collectUnknownPermissions,
+    );
     const next = new Map<string, PluginCatalogEntry>();
     for (const entry of manifestEntries) next.set(entry.plugin.id, entry);
 
@@ -134,7 +157,9 @@ export class PluginCatalog {
     const nextBundled = new Set<string>();
     for (const src of extras) {
       const manifestPath = path.join(src.packageRoot, 'manifest.yaml');
-      const entry = await loadManifestFromPath(manifestPath);
+      const entry = await loadManifestFromPath(
+        manifestPath, collectUnknownPermissions,
+      );
       if (entry) {
         // #794 — the origin the CALLER asserted, not one the package claimed.
         const origin = src.origin ?? 'installed';
@@ -150,6 +175,11 @@ export class PluginCatalog {
     }
     this.entries = next;
     this.bundled = nextBundled;
+    if (unknownPermissions.length > 0) {
+      (this.options.reportUnknownPermissions ?? reportUnknownPermissionKeys)(
+        unknownPermissions,
+      );
+    }
   }
 
   list(): PluginCatalogEntry[] {
@@ -187,11 +217,12 @@ export class PluginCatalog {
  */
 export async function loadManifestFromPath(
   absPath: string,
+  reportUnknownPermissions: UnknownPermissionReporter = reportUnknownPermissionKeys,
 ): Promise<PluginCatalogEntry | null> {
   try {
     const raw = await fs.readFile(absPath, 'utf-8');
     const doc = parseYaml(raw) as Record<string, unknown>;
-    const plugin = adaptManifestV1(doc);
+    const plugin = adaptManifestV1(doc, reportUnknownPermissions);
     if (!plugin) return null;
     return {
       plugin,
@@ -215,8 +246,10 @@ export async function loadManifestFromPath(
 
 async function loadManifestV1Entries(
   dir: string,
+  source: { readonly optional: boolean },
+  reportUnknownPermissions: UnknownPermissionReporter,
 ): Promise<PluginCatalogEntry[]> {
-  const files = await safeReadDir(dir);
+  const files = await safeReadDir(dir, source);
   const manifestFiles = files.filter((f) => f.endsWith('.manifest.yaml'));
   const entries: PluginCatalogEntry[] = [];
   for (const name of manifestFiles) {
@@ -224,7 +257,7 @@ async function loadManifestV1Entries(
     try {
       const raw = await fs.readFile(fullPath, 'utf-8');
       const doc = parseYaml(raw) as Record<string, unknown>;
-      const plugin = adaptManifestV1(doc);
+      const plugin = adaptManifestV1(doc, reportUnknownPermissions);
       if (plugin) {
         entries.push({
           plugin,
@@ -264,7 +297,10 @@ const PLUGIN_ID_MAX_LENGTH = 214;
 const PLUGIN_VERSION_PATTERN =
   /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
 
-export function adaptManifestV1(doc: Record<string, unknown>): Plugin | null {
+export function adaptManifestV1(
+  doc: Record<string, unknown>,
+  reportUnknownPermissions: UnknownPermissionReporter = reportUnknownPermissionKeys,
+): Plugin | null {
   if (doc['schema_version'] !== '1') return null;
 
   const identity = asRecord(doc['identity']);
@@ -300,6 +336,12 @@ export function adaptManifestV1(doc: Record<string, unknown>): Plugin | null {
   const setup = asRecord(doc['setup']);
   const permissions = asRecord(doc['permissions']);
   const integrations = asArray(doc['integrations']);
+  // OM-89 — direct callers (including upload validation) have no catalog to
+  // flush diagnostics for them. Default to reporting immediately; catalog
+  // builds pass a collector instead, so detection stays data and only the
+  // build boundary reports. Unknown keys still never reject the manifest.
+  const unknownPermissions = collectUnknownPermissionKeys(permissions, id);
+  if (unknownPermissions) reportUnknownPermissions([unknownPermissions]);
 
   const setupFields: PluginSetupField[] = [];
   const setupFieldsRaw = asArray(setup?.['fields']);
@@ -815,7 +857,6 @@ function extractPermissions(
   permissions: Record<string, unknown> | undefined,
   pluginId: string,
 ): PluginPermissionsSummary {
-  warnOnUnknownPermissionKeys(permissions, pluginId);
   const memory = asRecord(permissions?.['memory']);
   const graph = asRecord(permissions?.['graph']);
   const network = asRecord(permissions?.['network']);
@@ -911,7 +952,7 @@ function extractPermissions(
 }
 
 /**
- * Keys this loader understands under `permissions:`. Anything else is a typo,
+ * Keys this core understands under `permissions:`. Anything else is a typo,
  * a key from a newer core, or a key from a core that dropped it — all three of
  * which used to be silently ignored (recorded in `implementation.md` §2.5 as
  * the reason a plugin could declare a permission against an unpatched core and
@@ -923,6 +964,9 @@ function extractPermissions(
  */
 const KNOWN_PERMISSION_KEYS: ReadonlySet<string> = new Set([
   'events',
+  // OM-89 — a live ctx.scratch gate, read from the raw manifest at activation;
+  // absence from permissions_summary does not make this a retired permission.
+  'filesystem',
   'flows',
   'graph',
   'llm',
@@ -944,19 +988,26 @@ const KNOWN_PERMISSION_KEYS: ReadonlySet<string> = new Set([
  * plugin author needs, and it is the same signal a typo gets.
  */
 
-function warnOnUnknownPermissionKeys(
+function collectUnknownPermissionKeys(
   permissions: Record<string, unknown> | undefined,
   pluginId: string,
+): UnknownPermissionKeys | undefined {
+  if (!permissions) return undefined;
+  const unknown = Object.keys(permissions)
+    .filter((key) => !KNOWN_PERMISSION_KEYS.has(key))
+    .sort();
+  return unknown.length > 0 ? { pluginId, keys: unknown } : undefined;
+}
+
+function reportUnknownPermissionKeys(
+  diagnostics: readonly UnknownPermissionKeys[],
 ): void {
-  if (!permissions) return;
-  const unknown = Object.keys(permissions).filter(
-    (key) => !KNOWN_PERMISSION_KEYS.has(key),
-  );
-  if (unknown.length === 0) return;
+  const pluginIds = [...new Set(diagnostics.map(({ pluginId }) => pluginId))].sort();
+  const keys = [...new Set(diagnostics.flatMap(({ keys }) => keys))].sort();
   console.warn(
-    `[catalog] plugin '${pluginId}' declares unknown permission key(s) ${unknown
+    `[catalog] ${pluginIds.length} plugin(s) declare unknown permission key(s) ${keys
       .map((k) => `permissions.${k}`)
-      .join(', ')} — ignored. Check the spelling, or the core version this ` +
+      .join(', ')}: ${pluginIds.join(', ')} — ignored. Check the spelling, or the core version this ` +
       'manifest was written against.',
   );
 }
@@ -1120,13 +1171,23 @@ function extractIntegrationTargets(integrations: unknown[]): string[] {
 // Shared helpers
 // ---------------------------------------------------------------------------
 
-async function safeReadDir(dir: string): Promise<string[]> {
+async function safeReadDir(
+  dir: string,
+  source: { readonly optional: boolean },
+): Promise<string[]> {
   try {
     return await fs.readdir(dir);
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
     if (code === 'ENOENT') {
-      console.warn(`[catalog] directory does not exist, skipping: ${dir}`);
+      const message = `[catalog] directory does not exist, skipping: ${dir}`;
+      if (source.optional) {
+        // OM-93 — no debug logger exists in this loader; a missing gitignored
+        // dev source is expected on fresh checkouts, CI and desktop bundles.
+        console.debug(message);
+      } else {
+        console.warn(message);
+      }
       return [];
     }
     throw err;

--- a/middleware/src/plugins/toolPluginRuntime.ts
+++ b/middleware/src/plugins/toolPluginRuntime.ts
@@ -201,6 +201,7 @@ export class ToolPluginRuntime {
     // runtime deps (agent→tool) are handled by the outer boot order in
     // index.ts — this runtime runs before the agent runtime.
     const eligible: string[] = [];
+    const installedAtById = new Map<string, string>();
     for (const id of ids) {
       const catalogEntry = this.deps.catalog.get(id);
       if (!catalogEntry) continue;
@@ -214,9 +215,10 @@ export class ToolPluginRuntime {
       const reg = this.deps.registry.get(id);
       if (!reg || reg.status !== 'active') continue;
       eligible.push(id);
+      installedAtById.set(id, reg.installed_at);
     }
 
-    // Resolve capabilities BEFORE topo-sorting. Two guarantees land here:
+    // Resolve capabilities BEFORE topo-sorting. Three guarantees land here:
     //   (1) implicit provider→consumer edges flow into topoSort so that
     //       `ctx.services.get(<cap>)` inside a consumer's activate() sees
     //       the provider's service already registered;
@@ -224,8 +226,35 @@ export class ToolPluginRuntime {
     //       eligible set are dropped and marked errored — the boot does
     //       not abort, the unresolved plugin surfaces in the UI with an
     //       actionable message, and the operator can install the
-    //       missing provider via the wizard.
-    const resolution = resolveEligiblePlugins(eligible, this.deps.catalog);
+    //       missing provider via the wizard;
+    //   (3) OM-87 / #1053 — a younger duplicate provider is reported and
+    //       excluded without aborting boot. Pass installation timestamps as
+    //       plain data because this runtime already owns the registry, while
+    //       capability resolution should not depend on its storage contract.
+    const resolution = resolveEligiblePlugins(eligible, this.deps.catalog, {
+      installedAtById,
+    });
+
+    for (const duplicate of resolution.duplicateProviders) {
+      log(`[tool-runtime] ${duplicate.droppedId} not activated — ${duplicate.message}`);
+      try {
+        // OM-87 — this is a conflicting `provides`, not an unresolved
+        // `requires`. Persisting it as a requires-list would let the S+8.5
+        // retry loop mistake the surviving provider for a repaired dependency.
+        // Block immediately: retries cannot fix the configuration conflict.
+        // A manifest-mtime reset in retryErroredPlugins is self-correcting:
+        // the next resolution drops and blocks the duplicate again, with a
+        // fresh error timestamp, without aborting boot or looping here.
+        await this.deps.registry.markActivationBlocked(
+          duplicate.droppedId,
+          duplicate.message,
+        );
+      } catch (regErr) {
+        log(
+          `[tool-runtime] registry markActivationBlocked FAILED for ${duplicate.droppedId}: ${regErr instanceof Error ? regErr.message : String(regErr)}`,
+        );
+      }
+    }
 
     for (const u of resolution.unresolved) {
       const msg = `unresolved capability requires: ${u.requires.join(', ')}`;

--- a/middleware/test/bootstrap.test.ts
+++ b/middleware/test/bootstrap.test.ts
@@ -1027,6 +1027,98 @@ describe('bootstrapEmbeddingsFromEnv — env→config reconcile (overlay-on-exis
   });
 });
 
+describe('bootstrapBuiltInPackages — generic capability collision policy (OM-87)', () => {
+  const firstId = '@test/foo-first';
+  const secondId = '@test/foo-second';
+  const catalog = makeCatalog([
+    { id: firstId, provides: ['fooClient@1'], requires: [], depends_on: [] },
+    { id: secondId, provides: ['fooClient@1'], requires: [], depends_on: [] },
+  ]);
+  const builtInStore = makeBuiltInStore([
+    { id: firstId, path: '/x/foo-first' },
+    { id: secondId, path: '/x/foo-second' },
+  ]) as unknown as Parameters<typeof bootstrapBuiltInPackages>[0]['builtInStore'];
+  const config = {} as Config;
+  const vault = { get: async () => undefined, setMany: async () => {} } as unknown as SecretVault;
+
+  it('skips an arbitrary built-in capability already provided by an active plugin and logs its owner', async () => {
+    const registry = new InMemoryInstalledRegistry();
+    await registry.register(activeAgent(secondId));
+    const logs: string[] = [];
+
+    await bootstrapBuiltInPackages({
+      config,
+      vault,
+      registry,
+      catalog,
+      builtInStore,
+      log: (message: string) => logs.push(message),
+    });
+
+    assert.equal(registry.get(firstId), undefined);
+    assert.equal(registry.get(secondId)?.status, 'active');
+    assert.deepEqual(logs, [
+      `[bootstrap] built-in ${firstId} skipped — 'fooClient@1' is already provided by active ${secondId} (install it from the admin page after uninstalling the other)`,
+    ]);
+  });
+
+  it('auto-installs the same built-in when neither provider is active', async () => {
+    const registry = new InMemoryInstalledRegistry();
+    const logs: string[] = [];
+
+    await bootstrapBuiltInPackages({
+      config,
+      vault,
+      registry,
+      catalog,
+      builtInStore,
+      log: (message: string) => logs.push(message),
+    });
+
+    assert.equal(registry.get(firstId)?.status, 'active');
+    assert.equal(registry.get(secondId), undefined);
+    assert.deepEqual(logs, [
+      `[bootstrap] ⚐ auto-installed built-in ${firstId} v0.1.0`,
+      `[bootstrap] built-in ${secondId} skipped — 'fooClient@1' is already provided by active ${firstId} (install it from the admin page after uninstalling the other)`,
+    ]);
+  });
+
+  it('keeps the KG and memory opt-in lists effective even without an active provider', async () => {
+    const policyIds = [
+      'de.byte5.tool.knowledge-graph',
+      '@omadia/knowledge-graph-inmemory',
+      '@omadia/knowledge-graph-neon',
+      '@omadia/memory',
+      '@omadia/memory-postgres',
+    ];
+    const registry = new InMemoryInstalledRegistry();
+    const logs: string[] = [];
+
+    await bootstrapBuiltInPackages({
+      config,
+      vault,
+      registry,
+      catalog: makeCatalog(policyIds.map((id) => ({
+        id,
+        provides: [],
+        requires: [],
+        depends_on: [],
+      }))),
+      builtInStore: makeBuiltInStore(policyIds.map((id) => ({
+        id,
+        path: `/x/${id}`,
+      }))) as unknown as Parameters<typeof bootstrapBuiltInPackages>[0]['builtInStore'],
+      log: (message: string) => logs.push(message),
+    });
+
+    assert.deepEqual(registry.list(), []);
+    assert.equal(logs.length, policyIds.length);
+    for (const id of policyIds) {
+      assert.ok(logs.some((message) => message.includes(`built-in ${id} skipped`)));
+    }
+  });
+});
+
 // ---------------------------------------------------------------------------
 // embeddingClient@1 mutual exclusion (#1041 follow-up — production boot fatal)
 // ---------------------------------------------------------------------------

--- a/middleware/test/bundledPluginSqlGateBoot.pg.test.ts
+++ b/middleware/test/bundledPluginSqlGateBoot.pg.test.ts
@@ -61,6 +61,7 @@ import { newTestRouteRegistry } from './_helpers/routeRegistry.js';
 
 import { PluginCatalog } from '../src/plugins/manifestLoader.js';
 import { BuiltInPackageStore } from '../src/plugins/builtInPackageStore.js';
+import { InMemoryInstalledRegistry } from '../src/plugins/installedRegistry.js';
 import {
   ToolPluginRuntime,
   type ToolPluginRuntimeDeps,
@@ -254,6 +255,14 @@ describe('#794 — real boot: memory-postgres activates against a real pool', ()
     serviceRegistry.provide('graphPool', pool);
 
     const nativeTools: string[] = [];
+    const installed = new InMemoryInstalledRegistry();
+    await installed.register({
+      id: MEMORY_PG,
+      installed_version: '1.0.0',
+      installed_at: '2026-09-10T00:00:00Z',
+      status: 'active',
+      config: { seed_mode: 'skip' },
+    });
     const deps = {
       catalog,
       builtInStore,
@@ -264,8 +273,10 @@ describe('#794 — real boot: memory-postgres activates against a real pool', ()
         // The plugin reads `seed_dir` / `seed_mode` / the dev-endpoint flag
         // from here. Seeding is turned OFF so the suite asserts the gate, not
         // the seeder.
-        get: () => ({ id: MEMORY_PG, config: { seed_mode: 'skip' } }),
+        get: (id: string) => installed.get(id),
         updateConfig: async () => undefined,
+        markActivationBlocked: (id: string, error: string) =>
+          installed.markActivationBlocked(id, error),
         markActivationFailed: async () => undefined,
       },
       vault: {
@@ -341,6 +352,14 @@ describe('#794 — real boot: memory-postgres activates against a real pool', ()
     const pool = new Pool({ connectionString: PG_URL, max: 2 });
     serviceRegistry.provide('graphPool', pool);
 
+    const installed = new InMemoryInstalledRegistry();
+    await installed.register({
+      id: MEMORY_PG,
+      installed_version: '1.0.0',
+      installed_at: '2026-09-10T00:00:00Z',
+      status: 'active',
+      config: { seed_mode: 'skip' },
+    });
     const deps = {
       catalog,
       builtInStore,
@@ -348,8 +367,10 @@ describe('#794 — real boot: memory-postgres activates against a real pool', ()
       registry: {
         has: () => true,
         list: () => [],
-        get: () => ({ id: MEMORY_PG, config: { seed_mode: 'skip' } }),
+        get: (id: string) => installed.get(id),
         updateConfig: async () => undefined,
+        markActivationBlocked: (id: string, error: string) =>
+          installed.markActivationBlocked(id, error),
         markActivationFailed: async () => undefined,
       },
       vault: { get: async () => undefined, listKeys: async () => [] },

--- a/middleware/test/capabilityResolver.test.ts
+++ b/middleware/test/capabilityResolver.test.ts
@@ -18,7 +18,11 @@ import {
 } from '../src/plugins/capabilityResolver.js';
 import type { PluginCatalog } from '../src/plugins/manifestLoader.js';
 import { topoSortByDependsOn } from '../src/plugins/topoSort.js';
-import type { InstalledAgent, InstalledRegistry } from '../src/plugins/installedRegistry.js';
+import {
+  blockActivation,
+  type InstalledAgent,
+  type InstalledRegistry,
+} from '../src/plugins/installedRegistry.js';
 import type { Plugin } from '../src/api/admin-v1.js';
 
 /**
@@ -37,12 +41,14 @@ type Partial_Plugin = Pick<
 };
 
 function makeCatalog(plugins: Partial_Plugin[]): PluginCatalog {
-  const map = new Map<string, { plugin: Plugin; manifest: unknown; source_path: string; source_kind: 'manifest-v1' }>();
+  const map = new Map<string, { plugin: Plugin; manifest: unknown; source_path: string; source_kind: 'manifest-v1'; origin: 'installed' }>();
   for (const p of plugins) {
     map.set(p.id, {
       plugin: {
         id: p.id,
         kind: p.kind ?? 'tool',
+        multi_instance: false,
+        privacy_class: 'default',
         name: p.name ?? p.id,
         version: '0.1.0',
         latest_version: '0.1.0',
@@ -99,11 +105,20 @@ function makeRegistry(active: InstalledAgent[] = []): InstalledRegistry {
     remove: async (id) => {
       map.delete(id);
     },
+    markActivationBlocked: async (id: string, error: string) => {
+      const current = map.get(id);
+      if (current) {
+        map.set(id, blockActivation(current, error, new Date().toISOString()));
+      }
+    },
     markActivationFailed: async () => {
       /* no-op for tests */
     },
     markActivationSucceeded: async () => {
       /* no-op for tests */
+    },
+    clearActivationError: async () => {
+      /* no-op */
     },
     updateConfig: async () => {
       /* no-op */
@@ -212,6 +227,7 @@ describe('resolveCapabilities (single-pass, soft-fail)', () => {
     assert.deepEqual(resolveCapabilities(['a'], cat), {
       edges: [],
       unresolved: [],
+      duplicateProviders: [],
     });
   });
 
@@ -256,6 +272,14 @@ describe('resolveCapabilities (single-pass, soft-fail)', () => {
       () => resolveCapabilities(['p1', 'p2'], cat),
       /provided by both/,
     );
+    assert.throws(
+      () => resolveCapabilities(['p1', 'p2'], cat, { onDuplicate: 'throw' }),
+      { message: "capability 'memoryStore@1' is provided by both 'p1' and 'p2' — uninstall one" },
+    );
+    assert.throws(
+      () => resolveEligiblePlugins(['p1', 'p2'], cat, { onDuplicate: 'throw' }),
+      /provided by both/,
+    );
   });
 
   it('allows a plugin to self-require its own provides (no edge generated, no unresolved)', () => {
@@ -265,6 +289,7 @@ describe('resolveCapabilities (single-pass, soft-fail)', () => {
     assert.deepEqual(resolveCapabilities(['self'], cat), {
       edges: [],
       unresolved: [],
+      duplicateProviders: [],
     });
   });
 
@@ -328,6 +353,201 @@ describe('resolveEligiblePlugins (iterative cascade)', () => {
     const result = resolveEligiblePlugins(['p', 'c'], cat);
     assert.deepEqual(result.resolved, ['p', 'c']);
     assert.deepEqual(result.unresolved, []);
+  });
+});
+
+describe('OM-87 duplicate providers', () => {
+  const cat = makeCatalog([
+    { id: 'A', provides: ['X@1'], requires: [], depends_on: [] },
+    { id: 'B', provides: ['X@1'], requires: [], depends_on: [] },
+    { id: 'consumer', provides: [], requires: ['X@^1'], depends_on: [] },
+  ]);
+  const installedAtById: ReadonlyMap<string, string> = new Map([
+    ['A', '2026-09-01T00:00:00Z'],
+    ['B', '2026-09-02T00:00:00Z'],
+  ]);
+  const duplicate = {
+    droppedId: 'B',
+    keptId: 'A',
+    capability: 'X@1',
+    message: "capability 'X@1' is also provided by 'A' — uninstall one",
+  };
+
+  for (const providers of [['A', 'B'], ['B', 'A']]) {
+    it(`keeps the older provider with discovery order ${providers.join(', ')}`, () => {
+      const eligible = Object.freeze(['consumer', ...providers]);
+      const timestampsBefore = [...installedAtById];
+      const result = resolveEligiblePlugins(eligible, cat, { installedAtById });
+      assert.deepEqual(result, {
+        resolved: ['consumer', 'A'],
+        edges: [{ from: 'A', to: 'consumer' }],
+        unresolved: [],
+        duplicateProviders: [duplicate],
+      });
+      assert.deepEqual(eligible, ['consumer', ...providers]);
+      assert.deepEqual([...installedAtById], timestampsBefore);
+      assert.deepEqual(topoSortByDependsOn(result.resolved, cat, result.edges), ['A', 'consumer']);
+    });
+  }
+
+  const tieCases: ReadonlyArray<{
+    readonly name: string;
+    readonly dates?: ReadonlyMap<string, string>;
+  }> = [
+    { name: 'no age map' },
+    { name: 'both absent', dates: new Map() },
+    { name: 'first absent', dates: new Map([['A', '2026-09-01T00:00:00Z']]) },
+    { name: 'second absent', dates: new Map([['B', '2026-09-02T00:00:00Z']]) },
+    { name: 'identical', dates: new Map([['A', '2026-09-01T00:00:00Z'], ['B', '2026-09-01T00:00:00Z']]) },
+    { name: 'equal instants with offsets', dates: new Map([['A', '2026-09-01T00:00:00Z'], ['B', '2026-09-01T02:00:00+02:00']]) },
+    { name: 'first invalid', dates: new Map([['A', '2026-09-01T00:00:00Z'], ['B', 'invalid']]) },
+    { name: 'second invalid', dates: new Map([['A', 'invalid'], ['B', '2026-09-02T00:00:00Z']]) },
+  ];
+  for (const { name, dates } of tieCases) {
+    it(`uses stable input order when timestamps are ${name}`, () => {
+      const resolve = () => resolveEligiblePlugins(['B', 'A', 'consumer'], cat, { installedAtById: dates });
+      const first = resolve();
+      assert.deepEqual(first, resolve());
+      assert.deepEqual(first.resolved, ['B', 'consumer']);
+      assert.deepEqual(first.duplicateProviders, [{
+        droppedId: 'A', keptId: 'B', capability: 'X@1',
+        message: "capability 'X@1' is also provided by 'B' — uninstall one",
+      }]);
+    });
+  }
+
+  it('orders ISO timestamps by instant instead of lexical representation', () => {
+    const result = resolveEligiblePlugins(['B', 'A', 'consumer'], cat, {
+      installedAtById: new Map([
+        ['A', '2026-09-01T02:00:00+03:00'],
+        ['B', '2026-09-01T00:00:00Z'],
+      ]),
+    });
+    assert.deepEqual(result.resolved, ['A', 'consumer']);
+    assert.deepEqual(result.duplicateProviders, [duplicate]);
+  });
+
+  it('single-pass errored mode removes all loser slots and never reports its requires', () => {
+    const multi = makeCatalog([
+      { id: 'B', provides: ['unique@1', 'X@1'], requires: ['missing@1'], depends_on: [] },
+      { id: 'A', provides: ['X@1', 'X@^1'], requires: ['X@^1'], depends_on: [] },
+      { id: 'consumer', provides: [], requires: ['unique@1'], depends_on: [] },
+    ]);
+    const result = resolveCapabilities(['B', 'A', 'consumer'], multi, {
+      onDuplicate: 'errored', installedAtById,
+    });
+    assert.deepEqual(result, {
+      edges: [],
+      unresolved: [{ consumerId: 'consumer', requires: ['unique@1'] }],
+      duplicateProviders: [duplicate],
+    });
+    const iterative = resolveEligiblePlugins(['B', 'A', 'consumer'], multi, { installedAtById });
+    assert.deepEqual(iterative.resolved, ['A']);
+    assert.deepEqual(iterative.duplicateProviders, [duplicate]);
+    assert.deepEqual(iterative.unresolved, result.unresolved);
+  });
+
+  it('keeps the raw colliding provides entry in the operator message', () => {
+    const raw = makeCatalog([
+      { id: 'A', provides: ['X@1'], requires: [], depends_on: [] },
+      { id: 'B', provides: [' X@^1 '], requires: [], depends_on: [] },
+    ]);
+    assert.deepEqual(resolveEligiblePlugins(['A', 'B'], raw).duplicateProviders, [{
+      ...duplicate,
+      capability: ' X@^1 ',
+      message: "capability ' X@^1 ' is also provided by 'A' — uninstall one",
+    }]);
+  });
+
+  it('skips malformed provides without inventing a duplicate or satisfying a consumer', () => {
+    const malformed = makeCatalog([
+      { id: 'A', provides: ['invalid', 'X@1'], requires: [], depends_on: [] },
+      { id: 'B', provides: ['invalid', 'X@2'], requires: [], depends_on: [] },
+      { id: 'consumer', provides: [], requires: ['invalid@1'], depends_on: [] },
+    ]);
+    const result = resolveEligiblePlugins(['A', 'B', 'consumer', 'unknown'], malformed);
+    assert.deepEqual(result, {
+      resolved: ['A', 'B', 'unknown'],
+      edges: [],
+      unresolved: [{ consumerId: 'consumer', requires: ['invalid@1'] }],
+      duplicateProviders: [],
+    });
+  });
+
+  it('reports every dropped provider across three installations and dependency cascades', () => {
+    const cascade = makeCatalog([
+      { id: 'B', provides: ['X@1'], requires: [], depends_on: [] },
+      { id: 'C', provides: ['X@1'], requires: [], depends_on: [] },
+      { id: 'A', provides: ['X@1'], requires: ['missing@1'], depends_on: [] },
+      { id: 'consumer', provides: [], requires: ['X@1'], depends_on: [] },
+    ]);
+    const result = resolveEligiblePlugins(['A', 'B', 'C', 'consumer'], cascade, {
+      installedAtById: new Map([...installedAtById, ['C', '2026-09-03T00:00:00Z']]),
+    });
+    assert.deepEqual(result.resolved, []);
+    assert.deepEqual(result.edges, []);
+    assert.deepEqual(result.duplicateProviders, [duplicate, { ...duplicate, droppedId: 'C' }]);
+    assert.deepEqual(result.unresolved, [
+      { consumerId: 'A', requires: ['missing@1'] },
+      { consumerId: 'consumer', requires: ['X@1'] },
+    ]);
+  });
+
+  it('resolves an empty eligible set in both modes', () => {
+    assert.deepEqual(resolveEligiblePlugins([], cat), {
+      resolved: [], edges: [], unresolved: [], duplicateProviders: [],
+    });
+    assert.deepEqual(resolveCapabilities([], cat, { onDuplicate: 'errored' }), {
+      edges: [], unresolved: [], duplicateProviders: [],
+    });
+  });
+
+  it('rebuilds after a collision winner loses another slot and retains both diagnostics', () => {
+    const overlapping = makeCatalog([
+      { id: 'A', provides: ['X@1'], requires: [], depends_on: [] },
+      { id: 'B', provides: ['X@1', 'Y@1'], requires: [], depends_on: [] },
+      { id: 'C', provides: ['Y@1'], requires: [], depends_on: [] },
+      { id: 'consumer', provides: [], requires: ['X@1'], depends_on: [] },
+    ]);
+    const result = resolveEligiblePlugins(['A', 'B', 'C', 'consumer'], overlapping, {
+      installedAtById: new Map([
+        ['A', '2026-09-03T00:00:00Z'],
+        ['B', '2026-09-02T00:00:00Z'],
+        ['C', '2026-09-01T00:00:00Z'],
+      ]),
+    });
+    assert.deepEqual(result, {
+      resolved: ['C'],
+      edges: [],
+      unresolved: [{ consumerId: 'consumer', requires: ['X@1'] }],
+      duplicateProviders: [
+        { droppedId: 'A', keptId: 'B', capability: 'X@1',
+          message: "capability 'X@1' is also provided by 'B' — uninstall one" },
+        { droppedId: 'B', keptId: 'C', capability: 'Y@1',
+          message: "capability 'Y@1' is also provided by 'C' — uninstall one" },
+      ],
+    });
+  });
+
+  it('uses deterministic pairwise fallback with mixed dated and undated providers', () => {
+    const mixed = makeCatalog([
+      { id: 'A', provides: ['X@1'], requires: [], depends_on: [] },
+      { id: 'B', provides: ['X@1'], requires: [], depends_on: [] },
+      { id: 'C', provides: ['X@1'], requires: [], depends_on: [] },
+    ]);
+    const resolve = () => resolveEligiblePlugins(['A', 'B', 'C'], mixed, {
+      installedAtById: new Map([
+        ['A', '2026-09-03T00:00:00Z'], ['C', '2026-09-01T00:00:00Z'],
+      ]),
+    });
+    const result = resolve();
+    assert.deepEqual(result, resolve());
+    assert.deepEqual(result.resolved, ['C']);
+    assert.deepEqual(result.duplicateProviders, [
+      duplicate,
+      { droppedId: 'A', keptId: 'C', capability: 'X@1',
+        message: "capability 'X@1' is also provided by 'C' — uninstall one" },
+    ]);
   });
 });
 

--- a/middleware/test/configStoreAgentPlugins.test.ts
+++ b/middleware/test/configStoreAgentPlugins.test.ts
@@ -1,0 +1,60 @@
+/** OM-95: plugin uninstall revokes bindings across agents with one query. */
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import type { Pool } from 'pg';
+
+import { ConfigStore } from '../packages/harness-orchestrator/src/registry/configStore.js';
+
+interface QueryCall {
+  sql: string;
+  params: unknown[] | undefined;
+}
+
+// Recording-pool fixture, as in agentGrantsStore.test.ts.
+function fakePool(rowCount: number | null): { pool: Pool; calls: QueryCall[] } {
+  const calls: QueryCall[] = [];
+  const pool = {
+    query: async (sql: string, params?: unknown[]) => {
+      calls.push({ sql, params });
+      return { rows: [], rowCount };
+    },
+  } as unknown as Pool;
+  return { pool, calls };
+}
+
+test('deleteAgentPluginsForPlugin deletes enabled and disabled bindings across all agents, scoped to the bound plugin id', async () => {
+  const { pool, calls } = fakePool(3);
+  const pluginId = "plugin' OR 1=1 --";
+
+  assert.equal(await new ConfigStore(pool).deleteAgentPluginsForPlugin(pluginId), 3);
+  assert.deepEqual(calls, [{
+    sql: 'DELETE FROM agent_plugins WHERE plugin_id = $1',
+    params: [pluginId],
+  }]);
+});
+
+test('deleteAgentPluginsForPlugin returns zero when no binding exists', async () => {
+  const { pool, calls } = fakePool(0);
+
+  assert.equal(await new ConfigStore(pool).deleteAgentPluginsForPlugin('absent'), 0);
+  assert.equal(calls.length, 1);
+});
+
+test('deleteAgentPluginsForPlugin treats an unavailable row count as zero', async () => {
+  const { pool } = fakePool(null);
+
+  assert.equal(await new ConfigStore(pool).deleteAgentPluginsForPlugin('absent'), 0);
+});
+
+test('deleteAgentPluginsForPlugin passes database failures to the best-effort lifecycle cleanup', async () => {
+  const error = new Error('database unavailable');
+  const pool = {
+    query: async () => { throw error; },
+  } as unknown as Pool;
+
+  await assert.rejects(
+    new ConfigStore(pool).deleteAgentPluginsForPlugin('plugin'),
+    (caught: unknown) => caught === error,
+  );
+});

--- a/middleware/test/dependencyChainResolver.test.ts
+++ b/middleware/test/dependencyChainResolver.test.ts
@@ -7,7 +7,7 @@ import {
 } from '../src/plugins/dependencyChainResolver.js';
 import type { Plugin, PluginKind } from '../src/api/admin-v1.js';
 import type { PluginCatalog } from '../src/plugins/manifestLoader.js';
-import type { InstalledRegistry } from '../src/plugins/installedRegistry.js';
+import { InMemoryInstalledRegistry, type InstalledRegistry } from '../src/plugins/installedRegistry.js';
 import type { RegistryClient } from '../src/plugins/registryClient.js';
 import type {
   PackageUploadService,
@@ -74,7 +74,6 @@ function harness(opts: {
 } {
   const present = new Map<string, string[]>(Object.entries(opts.local));
   const remoteMap = new Map<string, string[]>(Object.entries(opts.remote ?? {}));
-  const installedSet = new Set<string>(opts.installed ?? []);
   const fetched: string[] = [];
 
   const catalog = {
@@ -84,9 +83,16 @@ function harness(opts: {
       [...present].map(([id, d]) => ({ plugin: mkPlugin(id, d), manifest: {} })),
   } as unknown as PluginCatalog;
 
-  const registry = {
-    has: (id: string) => installedSet.has(id),
-  } as unknown as InstalledRegistry;
+  const registry: InstalledRegistry = new InMemoryInstalledRegistry();
+  for (const id of opts.installed ?? []) {
+    void registry.register({
+      id,
+      installed_version: '1.0.0',
+      installed_at: '2026-09-10T00:00:00Z',
+      status: 'active',
+      config: {},
+    });
+  }
 
   const client = {
     hasRegistries: () => remoteMap.size > 0,

--- a/middleware/test/dynamicAgentRuntimeActivationFailures.test.ts
+++ b/middleware/test/dynamicAgentRuntimeActivationFailures.test.ts
@@ -1,0 +1,164 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import {
+  DynamicAgentRuntime,
+  type DynamicAgentRuntimeDeps,
+} from '../src/plugins/dynamicAgentRuntime.js';
+import {
+  CIRCUIT_BREAKER_THRESHOLD,
+  InMemoryInstalledRegistry,
+  type InstalledRegistry,
+} from '../src/plugins/installedRegistry.js';
+import {
+  adaptManifestV1,
+  type PluginCatalog,
+  type PluginCatalogEntry,
+} from '../src/plugins/manifestLoader.js';
+import type { UploadedPackageStore } from '../src/plugins/uploadedPackageStore.js';
+
+const AGENT_ID = '@test/transient-agent';
+const ACTIVATION_ERROR = 'ECONNREFUSED: agent dependency unavailable';
+type FailureCall = Parameters<InstalledRegistry['markActivationFailed']>;
+type BlockCall = Parameters<InstalledRegistry['markActivationBlocked']>;
+
+class RecordingRegistry extends InMemoryInstalledRegistry {
+  readonly failureCalls: FailureCall[] = [];
+  readonly blockCalls: BlockCall[] = [];
+
+  constructor(private readonly writeFailure?: unknown) {
+    super();
+  }
+
+  override async markActivationFailed(...args: FailureCall): Promise<void> {
+    this.failureCalls.push(args);
+    if (this.writeFailure !== undefined) throw this.writeFailure;
+    await super.markActivationFailed(...args);
+  }
+
+  override async markActivationBlocked(...args: BlockCall): Promise<void> {
+    this.blockCalls.push(args);
+    await super.markActivationBlocked(...args);
+  }
+}
+
+class ThrowingActivationRuntime extends DynamicAgentRuntime {
+  readonly attempts: string[] = [];
+
+  constructor(deps: DynamicAgentRuntimeDeps, private readonly activationError: unknown) {
+    super(deps);
+  }
+
+  override async activate(id: string): Promise<never> {
+    this.attempts.push(id);
+    throw this.activationError;
+  }
+}
+
+async function makeRuntime(activationError: unknown, writeFailure?: unknown) {
+  const registry = new RecordingRegistry(writeFailure);
+  await registry.register({
+    id: AGENT_ID,
+    installed_version: '1.0.0',
+    installed_at: '2026-09-01T00:00:00Z',
+    status: 'active',
+    config: {},
+    unresolved_requires: ['obsoleteClient@1'],
+  });
+  const manifest = {
+    schema_version: '1',
+    identity: {
+      id: AGENT_ID,
+      name: 'Transient agent',
+      version: '1.0.0',
+      kind: 'agent',
+      domain: 'test.activation',
+    },
+    lifecycle: { entry: 'plugin.ts' },
+    provides: [],
+    requires: [],
+  };
+  const plugin = adaptManifestV1(manifest);
+  assert.ok(plugin, 'fixture agent manifest must adapt');
+  const entry: PluginCatalogEntry = {
+    plugin,
+    manifest,
+    source_path: '/unused/transient-agent',
+    source_kind: 'manifest-v1',
+    origin: 'installed',
+  };
+  const catalog = {
+    get: (id: string): PluginCatalogEntry | undefined => id === AGENT_ID ? entry : undefined,
+    list: (): PluginCatalogEntry[] => [entry],
+  } satisfies Pick<PluginCatalog, 'get' | 'list'>;
+  const uploadedStore = {
+    list: () => [{
+      id: AGENT_ID,
+      version: '1.0.0',
+      path: entry.source_path,
+      uploaded_at: '2026-09-01T00:00:00Z',
+      uploaded_by: 'test',
+      sha256: '0'.repeat(64),
+      peers_missing: [],
+      zip_bytes: 0,
+      extracted_bytes: 0,
+      file_count: 0,
+    }],
+  } satisfies Pick<UploadedPackageStore, 'list'>;
+  const logs: unknown[][] = [];
+  // Only activate() is substituted. Boot selection, catch/log handling, and
+  // counted registry writes are real; LLM and filesystem activation deps
+  // cannot be reached through this override and are deliberately omitted.
+  const deps = {
+    registry,
+    catalog,
+    uploadedStore,
+    log: (...args: unknown[]): void => { logs.push(args); },
+  } as unknown as DynamicAgentRuntimeDeps;
+  return { runtime: new ThrowingActivationRuntime(deps, activationError), registry, logs };
+}
+
+describe('DynamicAgentRuntime.activateAllInstalled — transient failure regression', () => {
+  for (const { label, failure } of [
+    { label: 'Error', failure: new Error(ACTIVATION_ERROR) },
+    { label: 'non-Error', failure: ACTIVATION_ERROR },
+  ]) {
+    it(`counts ordinary ${label} activation failures and skips the fourth attempt`, async () => {
+      const { runtime, registry, logs } = await makeRuntime(failure);
+
+      for (let attempt = 1; attempt <= CIRCUIT_BREAKER_THRESHOLD; attempt += 1) {
+        assert.deepEqual(await runtime.activateAllInstalled(), []);
+        const entry = registry.get(AGENT_ID);
+        assert.ok(entry);
+        assert.equal(entry.status, attempt < CIRCUIT_BREAKER_THRESHOLD ? 'active' : 'errored');
+        assert.equal(entry.activation_failure_count, attempt);
+        assert.equal(entry.last_activation_error, ACTIVATION_ERROR);
+        assert.ok(entry.last_activation_error_at);
+        assert.equal(Object.hasOwn(entry, 'unresolved_requires'), false);
+        assert.equal(runtime.attempts.length, attempt);
+        assert.equal(registry.failureCalls.length, attempt);
+        assert.deepEqual(registry.failureCalls.at(-1), [AGENT_ID, ACTIVATION_ERROR]);
+        assert.deepEqual(registry.blockCalls, []);
+      }
+
+      assert.deepEqual(await runtime.activateAllInstalled(), []);
+      assert.deepEqual(runtime.attempts, Array<string>(CIRCUIT_BREAKER_THRESHOLD).fill(AGENT_ID));
+      assert.equal(registry.failureCalls.length, CIRCUIT_BREAKER_THRESHOLD);
+      assert.deepEqual(logs, Array.from({ length: CIRCUIT_BREAKER_THRESHOLD }, () => [
+        `[dynamic-runtime] activate FAILED for ${AGENT_ID}: ${ACTIVATION_ERROR}`,
+      ]));
+    });
+
+    it(`contains a registry-write failure (${label}) without aborting boot`, async () => {
+      const { runtime, registry, logs } = await makeRuntime(new Error(ACTIVATION_ERROR), failure);
+
+      assert.deepEqual(await runtime.activateAllInstalled(), []);
+      assert.deepEqual(registry.failureCalls, [[AGENT_ID, ACTIVATION_ERROR]]);
+      assert.deepEqual(registry.blockCalls, []);
+      assert.deepEqual(logs, [
+        [`[dynamic-runtime] activate FAILED for ${AGENT_ID}: ${ACTIVATION_ERROR}`],
+        [`[dynamic-runtime] registry markActivationFailed FAILED for ${AGENT_ID}: ${ACTIVATION_ERROR}`],
+      ]);
+    });
+  }
+});

--- a/middleware/test/embeddingGateStatusPublication.test.ts
+++ b/middleware/test/embeddingGateStatusPublication.test.ts
@@ -4,7 +4,7 @@ import { describe, it } from 'node:test';
 import { createEmbeddingGateStatus } from '@omadia/knowledge-graph-neon/dist/gateStatusPublication.js';
 
 import { buildKgHealth } from '../src/health/kgHealth.js';
-import type { InstalledRegistry } from '../src/plugins/installedRegistry.js';
+import { InMemoryInstalledRegistry, type InstalledRegistry } from '../src/plugins/installedRegistry.js';
 
 /**
  * #440 — the gate runs once, at activation. What it describes does NOT stay
@@ -17,16 +17,21 @@ import type { InstalledRegistry } from '../src/plugins/installedRegistry.js';
 const KG_NEON = '@omadia/knowledge-graph-neon';
 const EMBEDDINGS = '@omadia/embeddings';
 
-/** Minimal stand-in for the installed registry: buildKgHealth only calls get(). */
+/** Seed the real registry so status writes keep the same contract as reads. */
 function registry(
   entries: ReadonlyArray<{ id: string; config?: Record<string, unknown> }>,
 ): InstalledRegistry {
-  const byId = new Map(
-    entries.map((e) => [e.id, { status: 'active', config: e.config ?? {} }]),
-  );
-  return {
-    get: (id: string) => byId.get(id),
-  } as unknown as InstalledRegistry;
+  const installed = new InMemoryInstalledRegistry();
+  for (const entry of entries) {
+    void installed.register({
+      id: entry.id,
+      installed_version: '1.0.0',
+      installed_at: '2026-09-10T00:00:00Z',
+      status: 'active',
+      config: entry.config ?? {},
+    });
+  }
+  return installed;
 }
 
 const OWED_MATCH = {
@@ -299,6 +304,8 @@ describe('embedding gate status publication (#440)', () => {
             column: 'embedding',
             previousDimensions: 768,
             newDimensions: 1536,
+            indexes: [],
+            attemptsReset: 0,
             discardedVectors: 7,
           },
         ],

--- a/middleware/test/installJobActivationState.test.ts
+++ b/middleware/test/installJobActivationState.test.ts
@@ -41,6 +41,7 @@ import { describe, it } from 'node:test';
 import { InstallService } from '../src/plugins/installService.js';
 import {
   InMemoryInstalledRegistry,
+  blockActivation,
   type InstalledAgent,
   type InstalledRegistry,
 } from '../src/plugins/installedRegistry.js';
@@ -264,6 +265,12 @@ function makeStickyActiveHarness(
     },
     remove: async (id: string) => {
       installed.delete(id);
+    },
+    markActivationBlocked: async (id: string, error: string) => {
+      const current = installed.get(id);
+      if (current) {
+        installed.set(id, blockActivation(current, error, new Date().toISOString()));
+      }
     },
     markActivationFailed: async (id: string, error: string) => {
       const current = installed.get(id);
@@ -642,6 +649,8 @@ void describe('#825 — a registry that records no status', () => {
         installed.add(e.id);
       },
       remove: async () => {},
+      // Deliberately ignore status writes: this fixture isolates thrown hooks.
+      markActivationBlocked: async () => {},
       markActivationFailed: async () => {},
       markActivationSucceeded: async () => {},
       updateConfig: async () => {},

--- a/middleware/test/installService.test.ts
+++ b/middleware/test/installService.test.ts
@@ -2,15 +2,18 @@ import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
 import type { Plugin } from '../src/api/admin-v1.js';
-import type {
-  InstalledAgent,
-  InstalledRegistry,
+import {
+  blockActivation,
+  type InstalledAgent,
+  type InstalledRegistry,
 } from '../src/plugins/installedRegistry.js';
 import {
   extractSetupSchema,
   InstallError,
   InstallService,
+  purgePluginAgentBindings,
 } from '../src/plugins/installService.js';
+import type { AgentPluginBindingStore } from '../src/plugins/installService.js';
 import type {
   PluginCatalog,
   PluginCatalogEntry,
@@ -43,6 +46,8 @@ function makePlugin(p: Partial_Plugin): Plugin {
   return {
     id: p.id,
     kind: p.kind ?? 'tool',
+    multi_instance: false,
+    privacy_class: 'default',
     name: p.name ?? p.id,
     version: '0.1.0',
     latest_version: '0.1.0',
@@ -113,10 +118,19 @@ function makeRegistry(active: InstalledAgent[] = []): InstalledRegistry {
     remove: async (id) => {
       map.delete(id);
     },
+    markActivationBlocked: async (id: string, error: string) => {
+      const current = map.get(id);
+      if (current) {
+        map.set(id, blockActivation(current, error, new Date().toISOString()));
+      }
+    },
     markActivationFailed: async () => {
       /* no-op */
     },
     markActivationSucceeded: async () => {
+      /* no-op */
+    },
+    clearActivationError: async () => {
       /* no-op */
     },
     updateConfig: async () => {
@@ -148,6 +162,252 @@ const noopVault: SecretVault = {
   },
   list: async () => [],
 } as unknown as SecretVault;
+
+describe('InstallService — agent-plugin binding cleanup (OM-95)', () => {
+  it('uninstall deletes every binding for the plugin and preserves other plugins', async (t) => {
+    const registry = makeRegistry([makeActive('removed'), makeActive('kept')]);
+    let bindings = [
+      { agentId: 'one', pluginId: 'removed', enabled: true },
+      { agentId: 'two', pluginId: 'removed', enabled: false },
+      { agentId: 'one', pluginId: 'kept', enabled: true },
+    ];
+    const calls: string[] = [];
+    const teardownObservations: Array<{
+      pluginId: string;
+      reason: string;
+      bindingCount: number;
+    }> = [];
+    const store: AgentPluginBindingStore = {
+      deleteAgentPluginsForPlugin: async (pluginId) => {
+        calls.push(pluginId);
+        const before = bindings.length;
+        bindings = bindings.filter((row) => row.pluginId !== pluginId);
+        return before - bindings.length;
+      },
+    };
+    const log = t.mock.method(console, 'log', () => {});
+    // The registry wires later than the install service during a real boot.
+    let wiredStore: AgentPluginBindingStore | undefined;
+    const service = new InstallService({
+      catalog: makeCatalog([]),
+      registry,
+      vault: noopVault,
+      agentPluginBindingStore: () => wiredStore,
+      onUninstall: async (pluginId, reason) => {
+        teardownObservations.push({
+          pluginId,
+          reason,
+          bindingCount: bindings.length,
+        });
+        wiredStore = undefined;
+      },
+    });
+    wiredStore = store;
+
+    await service.uninstall('removed');
+
+    assert.deepEqual(calls, ['removed']);
+    assert.deepEqual(bindings, [
+      { agentId: 'one', pluginId: 'kept', enabled: true },
+    ]);
+    assert.equal(registry.has('removed'), false);
+    assert.equal(registry.has('kept'), true);
+    assert.deepEqual(teardownObservations, [
+      { pluginId: 'removed', reason: 'uninstall', bindingCount: 1 },
+    ]);
+    assert.equal(wiredStore, undefined, 'runtime teardown removed the store');
+    assert.deepEqual(log.mock.calls.map((call) => call.arguments), [
+      ['[install] removed 2 agent-plugin binding(s) for removed'],
+    ]);
+  });
+
+  it('uninstall completes silently when the plugin has no bindings', async (t) => {
+    const registry = makeRegistry([makeActive('unbound')]);
+    const calls: string[] = [];
+    const log = t.mock.method(console, 'log', () => {});
+    const error = t.mock.method(console, 'error', () => {});
+    const service = new InstallService({
+      catalog: makeCatalog([]),
+      registry,
+      vault: noopVault,
+      agentPluginBindingStore: () => ({
+        deleteAgentPluginsForPlugin: async (pluginId) => {
+          calls.push(pluginId);
+          return 0;
+        },
+      }),
+    });
+
+    await service.uninstall('unbound');
+
+    assert.deepEqual(calls, ['unbound']);
+    assert.equal(registry.has('unbound'), false);
+    assert.equal(log.mock.callCount(), 0);
+    assert.equal(error.mock.callCount(), 0);
+  });
+
+  it('uninstall works when no orchestrator getter is wired', async (t) => {
+    const registry = makeRegistry([makeActive('standalone')]);
+    const log = t.mock.method(console, 'log', () => {});
+    const error = t.mock.method(console, 'error', () => {});
+    const service = new InstallService({
+      catalog: makeCatalog([]),
+      registry,
+      vault: noopVault,
+    });
+
+    await service.uninstall('standalone');
+
+    assert.equal(registry.has('standalone'), false);
+    assert.equal(log.mock.callCount(), 0);
+    assert.equal(error.mock.callCount(), 0);
+  });
+
+  it('uninstall works when the orchestrator getter has no store yet', async (t) => {
+    const registry = makeRegistry([makeActive('standalone')]);
+    const log = t.mock.method(console, 'log', () => {});
+    const error = t.mock.method(console, 'error', () => {});
+    const service = new InstallService({
+      catalog: makeCatalog([]),
+      registry,
+      vault: noopVault,
+      agentPluginBindingStore: () => undefined,
+    });
+
+    await service.uninstall('standalone');
+
+    assert.equal(registry.has('standalone'), false);
+    assert.equal(log.mock.callCount(), 0);
+    assert.equal(error.mock.callCount(), 0);
+  });
+
+  it('uninstall logs a database failure with plugin context and still removes the plugin', async (t) => {
+    const registry = makeRegistry([makeActive('db-down')]);
+    const error = t.mock.method(console, 'error', () => {});
+    const service = new InstallService({
+      catalog: makeCatalog([]),
+      registry,
+      vault: noopVault,
+      agentPluginBindingStore: () => ({
+        deleteAgentPluginsForPlugin: async () => {
+          throw new Error('database unavailable');
+        },
+      }),
+    });
+
+    await assert.doesNotReject(service.uninstall('db-down'));
+
+    assert.equal(registry.has('db-down'), false);
+    assert.deepEqual(error.mock.calls.map((call) => call.arguments), [
+      [
+        '[install] agent-plugin binding purge failed for db-down:',
+        'database unavailable',
+      ],
+    ]);
+  });
+
+  it('uninstall also contains a failure resolving the binding store', async (t) => {
+    const registry = makeRegistry([makeActive('lookup-down')]);
+    const error = t.mock.method(console, 'error', () => {});
+    const service = new InstallService({
+      catalog: makeCatalog([]),
+      registry,
+      vault: noopVault,
+      agentPluginBindingStore: () => {
+        throw new Error('service lookup unavailable');
+      },
+    });
+
+    await assert.doesNotReject(service.uninstall('lookup-down'));
+
+    assert.equal(registry.has('lookup-down'), false);
+    assert.deepEqual(error.mock.calls.map((call) => call.arguments), [
+      [
+        '[install] agent-plugin binding purge failed for lookup-down:',
+        'service lookup unavailable',
+      ],
+    ]);
+  });
+
+  it('reactivate tears down and restarts the plugin without deleting bindings', async () => {
+    const registry = makeRegistry([makeActive('configured')]);
+    let bindings = [{ agentId: 'one', pluginId: 'configured', enabled: true }];
+    const hooks: string[] = [];
+    let storeLookups = 0;
+    const service = new InstallService({
+      catalog: makeCatalog([]),
+      registry,
+      vault: noopVault,
+      onUninstall: async (pluginId, reason) => {
+        hooks.push(`teardown:${pluginId}:${reason}`);
+      },
+      onInstalled: async (pluginId) => {
+        hooks.push(`activate:${pluginId}`);
+      },
+      agentPluginBindingStore: () => {
+        storeLookups++;
+        return {
+          deleteAgentPluginsForPlugin: async () => {
+            const removed = bindings.length;
+            bindings = [];
+            return removed;
+          },
+        };
+      },
+    });
+
+    const status = await service.reactivate('configured');
+
+    assert.deepEqual(hooks, [
+      'teardown:configured:reactivate',
+      'activate:configured',
+    ]);
+    assert.equal(status, 'active');
+    assert.equal(registry.has('configured'), true);
+    assert.equal(storeLookups, 0);
+    assert.deepEqual(bindings, [
+      { agentId: 'one', pluginId: 'configured', enabled: true },
+    ]);
+  });
+
+  it('exposes cleanup independently for bootstrap removal and repeated calls are silent', async (t) => {
+    let bindings = [{ agentId: 'one', pluginId: 'auto-removed' }];
+    const store: AgentPluginBindingStore = {
+      deleteAgentPluginsForPlugin: async (pluginId) => {
+        const before = bindings.length;
+        bindings = bindings.filter((row) => row.pluginId !== pluginId);
+        return before - bindings.length;
+      },
+    };
+    const log = t.mock.method(console, 'log', () => {});
+
+    await purgePluginAgentBindings('auto-removed', () => store);
+    await purgePluginAgentBindings('auto-removed', () => store);
+
+    assert.deepEqual(bindings, []);
+    assert.deepEqual(log.mock.calls.map((call) => call.arguments), [
+      ['[install] removed 1 agent-plugin binding(s) for auto-removed'],
+    ]);
+  });
+
+  it('independent cleanup logs non-Error rejections without throwing', async (t) => {
+    const error = t.mock.method(console, 'error', () => {});
+    const store: AgentPluginBindingStore = {
+      deleteAgentPluginsForPlugin: () => Promise.reject('connection closed'),
+    };
+
+    await assert.doesNotReject(
+      purgePluginAgentBindings('auto-removed', () => store),
+    );
+
+    assert.deepEqual(error.mock.calls.map((call) => call.arguments), [
+      [
+        '[install] agent-plugin binding purge failed for auto-removed:',
+        'connection closed',
+      ],
+    ]);
+  });
+});
 
 describe('InstallService.create — capability gate', () => {
   it('allows install when target has no requires', () => {

--- a/middleware/test/installServiceJsonFileConfigure.test.ts
+++ b/middleware/test/installServiceJsonFileConfigure.test.ts
@@ -23,7 +23,7 @@ import type {
   PluginCatalogEntry,
 } from '../src/plugins/manifestLoader.js';
 import { InstallService } from '../src/plugins/installService.js';
-import type { InstalledRegistry } from '../src/plugins/installedRegistry.js';
+import { blockActivation, type InstalledAgent, type InstalledRegistry } from '../src/plugins/installedRegistry.js';
 import type { SecretVault } from '../src/secrets/vault.js';
 
 const PEM = ['-----BEGIN', 'PRIVATE', 'KEY-----'].join(' ') + '\nMIIEtest\n' +
@@ -89,17 +89,25 @@ function makeDeps() {
   } as unknown as PluginCatalog;
 
   const config = new Map<string, Record<string, unknown>>();
-  const installed = new Set<string>();
+  const installed = new Map<string, InstalledAgent>();
   const registry = {
     list: () => [],
-    get: (id: string) =>
-      installed.has(id) ? { id, config: config.get(id) ?? {} } : undefined,
+    get: (id: string) => {
+      const entry = installed.get(id);
+      return entry ? { ...entry, config: config.get(id) ?? {} } : undefined;
+    },
     has: (id: string) => installed.has(id),
-    register: async (e: { id: string; config?: Record<string, unknown> }) => {
-      installed.add(e.id);
+    register: async (e: InstalledAgent) => {
+      installed.set(e.id, e);
       config.set(e.id, e.config ?? {});
     },
     remove: async () => {},
+    markActivationBlocked: async (id: string, error: string) => {
+      const current = installed.get(id);
+      if (current) {
+        installed.set(id, blockActivation(current, error, new Date().toISOString()));
+      }
+    },
     markActivationFailed: async () => {},
     markActivationSucceeded: async () => {},
     updateConfig: async (id: string, c: Record<string, unknown>) => {

--- a/middleware/test/installServiceOAuthField.test.ts
+++ b/middleware/test/installServiceOAuthField.test.ts
@@ -16,7 +16,7 @@ import type {
   PluginCatalogEntry,
 } from '../src/plugins/manifestLoader.js';
 import { InstallService } from '../src/plugins/installService.js';
-import type { InstalledRegistry } from '../src/plugins/installedRegistry.js';
+import { blockActivation, type InstalledAgent, type InstalledRegistry } from '../src/plugins/installedRegistry.js';
 import type { SecretVault } from '../src/secrets/vault.js';
 
 const MANIFEST = {
@@ -76,17 +76,25 @@ function makeDeps() {
   } as unknown as PluginCatalog;
 
   const config = new Map<string, Record<string, unknown>>();
-  const installed = new Set<string>();
+  const installed = new Map<string, InstalledAgent>();
   const registry = {
     list: () => [],
-    get: (id: string) =>
-      installed.has(id) ? { id, config: config.get(id) ?? {} } : undefined,
+    get: (id: string) => {
+      const entry = installed.get(id);
+      return entry ? { ...entry, config: config.get(id) ?? {} } : undefined;
+    },
     has: (id: string) => installed.has(id),
-    register: async (e: { id: string; config?: Record<string, unknown> }) => {
-      installed.add(e.id);
+    register: async (e: InstalledAgent) => {
+      installed.set(e.id, e);
       config.set(e.id, e.config ?? {});
     },
     remove: async () => {},
+    markActivationBlocked: async (id: string, error: string) => {
+      const current = installed.get(id);
+      if (current) {
+        installed.set(id, blockActivation(current, error, new Date().toISOString()));
+      }
+    },
     markActivationFailed: async () => {},
     markActivationSucceeded: async () => {},
     updateConfig: async (id: string, c: Record<string, unknown>) => {

--- a/middleware/test/installedRegistry.test.ts
+++ b/middleware/test/installedRegistry.test.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'node:assert';
-import { describe, it } from 'node:test';
+import { describe, it, type TestContext } from 'node:test';
 
 import { promises as fs } from 'node:fs';
 import os from 'node:os';
@@ -9,6 +9,7 @@ import {
   CIRCUIT_BREAKER_THRESHOLD,
   InMemoryInstalledRegistry,
   type InstalledAgent,
+  type InstalledRegistry,
 } from '../src/plugins/installedRegistry.js';
 import { FileInstalledRegistry } from '../src/plugins/fileInstalledRegistry.js';
 
@@ -78,6 +79,169 @@ describe('InstalledRegistry.markActivationFailed (with unresolvedRequires)', () 
     assert.equal(reg.get('does-not-exist'), undefined);
   });
 });
+
+interface RegistryFixture {
+  registry: InstalledRegistry;
+  read(id: string): Promise<InstalledAgent | undefined>;
+}
+
+const registryBackends: ReadonlyArray<{
+  name: string;
+  create(t: TestContext): Promise<RegistryFixture>;
+}> = [
+  {
+    name: 'InMemoryInstalledRegistry',
+    async create() {
+      const registry = new InMemoryInstalledRegistry();
+      return { registry, read: async (id) => registry.get(id) };
+    },
+  },
+  {
+    name: 'FileInstalledRegistry',
+    async create(t) {
+      const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'omadia-reg-block-'));
+      t.after(() => fs.rm(dir, { recursive: true, force: true }));
+      const file = path.join(dir, 'installed.json');
+      const registry = new FileInstalledRegistry(file);
+      await registry.load();
+      return {
+        registry,
+        async read(id) {
+          // Every assertion reads a fresh instance, so memory-only writes fail.
+          const reloaded = new FileInstalledRegistry(file);
+          await reloaded.load();
+          return reloaded.get(id);
+        },
+      };
+    },
+  },
+];
+
+for (const backend of registryBackends) {
+  describe(`${backend.name} terminal blocks and counted failures (OM-87)`, () => {
+    it('blocks immediately, bounds the error, stamps time and preserves metadata', async (t) => {
+      const { registry, read } = await backend.create(t);
+      const original = {
+        ...activeAgent('a'),
+        config: { region: 'eu' },
+        last_activated_at: '2026-04-29T01:00:00.000Z',
+      };
+      await registry.register(original);
+      const before = Date.now();
+      const error = `duplicate provider: ${'x'.repeat(600)}`;
+      await registry.markActivationBlocked('a', error);
+      const blocked = await read('a');
+      assert.ok(blocked);
+      assert.equal(blocked.status, 'errored');
+      assert.equal(blocked.activation_failure_count, CIRCUIT_BREAKER_THRESHOLD);
+      assert.equal(blocked.last_activation_error, error.slice(0, 500));
+      assert.ok(blocked.last_activation_error_at);
+      const at = Date.parse(blocked.last_activation_error_at);
+      assert.ok(at >= before && at <= Date.now());
+      assert.equal(Object.hasOwn(blocked, 'unresolved_requires'), false);
+      assert.equal(blocked.installed_at, original.installed_at);
+      assert.equal(blocked.installed_version, original.installed_version);
+      assert.equal(blocked.last_activated_at, original.last_activated_at);
+      assert.deepEqual(blocked.config, original.config);
+      assert.equal(original.status, 'active', 'does not mutate the old entry');
+    });
+
+    it('clears a stale requires-list when replacing a counted failure with a block', async (t) => {
+      const { registry, read } = await backend.create(t);
+      await registry.register(activeAgent('a'));
+      await registry.markActivationFailed('a', 'missing dependency', ['missing@^1']);
+      await registry.markActivationBlocked('a', 'duplicate provider');
+      const blocked = await read('a');
+      assert.ok(blocked);
+      assert.equal(blocked.status, 'errored');
+      assert.equal(Object.hasOwn(blocked, 'unresolved_requires'), false);
+    });
+
+    for (const previous of [0, 1, CIRCUIT_BREAKER_THRESHOLD, CIRCUIT_BREAKER_THRESHOLD + 4]) {
+      it(`repeated blocks keep a stable counter starting at ${previous}`, async (t) => {
+        const { registry, read } = await backend.create(t);
+        await registry.register({ ...activeAgent('a'), activation_failure_count: previous });
+        await registry.markActivationBlocked('a', 'first conflict');
+        const first = await read('a');
+        await registry.markActivationBlocked('a', 'current conflict');
+        const second = await read('a');
+        assert.ok(first);
+        assert.ok(second);
+        assert.equal(first.activation_failure_count, Math.max(previous, CIRCUIT_BREAKER_THRESHOLD));
+        assert.equal(second.activation_failure_count, first.activation_failure_count);
+        assert.equal(second.status, 'errored');
+        assert.equal(second.last_activation_error, 'current conflict');
+        assert.ok(Date.parse(second.last_activation_error_at!) >= Date.parse(first.last_activation_error_at!));
+        assert.equal(Object.hasOwn(second, 'unresolved_requires'), false);
+      });
+    }
+
+    it('unknown ids are no-ops for blocked and both counted call shapes', async (t) => {
+      const { registry, read } = await backend.create(t);
+      const original = activeAgent('a');
+      await registry.register(original);
+      await registry.markActivationBlocked('unknown', 'conflict');
+      await registry.markActivationFailed('unknown', 'transient');
+      await registry.markActivationFailed('unknown', 'missing', ['missing@^1']);
+      assert.equal(await read('unknown'), undefined);
+      assert.deepEqual(await read('a'), original);
+    });
+
+    for (const requires of [undefined, ['missing@^1']]) {
+      it(`preserves counted failures ${requires ? 'with requires' : 'without requires'}`, async (t) => {
+        const { registry, read } = await backend.create(t);
+        await registry.register(activeAgent('a'));
+        const error = `activation failed: ${'x'.repeat(600)}`;
+        for (let attempt = 1; attempt <= CIRCUIT_BREAKER_THRESHOLD + 1; attempt++) {
+          const before = Date.now();
+          if (requires) await registry.markActivationFailed('a', error, requires);
+          else await registry.markActivationFailed('a', error);
+          const failed = await read('a');
+          assert.ok(failed);
+          assert.equal(failed.activation_failure_count, attempt);
+          assert.equal(failed.status, attempt < CIRCUIT_BREAKER_THRESHOLD ? 'active' : 'errored');
+          assert.equal(failed.last_activation_error, error.slice(0, 500));
+          assert.ok(failed.last_activation_error_at);
+          assert.ok(Date.parse(failed.last_activation_error_at) >= before);
+          assert.deepEqual(failed.unresolved_requires, requires);
+        }
+      });
+    }
+
+    it('counted failures copy requires and still remove them for absent or empty lists', async (t) => {
+      const { registry, read } = await backend.create(t);
+      for (const replacement of [undefined, []]) {
+        await registry.register(activeAgent('a'));
+        const requires = ['missing@^1'];
+        await registry.markActivationFailed('a', 'missing', requires);
+        requires.push('later@^1');
+        assert.deepEqual((await read('a'))?.unresolved_requires, ['missing@^1']);
+        await registry.markActivationFailed('a', 'changed', replacement);
+        assert.equal((await read('a'))?.unresolved_requires, undefined);
+        assert.equal((await read('a'))?.activation_failure_count, 2);
+        assert.equal((await read('a'))?.status, 'active');
+      }
+    });
+
+    it('clearing a block restores active and resets the next transient failure to one', async (t) => {
+      const { registry, read } = await backend.create(t);
+      await registry.register(activeAgent('a'));
+      await registry.markActivationBlocked('a', 'conflict');
+      await registry.clearActivationError('a');
+      assert.deepEqual(await read('a'), activeAgent('a'));
+      await registry.markActivationFailed('a', 'transient');
+      assert.equal((await read('a'))?.activation_failure_count, 1);
+      assert.equal((await read('a'))?.status, 'active');
+      await registry.markActivationSucceeded('a');
+      const success = await read('a');
+      assert.ok(success?.last_activated_at);
+      assert.equal(success.activation_failure_count, undefined);
+      assert.equal(success.last_activation_error, undefined);
+      assert.equal(success.last_activation_error_at, undefined);
+      assert.equal(success.unresolved_requires, undefined);
+    });
+  });
+}
 
 describe('InstalledRegistry.markActivationSucceeded', () => {
   it('clears unresolved_requires alongside the other error fields', async () => {

--- a/middleware/test/kgPluginPoolLifetime.pg.test.ts
+++ b/middleware/test/kgPluginPoolLifetime.pg.test.ts
@@ -7,6 +7,7 @@ import { probePgTest } from './_helpers/pgTestDb.js';
 
 import { activate } from '@omadia/knowledge-graph-neon/dist/plugin.js';
 import { InstallService } from '../src/plugins/installService.js';
+import { InMemoryInstalledRegistry } from '../src/plugins/installedRegistry.js';
 
 /**
  * Issue #665 — the knowledge-graph plugin must not end the pg pool the whole
@@ -148,6 +149,14 @@ describe('#665 — KG plugin close() must not end the shared pg pool', () => {
     // funnel is ever rewired.
     let reactivations = 0;
     const statusWrites = { cleared: 0, succeeded: 0, failed: 0 };
+    const installed = new InMemoryInstalledRegistry();
+    await installed.register({
+      id: KG_ID,
+      installed_version: '1.0.0',
+      installed_at: '2026-09-10T00:00:00Z',
+      status: 'active',
+      config: {},
+    });
     const service = new InstallService({
       catalog: { list: () => [], get: () => undefined } as never,
       // `reactivate` records the outcome truthfully since #470 C16, so the
@@ -158,14 +167,15 @@ describe('#665 — KG plugin close() must not end the shared pg pool', () => {
       // re-activation rather than a swallowed one.
       registry: {
         has: (id: string) => id === KG_ID,
-        get: (id: string) =>
-          id === KG_ID ? { id, status: 'active' } : undefined,
+        get: (id: string) => installed.get(id),
         clearActivationError: async (): Promise<void> => {
           statusWrites.cleared += 1;
         },
         markActivationSucceeded: async (): Promise<void> => {
           statusWrites.succeeded += 1;
         },
+        markActivationBlocked: (id: string, error: string) =>
+          installed.markActivationBlocked(id, error),
         markActivationFailed: async (): Promise<void> => {
           statusWrites.failed += 1;
         },

--- a/middleware/test/manifestBootRobustness.test.ts
+++ b/middleware/test/manifestBootRobustness.test.ts
@@ -1,0 +1,370 @@
+import { strict as assert } from 'node:assert';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, it, mock } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  adaptManifestV1,
+  loadManifestFromPath,
+  PluginCatalog,
+} from '../src/plugins/manifestLoader.js';
+import type { UnknownPermissionKeys } from '../src/plugins/manifestLoader.js';
+
+const DEFAULT_MANIFEST_DIR = fileURLToPath(
+  new URL('../../docs/harness-platform/examples', import.meta.url),
+);
+const PACKAGES_DIR = fileURLToPath(new URL('../packages/', import.meta.url));
+
+function manifest(
+  id: string,
+  permissions?: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    schema_version: '1',
+    identity: {
+      id,
+      kind: 'integration',
+      domain: 'test',
+      name: id,
+      version: '1.0.0',
+    },
+    ...(permissions === undefined ? {} : { permissions }),
+  };
+}
+
+async function withTempDir(run: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'manifest-boot-'));
+  try {
+    await run(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+interface CapturedLogs {
+  readonly warnings: string[];
+  readonly debug: string[];
+}
+
+async function withCapturedLogs(
+  run: (logs: CapturedLogs) => Promise<void>,
+): Promise<void> {
+  const logs: CapturedLogs = { warnings: [], debug: [] };
+  const warn = mock.method(console, 'warn', (...args: unknown[]): void => {
+    logs.warnings.push(args.map(String).join(' '));
+  });
+  const debug = mock.method(console, 'debug', (...args: unknown[]): void => {
+    logs.debug.push(args.map(String).join(' '));
+  });
+  try {
+    await run(logs);
+  } finally {
+    warn.mock.restore();
+    debug.mock.restore();
+  }
+}
+
+async function withManifestDirEnv(
+  value: string | undefined,
+  run: () => Promise<void>,
+): Promise<void> {
+  const previous = process.env['PLUGIN_MANIFEST_DIR'];
+  if (value === undefined) delete process.env['PLUGIN_MANIFEST_DIR'];
+  else process.env['PLUGIN_MANIFEST_DIR'] = value;
+  try {
+    await run();
+  } finally {
+    if (previous === undefined) delete process.env['PLUGIN_MANIFEST_DIR'];
+    else process.env['PLUGIN_MANIFEST_DIR'] = previous;
+  }
+}
+
+async function withDefaultDirectoryError(
+  code: string,
+  run: (error: NodeJS.ErrnoException) => Promise<void>,
+): Promise<void> {
+  const error: NodeJS.ErrnoException = Object.assign(new Error(code), { code });
+  // OM-93: the local-only default may exist on a developer machine. Inject
+  // its failure without removing their docs or changing another source's I/O.
+  const readdir = mock.method(fs, 'readdir', async (dir: unknown) => {
+    assert.equal(dir, DEFAULT_MANIFEST_DIR);
+    throw error;
+  });
+  try {
+    await run(error);
+  } finally {
+    readdir.mock.restore();
+  }
+}
+
+async function writeManifest(
+  file: string,
+  id: string,
+  permissions?: Record<string, unknown>,
+): Promise<void> {
+  await fs.writeFile(file, JSON.stringify(manifest(id, permissions)));
+}
+
+describe('OM-89 catalog permission diagnostics', { concurrency: false }, () => {
+  it('accepts filesystem as a live permission without reporting it', () => {
+    const reports: (readonly UnknownPermissionKeys[])[] = [];
+    for (const permissions of [
+      { filesystem: { scratch: true } },
+      { filesystem: { scratch: false } },
+      {},
+      undefined,
+    ]) {
+      const plugin = adaptManifestV1(
+        manifest('test.filesystem', permissions),
+        (diagnostics) => reports.push(diagnostics),
+      );
+      assert.ok(plugin);
+    }
+    assert.deepEqual(reports, []);
+  });
+
+  it('reports unknown keys as data while still adapting the manifest', () => {
+    const reports: (readonly UnknownPermissionKeys[])[] = [];
+    const plugin = adaptManifestV1(
+      manifest('test.unknown', {
+        foo: true,
+        filesystem: { scratch: true },
+        bar: { retired_option: true },
+        flows: true,
+      }),
+      (diagnostics) => reports.push(diagnostics),
+    );
+    assert.ok(plugin);
+    assert.equal(plugin.permissions_summary.flows, true);
+    assert.equal(Object.hasOwn(plugin.permissions_summary, 'foo'), false);
+    assert.equal(Object.hasOwn(plugin.permissions_summary, 'bar'), false);
+    assert.deepEqual(reports, [
+      [{ pluginId: 'test.unknown', keys: ['bar', 'foo'] }],
+    ]);
+  });
+
+  it('preserves the default warning for direct adapt callers', async () => {
+    await withCapturedLogs(async ({ warnings }) => {
+      assert.ok(adaptManifestV1(manifest('test.direct', { foo: true })));
+      assert.equal(warnings.length, 1);
+      assert.equal(
+        warnings[0],
+        '[catalog] 1 plugin(s) declare unknown permission key(s) permissions.foo: test.direct' +
+          ' — ignored. Check the spelling, or the core version this manifest was written against.',
+      );
+    });
+  });
+
+  it('forwards a direct single-file load diagnostic to its collector', async () => {
+    await withTempDir(async (dir) => {
+      const file = path.join(dir, 'manifest.yaml');
+      await writeManifest(file, 'test.single-file', { foo: true });
+      const reports: (readonly UnknownPermissionKeys[])[] = [];
+      const entry = await loadManifestFromPath(file, (diagnostics) => reports.push(diagnostics));
+      assert.ok(entry);
+      assert.equal(entry.plugin.id, 'test.single-file');
+      assert.deepEqual(entry.manifest, manifest('test.single-file', { foo: true }));
+      assert.deepEqual(reports, [
+        [{ pluginId: 'test.single-file', keys: ['foo'] }],
+      ]);
+    });
+  });
+
+  it('preserves the default warning for direct single-file load callers', async () => {
+    await withTempDir(async (dir) => {
+      const file = path.join(dir, 'manifest.yaml');
+      await writeManifest(file, 'test.direct-file', { foo: true });
+      await withCapturedLogs(async ({ warnings }) => {
+        const entry = await loadManifestFromPath(file);
+        assert.ok(entry);
+        assert.equal(entry.plugin.id, 'test.direct-file');
+        assert.deepEqual(warnings, [
+          '[catalog] 1 plugin(s) declare unknown permission key(s) permissions.foo: test.direct-file' +
+            ' — ignored. Check the spelling, or the core version this manifest was written against.',
+        ]);
+      });
+    });
+  });
+
+  it('collects both sources once and clears diagnostics on the next catalog build', async () => {
+    await withTempDir(async (dir) => {
+      const legacyFile = path.join(dir, 'first.manifest.yaml');
+      const packageRoot = path.join(dir, 'extra');
+      const extraFile = path.join(packageRoot, 'manifest.yaml');
+      await fs.mkdir(packageRoot);
+      await writeManifest(legacyFile, 'test.first', { foo: true });
+      await writeManifest(extraFile, 'test.second', { bar: true });
+      const reports: (readonly UnknownPermissionKeys[])[] = [];
+      const catalog = new PluginCatalog({
+        manifestDir: dir,
+        extraSources: () => [{ packageRoot }],
+        reportUnknownPermissions: (diagnostics) => reports.push(diagnostics),
+      });
+
+      await catalog.load();
+      assert.deepEqual(reports, [[
+        { pluginId: 'test.first', keys: ['foo'] },
+        { pluginId: 'test.second', keys: ['bar'] },
+      ]]);
+      assert.equal(catalog.list().length, 2, 'unknown keys never reject a plugin');
+
+      await writeManifest(legacyFile, 'test.first', { filesystem: { scratch: true } });
+      await writeManifest(extraFile, 'test.second', {});
+      await catalog.load();
+      assert.equal(reports.length, 1, 'the clean reload must not re-report old diagnostics');
+      assert.equal(catalog.list().length, 2);
+
+      await writeManifest(extraFile, 'test.second', { baz: true });
+      await catalog.load();
+      assert.deepEqual(reports[1], [{ pluginId: 'test.second', keys: ['baz'] }]);
+      assert.equal(reports.length, 2, 'each nonempty build reports once');
+      assert.deepEqual(reports[0], [
+        { pluginId: 'test.first', keys: ['foo'] },
+        { pluginId: 'test.second', keys: ['bar'] },
+      ], 'later builds must not mutate a previous report');
+    });
+  });
+
+  it('emits one deterministic warning naming both plugin ids and unique keys', async () => {
+    await withTempDir(async (dir) => {
+      await writeManifest(path.join(dir, 'a.manifest.yaml'), 'test.zed', { foo: true });
+      await writeManifest(path.join(dir, 'b.manifest.yaml'), 'test.alpha', { foo: true, bar: true });
+      await withCapturedLogs(async ({ warnings }) => {
+        await new PluginCatalog({ manifestDir: dir }).load();
+        assert.deepEqual(warnings, [
+          '[catalog] 2 plugin(s) declare unknown permission key(s) permissions.bar, permissions.foo: test.alpha, test.zed' +
+            ' — ignored. Check the spelling, or the core version this manifest was written against.',
+        ]);
+      });
+    });
+  });
+
+  it('loads all 24 built-in filesystem manifests without an unknown-key report', async () => {
+    await withTempDir(async (dir) => {
+      const packageRoots: string[] = [];
+      for (const entry of await fs.readdir(PACKAGES_DIR, { withFileTypes: true })) {
+        if (!entry.isDirectory()) continue;
+        const packageRoot = path.join(PACKAGES_DIR, entry.name);
+        let raw: string;
+        try {
+          raw = await fs.readFile(path.join(packageRoot, 'manifest.yaml'), 'utf-8');
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === 'ENOENT') continue;
+          throw error;
+        }
+        if (/^ {2}filesystem:\s*$/m.test(raw)) packageRoots.push(packageRoot);
+      }
+      assert.ok(packageRoots.length >= 24, 'all 24 current built-in declarations must be covered');
+      const reports: (readonly UnknownPermissionKeys[])[] = [];
+      const catalog = new PluginCatalog({
+        manifestDir: dir,
+        extraSources: () => packageRoots.map((packageRoot) => ({ packageRoot, origin: 'bundled' })),
+        reportUnknownPermissions: (diagnostics) => reports.push(diagnostics),
+      });
+      await catalog.load();
+      assert.equal(catalog.list().length, packageRoots.length);
+      assert.deepEqual(reports, []);
+    });
+  });
+});
+
+describe('OM-93 manifest directory optionality', { concurrency: false }, () => {
+  it('logs a missing unconfigured default at debug level without warning', async () => {
+    await withManifestDirEnv(undefined, async () => {
+      await withDefaultDirectoryError('ENOENT', async () => {
+        await withCapturedLogs(async ({ warnings, debug }) => {
+          const catalog = new PluginCatalog();
+          await catalog.load();
+          assert.deepEqual(warnings, []);
+          assert.equal(debug.length, 1);
+          assert.ok(debug[0]?.includes(DEFAULT_MANIFEST_DIR));
+          assert.deepEqual(catalog.list(), []);
+        });
+      });
+    });
+  });
+
+  it('warns when an explicitly configured options directory is missing', async () => {
+    await withTempDir(async (dir) => {
+      const missing = path.join(dir, 'operator-configured-missing');
+      await withCapturedLogs(async ({ warnings, debug }) => {
+        const catalog = new PluginCatalog({ manifestDir: missing });
+        await catalog.load();
+        assert.deepEqual(warnings, [`[catalog] directory does not exist, skipping: ${missing}`]);
+        assert.deepEqual(debug, []);
+        assert.deepEqual(catalog.list(), []);
+      });
+    });
+  });
+
+  it('warns for a missing PLUGIN_MANIFEST_DIR set after module import', async () => {
+    await withTempDir(async (dir) => {
+      const missing = path.join(dir, 'docker-configured-missing');
+      const catalog = new PluginCatalog();
+      await withManifestDirEnv(missing, async () => {
+        await withCapturedLogs(async ({ warnings, debug }) => {
+          await catalog.load();
+          assert.deepEqual(warnings, [`[catalog] directory does not exist, skipping: ${missing}`]);
+          assert.deepEqual(debug, []);
+        });
+      });
+    });
+  });
+
+  it('treats an explicitly configured default path as required', async () => {
+    await withManifestDirEnv(DEFAULT_MANIFEST_DIR, async () => {
+      await withDefaultDirectoryError('ENOENT', async () => {
+        await withCapturedLogs(async ({ warnings, debug }) => {
+          await new PluginCatalog().load();
+          assert.deepEqual(warnings, [
+            `[catalog] directory does not exist, skipping: ${DEFAULT_MANIFEST_DIR}`,
+          ]);
+          assert.deepEqual(debug, []);
+        });
+      });
+    });
+  });
+
+  it('keeps an explicit options directory ahead of the environment source', async () => {
+    await withTempDir(async (dir) => {
+      await writeManifest(path.join(dir, 'plugin.manifest.yaml'), 'test.options-priority');
+      await withManifestDirEnv(path.join(dir, 'missing-env-source'), async () => {
+        await withCapturedLogs(async ({ warnings, debug }) => {
+          const catalog = new PluginCatalog({ manifestDir: dir });
+          await catalog.load();
+          assert.ok(catalog.get('test.options-priority'));
+          assert.deepEqual(warnings, []);
+          assert.deepEqual(debug, []);
+        });
+      });
+    });
+  });
+
+  it('rethrows a non-ENOENT error from the optional source unchanged', async () => {
+    await withManifestDirEnv(undefined, async () => {
+      await withDefaultDirectoryError('EACCES', async (expected) => {
+        await withCapturedLogs(async ({ warnings, debug }) => {
+          await assert.rejects(new PluginCatalog().load(), (error: unknown) => error === expected);
+          assert.deepEqual(warnings, []);
+          assert.deepEqual(debug, []);
+        });
+      });
+    });
+  });
+
+  it('rethrows a real non-ENOENT readdir failure from a required source', async () => {
+    await withTempDir(async (dir) => {
+      const file = path.join(dir, 'not-a-directory');
+      await fs.writeFile(file, 'ordinary file');
+      await withCapturedLogs(async ({ warnings, debug }) => {
+        await assert.rejects(new PluginCatalog({ manifestDir: file }).load(), {
+          code: 'ENOTDIR',
+        });
+        assert.deepEqual(warnings, []);
+        assert.deepEqual(debug, []);
+      });
+    });
+  });
+});

--- a/middleware/test/oauth/brokerService.test.ts
+++ b/middleware/test/oauth/brokerService.test.ts
@@ -12,7 +12,7 @@ import crypto from 'node:crypto';
 
 import { adaptManifestV1 } from '../../src/plugins/manifestLoader.js';
 import type { PluginCatalog } from '../../src/plugins/manifestLoader.js';
-import type { InstalledRegistry } from '../../src/plugins/installedRegistry.js';
+import { InMemoryInstalledRegistry, type InstalledRegistry } from '../../src/plugins/installedRegistry.js';
 import type { SecretVault } from '../../src/secrets/vault.js';
 import {
   OAuthBrokerService,
@@ -99,14 +99,19 @@ function makeHarness(opts: {
   const catalog = {
     get: (id: string) => (id === PLUGIN_ID ? { plugin } : undefined),
   } as unknown as PluginCatalog;
-  const registry = {
-    get: (id: string) => (id === PLUGIN_ID ? { id: PLUGIN_ID, config } : undefined),
-  } as unknown as InstalledRegistry;
+  const registry: InstalledRegistry = new InMemoryInstalledRegistry();
+  void registry.register({
+    id: PLUGIN_ID,
+    installed_version: '1.0.0',
+    installed_at: '2026-09-10T00:00:00Z',
+    status: 'active',
+    config,
+  });
   const signingKey = new Uint8Array(crypto.randomBytes(64));
   const pendingFlows = new PendingFlowStore();
   let lastBody = '';
   const fetchImpl: typeof fetch = async (_url, init) => {
-    lastBody = String((init as { body?: BodyInit }).body);
+    lastBody = String(init?.body);
     return new Response(
       JSON.stringify({
         access_token: 'AT',

--- a/middleware/test/optionalRequires.test.ts
+++ b/middleware/test/optionalRequires.test.ts
@@ -53,9 +53,10 @@ import {
   resolveEligiblePlugins,
   walkCapabilityInstallChain,
 } from '../src/plugins/capabilityResolver.js';
-import type {
-  InstalledAgent,
-  InstalledRegistry,
+import {
+  blockActivation,
+  type InstalledAgent,
+  type InstalledRegistry,
 } from '../src/plugins/installedRegistry.js';
 import { InstallError, InstallService } from '../src/plugins/installService.js';
 import { adaptManifestV1 } from '../src/plugins/manifestLoader.js';
@@ -160,6 +161,12 @@ function installedRegistry(active: readonly string[] = []): InstalledRegistry {
     },
     remove: async () => {
       /* no-op */
+    },
+    markActivationBlocked: async (id: string, error: string) => {
+      const current = map.get(id);
+      if (current) {
+        map.set(id, blockActivation(current, error, new Date().toISOString()));
+      }
     },
     markActivationFailed: async () => {
       /* no-op */

--- a/middleware/test/orchestratorRegistry.test.ts
+++ b/middleware/test/orchestratorRegistry.test.ts
@@ -374,6 +374,10 @@ test('US4-4d: registry.start() quarantines an uninstalled plugin instead of abor
   // every `/operator/*` route then returned `multi_orchestrator_unavailable`
   // (503). The registry must instead disable just the offending binding and
   // come up with the rest.
+  const snapshot: ConfigSnapshot = Object.freeze({
+    ...twoAgentSnapshot,
+    agentPlugins: Object.freeze(twoAgentSnapshot.agentPlugins.map((row) => Object.freeze({ ...row }))),
+  });
   const logged: Array<{ msg: string; fields?: Record<string, unknown> }> = [];
   const lookup: PluginCapabilityLookup = {
     isMultiInstance: () => true,
@@ -381,7 +385,7 @@ test('US4-4d: registry.start() quarantines an uninstalled plugin instead of abor
     isInstalled: (id) => (id === '@omadia/agent-odoo-hr' ? false : true),
   };
   const registry = new OrchestratorRegistry(
-    fakeStore(twoAgentSnapshot),
+    fakeStore(snapshot),
     deps(),
     {
       defaultRuntimeConfig: { model: 'm', maxTokens: 100, maxToolIterations: 4 },
@@ -398,6 +402,9 @@ test('US4-4d: registry.start() quarantines an uninstalled plugin instead of abor
   assert.ok(registry.get('public'), 'public agent present');
   const general = registry.get('general');
   assert.ok(general, 'general agent still present despite its missing plugin');
+  assert.equal(snapshot.agentPlugins[1]!.enabled, true, 'the input binding is never mutated');
+  assert.notEqual(general.plugins[0], snapshot.agentPlugins[1], 'quarantine creates a new row');
+  assert.equal(registry.get('public')!.plugins[0], snapshot.agentPlugins[0], 'healthy rows retain their identity');
   assert.deepEqual(
     general.plugins.filter((p) => p.enabled).map((p) => p.pluginId),
     [],
@@ -413,6 +420,34 @@ test('US4-4d: registry.start() quarantines an uninstalled plugin instead of abor
     ),
     'a per-binding warning is logged',
   );
+});
+
+test('OM-95: unknown or absent installation lookups leave bindings untouched without quarantine logs', async () => {
+  const lookups: Array<PluginCapabilityLookup | undefined> = [
+    { isMultiInstance: () => true, isInstalled: () => undefined },
+    { isMultiInstance: () => true },
+    undefined,
+  ];
+  for (const lookup of lookups) {
+    const logged: Array<{ msg: string; fields?: Record<string, unknown> }> = [];
+    const registry = new OrchestratorRegistry(fakeStore(twoAgentSnapshot), deps(), {
+      defaultRuntimeConfig: { model: 'm', maxTokens: 100, maxToolIterations: 4 },
+      ...(lookup ? { pluginLookup: lookup } : {}),
+      log: (msg, fields) => logged.push({ msg, ...(fields ? { fields } : {}) }),
+    });
+
+    await registry.start();
+    const plan = await registry.reload();
+
+    assert.equal(registry.size(), 2);
+    assert.equal(plan.actions.length, 0);
+    assert.equal(registry.get('public')!.plugins[0], twoAgentSnapshot.agentPlugins[0]);
+    assert.equal(registry.get('general')!.plugins[0], twoAgentSnapshot.agentPlugins[1]);
+    assert.deepEqual(
+      logged.filter((entry) => entry.msg.includes('quarantined') || entry.msg.includes('plugin not installed')),
+      [],
+    );
+  }
 });
 
 test('SC-007 / T018: a build-time failure for Agent B does NOT prevent Agent A', async () => {

--- a/middleware/test/orchestratorRegistryHotReload.test.ts
+++ b/middleware/test/orchestratorRegistryHotReload.test.ts
@@ -34,7 +34,10 @@ import {
   type ConfigSnapshot,
   type ConfigStore,
 } from '../packages/harness-orchestrator/src/registry/configStore.js';
-import { OrchestratorRegistry } from '../packages/harness-orchestrator/src/registry/index.js';
+import {
+  OrchestratorRegistry,
+  type PluginCapabilityLookup,
+} from '../packages/harness-orchestrator/src/registry/index.js';
 
 function fakeNativeToolRegistry(): NativeToolRegistry {
   const names = new Set<string>();
@@ -327,6 +330,212 @@ test('T020: an idempotent reload (no DB change) emits zero actions', async () =>
   const plan = await registry.reload();
   assert.equal(plan.actions.length, 0);
   assert.equal(plan.platformChanged, false);
+});
+
+test('OM-95: consecutive reconciles quarantine the same dead binding only once', async () => {
+  const binding = Object.freeze(pluginRow(baseSnapshot.agents[0]!.id, SEO_PLUGIN));
+  const snapshot: ConfigSnapshot = Object.freeze({
+    ...baseSnapshot,
+    agentPlugins: Object.freeze([binding]),
+  });
+  const store = new MutableFakeStore(snapshot);
+  const logged: Array<{ msg: string; fields?: Record<string, unknown> }> = [];
+  const registry = new OrchestratorRegistry(store as unknown as ConfigStore, deps(), {
+    defaultRuntimeConfig: { model: 'm', maxTokens: 100, maxToolIterations: 4 },
+    pluginLookup: { isMultiInstance: () => true, isInstalled: () => false },
+    log: (msg, fields) => logged.push({ msg, ...(fields ? { fields } : {}) }),
+  });
+
+  await registry.reload();
+  const publicBefore = registry.get('public')!.built.orchestrator;
+  const logCount = logged.length;
+  const plan = await registry.reload();
+
+  assert.equal(plan.actions.length, 0);
+  assert.equal(logged.length, logCount, 'an unchanged quarantine emits no log lines');
+  assert.equal(registry.get('public')!.built.orchestrator, publicBefore);
+  assert.equal(binding.enabled, true, 'even repeated quarantine never mutates the DB snapshot');
+  assert.equal(registry.get('public')!.plugins[0]!.enabled, false);
+  assert.deepEqual(
+    logged.filter((entry) => entry.msg === 'registry: plugin not installed — disabling binding'),
+    [{ msg: 'registry: plugin not installed — disabling binding', fields: { agentId: binding.agentId, pluginId: SEO_PLUGIN } }],
+  );
+  assert.deepEqual(
+    logged.filter((entry) => entry.msg === 'registry: quarantined unsatisfiable plugin binding(s)').map((entry) => entry.fields),
+    [{ newlyQuarantined: 1, noLongerQuarantined: 0, totalQuarantined: 1 }],
+  );
+});
+
+test('OM-95: a recovered plugin clears quarantine memory and a later disappearance logs again', async () => {
+  const snapshot: ConfigSnapshot = {
+    ...baseSnapshot,
+    agentPlugins: [pluginRow(baseSnapshot.agents[0]!.id, SEO_PLUGIN)],
+  };
+  const store = new MutableFakeStore(snapshot);
+  const logged: Array<{ msg: string; fields?: Record<string, unknown> }> = [];
+  let installed = false;
+  const registry = new OrchestratorRegistry(store as unknown as ConfigStore, deps(), {
+    defaultRuntimeConfig: { model: 'm', maxTokens: 100, maxToolIterations: 4 },
+    pluginLookup: { isMultiInstance: () => true, isInstalled: () => installed },
+    log: (msg, fields) => logged.push({ msg, ...(fields ? { fields } : {}) }),
+  });
+
+  await registry.start();
+  installed = true;
+  await registry.reload();
+  assert.equal(registry.get('public')!.plugins[0], snapshot.agentPlugins[0], 'recovery restores the untouched enabled row');
+  const recoveredLogCount = logged.length;
+  await registry.reload();
+  assert.equal(logged.length, recoveredLogCount, 'stable recovery is silent too');
+  installed = false;
+  await registry.reload();
+
+  assert.equal(registry.get('public')!.plugins[0]!.enabled, false);
+  assert.equal(logged.filter((entry) => entry.msg === 'registry: plugin not installed — disabling binding').length, 2);
+  assert.deepEqual(
+    logged.filter((entry) => entry.msg === 'registry: quarantined unsatisfiable plugin binding(s)').map((entry) => entry.fields),
+    [
+      { newlyQuarantined: 1, noLongerQuarantined: 0, totalQuarantined: 1 },
+      { newlyQuarantined: 0, noLongerQuarantined: 1, totalQuarantined: 0 },
+      { newlyQuarantined: 1, noLongerQuarantined: 0, totalQuarantined: 1 },
+    ],
+  );
+});
+
+test('OM-95: removed and explicitly disabled bindings leave quarantine memory', async () => {
+  for (const removed of [true, false]) {
+    const binding = pluginRow(baseSnapshot.agents[0]!.id, SEO_PLUGIN);
+    const snapshot: ConfigSnapshot = { ...baseSnapshot, agentPlugins: [binding] };
+    const store = new MutableFakeStore(snapshot);
+    const logged: Array<{ msg: string; fields?: Record<string, unknown> }> = [];
+    const registry = new OrchestratorRegistry(store as unknown as ConfigStore, deps(), {
+      defaultRuntimeConfig: { model: 'm', maxTokens: 100, maxToolIterations: 4 },
+      pluginLookup: { isMultiInstance: () => true, isInstalled: () => false },
+      log: (msg, fields) => logged.push({ msg, ...(fields ? { fields } : {}) }),
+    });
+
+    await registry.start();
+    store.set({ ...snapshot, agentPlugins: removed ? [] : [{ ...binding, enabled: false }] });
+    await registry.reload();
+    const clearedLogCount = logged.length;
+    await registry.reload();
+    assert.equal(logged.length, clearedLogCount, 'empty quarantine remains silent');
+    store.set(snapshot);
+    await registry.reload();
+
+    assert.equal(logged.filter((entry) => entry.msg === 'registry: plugin not installed — disabling binding').length, 2);
+    assert.deepEqual(
+      logged.filter((entry) => entry.msg === 'registry: quarantined unsatisfiable plugin binding(s)').map((entry) => entry.fields),
+      [
+        { newlyQuarantined: 1, noLongerQuarantined: 0, totalQuarantined: 1 },
+        { newlyQuarantined: 0, noLongerQuarantined: 1, totalQuarantined: 0 },
+        { newlyQuarantined: 1, noLongerQuarantined: 0, totalQuarantined: 1 },
+      ],
+    );
+  }
+});
+
+test('OM-95: losing the installation lookup clears quarantine memory without altering the snapshot', async () => {
+  for (const missingPluginLookup of [true, false]) {
+    const snapshot: ConfigSnapshot = {
+      ...baseSnapshot,
+      agentPlugins: [pluginRow(baseSnapshot.agents[0]!.id, SEO_PLUGIN)],
+    };
+    const store = new MutableFakeStore(snapshot);
+    const logged: string[] = [];
+    let lookup: PluginCapabilityLookup | undefined = {
+      isMultiInstance: () => true,
+      isInstalled: () => false,
+    };
+    const registry = new OrchestratorRegistry(store as unknown as ConfigStore, deps(), {
+      defaultRuntimeConfig: { model: 'm', maxTokens: 100, maxToolIterations: 4 },
+      get pluginLookup() { return lookup; },
+      log: (msg) => logged.push(msg),
+    });
+
+    await registry.start();
+    lookup = missingPluginLookup ? undefined : { isMultiInstance: () => true };
+    const quarantineLogCount = logged.filter((msg) => msg.includes('quarantined') || msg.includes('plugin not installed')).length;
+    await registry.reload();
+    assert.equal(registry.get('public')!.plugins[0], snapshot.agentPlugins[0]);
+    assert.equal(
+      logged.filter((msg) => msg.includes('quarantined') || msg.includes('plugin not installed')).length,
+      quarantineLogCount,
+      'missing lookup emits no quarantine logs',
+    );
+    lookup = { isMultiInstance: () => true, isInstalled: () => false };
+    await registry.reload();
+    assert.equal(logged.filter((msg) => msg === 'registry: plugin not installed — disabling binding').length, 2);
+  }
+});
+
+test('OM-95: tuple keys cannot collide and replacing quarantine members logs a change at the same total', async () => {
+  // These pairs collide with a NUL-delimited key despite being distinct bindings.
+  const first = pluginRow('a\0b', 'c');
+  const second = pluginRow('a', 'b\0c');
+  const snapshot: ConfigSnapshot = {
+    ...baseSnapshot,
+    agents: [agent('public', first.agentId), agent('general', second.agentId)],
+    agentPlugins: [first],
+  };
+  const store = new MutableFakeStore(snapshot);
+  const logged: Array<{ msg: string; fields?: Record<string, unknown> }> = [];
+  const registry = new OrchestratorRegistry(store as unknown as ConfigStore, deps(), {
+    defaultRuntimeConfig: { model: 'm', maxTokens: 100, maxToolIterations: 4 },
+    pluginLookup: { isMultiInstance: () => true, isInstalled: () => false },
+    log: (msg, fields) => logged.push({ msg, ...(fields ? { fields } : {}) }),
+  });
+
+  await registry.start();
+  store.set({ ...snapshot, agentPlugins: [second] });
+  await registry.reload();
+
+  assert.deepEqual(
+    logged.filter((entry) => entry.msg === 'registry: plugin not installed — disabling binding').map((entry) => entry.fields),
+    [
+      { agentId: first.agentId, pluginId: first.pluginId },
+      { agentId: second.agentId, pluginId: second.pluginId },
+    ],
+  );
+  assert.deepEqual(
+    logged.filter((entry) => entry.msg === 'registry: quarantined unsatisfiable plugin binding(s)').map((entry) => entry.fields),
+    [
+      { newlyQuarantined: 1, noLongerQuarantined: 0, totalQuarantined: 1 },
+      { newlyQuarantined: 1, noLongerQuarantined: 1, totalQuarantined: 1 },
+    ],
+  );
+});
+
+test('OM-95: quarantine tracking belongs to each registry instance', async () => {
+  const snapshot: ConfigSnapshot = {
+    ...baseSnapshot,
+    agentPlugins: [pluginRow(baseSnapshot.agents[0]!.id, SEO_PLUGIN)],
+  };
+  const store = new MutableFakeStore(snapshot);
+  const firstLogs: string[] = [];
+  const secondLogs: string[] = [];
+  const options = {
+    defaultRuntimeConfig: { model: 'm', maxTokens: 100, maxToolIterations: 4 },
+    pluginLookup: { isMultiInstance: () => true, isInstalled: () => false },
+  };
+  const first = new OrchestratorRegistry(store as unknown as ConfigStore, deps(), {
+    ...options,
+    log: (msg) => firstLogs.push(msg),
+  });
+  const second = new OrchestratorRegistry(store as unknown as ConfigStore, deps(), {
+    ...options,
+    log: (msg) => secondLogs.push(msg),
+  });
+
+  await first.start();
+  await second.start();
+  await first.reload();
+  await second.reload();
+
+  for (const logged of [firstLogs, secondLogs]) {
+    assert.equal(logged.filter((msg) => msg === 'registry: plugin not installed — disabling binding').length, 1);
+    assert.equal(logged.filter((msg) => msg === 'registry: quarantined unsatisfiable plugin binding(s)').length, 1);
+  }
 });
 
 test('T022: a throw inside one Agent\'s rebuild does NOT abort the rest of the diff', async () => {

--- a/middleware/test/pluginContextScratchPermissions.test.ts
+++ b/middleware/test/pluginContextScratchPermissions.test.ts
@@ -1,0 +1,155 @@
+/** OM-89: exercise the manifest gate through the context handed to activate(). */
+import { strict as assert } from 'node:assert';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+
+import { adaptManifestV1 } from '../src/plugins/manifestLoader.js';
+import type { PluginCatalog, PluginCatalogEntry } from '../src/plugins/manifestLoader.js';
+import { createPluginContext } from '../src/platform/pluginContext.js';
+import type { CreatePluginContextOptions } from '../src/platform/pluginContext.js';
+import { SCRATCH_DIR } from '../src/platform/paths.js';
+import { ServiceRegistry } from '../src/platform/serviceRegistry.js';
+
+const PLUGIN_ID = 'de.byte5.integration.scratch-permissions-test';
+
+function contextFor(fields: Readonly<Record<string, unknown>>): ReturnType<typeof createPluginContext> {
+  const manifest = {
+    schema_version: '1',
+    identity: {
+      id: PLUGIN_ID,
+      kind: 'integration',
+      domain: 'test',
+      name: 'Scratch Permissions Test',
+      version: '1.0.0',
+    },
+    ...fields,
+  };
+  const plugin = adaptManifestV1(manifest);
+  assert.ok(plugin);
+  const entry: PluginCatalogEntry = {
+    plugin,
+    manifest,
+    source_path: `/abs/${plugin.id}/manifest.yaml`,
+    source_kind: 'manifest-v1',
+    origin: 'installed',
+  };
+  const catalog = {
+    list: () => [entry],
+    get: (id: string) => (id === plugin.id ? entry : undefined),
+  } as unknown as PluginCatalog;
+
+  // Keep the activation harness aligned with manifestRetiredPermissionKey:
+  // only the manifest is real; unrelated providers cannot enable scratch.
+  return createPluginContext({
+    agentId: PLUGIN_ID,
+    vault: {
+      get: async () => undefined,
+      listKeys: async () => [],
+    } as unknown as CreatePluginContextOptions['vault'],
+    registry: {
+      has: () => true,
+      list: () => [],
+      get: () => undefined,
+    } as unknown as CreatePluginContextOptions['registry'],
+    catalog,
+    serviceRegistry: new ServiceRegistry(),
+    nativeToolRegistry: {
+      register: () => () => {},
+      registerHandler: () => () => {},
+    } as unknown as CreatePluginContextOptions['nativeToolRegistry'],
+    routeRegistry: {
+      register: () => () => {},
+      list: () => [],
+      disposeBySource: () => 0,
+    } as unknown as CreatePluginContextOptions['routeRegistry'],
+    jobScheduler: {
+      register: () => () => {},
+      stopForPlugin: () => {},
+    } as unknown as CreatePluginContextOptions['jobScheduler'],
+    notificationRouter: {
+      dispatch: () => {},
+      registerChannel: () => () => {},
+    } as unknown as CreatePluginContextOptions['notificationRouter'],
+    uiRouteCatalog: {
+      register: () => () => {},
+      registerNav: () => () => {},
+    } as unknown as CreatePluginContextOptions['uiRouteCatalog'],
+    logger: () => {},
+  } satisfies CreatePluginContextOptions);
+}
+
+describe('OM-89: scratch permissions reach the activation context', () => {
+  it('publishes a working, lazily-created ctx.scratch for permissions.filesystem.scratch: true', async (t) => {
+    const mkdir = t.mock.method(fs, 'mkdir', async () => undefined);
+    try {
+      const ctx = contextFor({ permissions: { filesystem: { scratch: true } } });
+      assert.ok(ctx.scratch, 'the canonical manifest must publish ctx.scratch');
+      assert.equal(mkdir.mock.callCount(), 0, 'context construction remains lazy');
+      const expected = path.join(SCRATCH_DIR, PLUGIN_ID);
+      assert.equal(await ctx.scratch.path(), expected);
+      assert.equal(await ctx.scratch.path(), expected);
+      assert.equal(mkdir.mock.callCount(), 1, 'the directory is ensured once');
+      assert.deepEqual(mkdir.mock.calls[0]?.arguments, [
+        expected,
+        { recursive: true, mode: 0o700 },
+      ]);
+    } finally {
+      mkdir.mock.restore();
+    }
+  });
+
+  const disabledCases: ReadonlyArray<{
+    name: string;
+    fields: Readonly<Record<string, unknown>>;
+  }> = [
+    { name: 'explicit false', fields: { permissions: { filesystem: { scratch: false } } } },
+    { name: 'filesystem block absent', fields: { permissions: {} } },
+    { name: 'whole permissions block absent', fields: {} },
+    { name: 'scratch absent', fields: { permissions: { filesystem: {} } } },
+    { name: 'string scratch', fields: { permissions: { filesystem: { scratch: 'true' } } } },
+    { name: 'numeric scratch', fields: { permissions: { filesystem: { scratch: 1 } } } },
+    { name: 'null scratch', fields: { permissions: { filesystem: { scratch: null } } } },
+    { name: 'null filesystem', fields: { permissions: { filesystem: null } } },
+    { name: 'array filesystem', fields: { permissions: { filesystem: [] } } },
+    { name: 'primitive filesystem', fields: { permissions: { filesystem: true } } },
+    { name: 'null permissions', fields: { permissions: null } },
+    { name: 'array permissions', fields: { permissions: [] } },
+    { name: 'primitive permissions', fields: { permissions: true } },
+    { name: 'legacy false', fields: { filesystem: { scratch: false } } },
+    { name: 'legacy scratch absent', fields: { filesystem: {} } },
+    { name: 'legacy nonboolean scratch', fields: { filesystem: { scratch: 'true' } } },
+  ];
+  for (const { name, fields } of disabledCases) {
+    it(`leaves ctx.scratch absent for ${name}`, () => {
+      const ctx = contextFor(fields);
+      assert.equal(ctx.scratch, undefined);
+      assert.equal(Object.hasOwn(ctx, 'scratch'), false);
+      assert.equal(ctx.agentId, PLUGIN_ID, 'a denied scratch gate still activates');
+    });
+  }
+
+  it('tolerates the legacy top-level filesystem.scratch: true declaration', () => {
+    assert.ok(contextFor({ filesystem: { scratch: true } }).scratch);
+  });
+
+  it('tolerates legacy scratch alongside unrelated canonical permissions', () => {
+    assert.ok(contextFor({ permissions: { flows: true }, filesystem: { scratch: true } }).scratch);
+  });
+
+  it('prefers canonical true over legacy false', () => {
+    assert.ok(contextFor({
+      permissions: { filesystem: { scratch: true } },
+      filesystem: { scratch: false },
+    }).scratch);
+  });
+
+  for (const filesystem of [{ scratch: false }, {}, { scratch: 'true' }, null, []]) {
+    it(`does not let legacy true override canonical ${JSON.stringify(filesystem)}`, () => {
+      assert.equal(contextFor({
+        permissions: { filesystem },
+        filesystem: { scratch: true },
+      }).scratch, undefined);
+    });
+  }
+});

--- a/middleware/test/pluginTemplates.test.ts
+++ b/middleware/test/pluginTemplates.test.ts
@@ -8,7 +8,11 @@ import type { TemplateManifest } from '@omadia/conductor-core';
 
 import type { Plugin } from '../src/api/admin-v1.js';
 import { InstallService } from '../src/plugins/installService.js';
-import type { InstalledAgent, InstalledRegistry } from '../src/plugins/installedRegistry.js';
+import {
+  blockActivation,
+  type InstalledAgent,
+  type InstalledRegistry,
+} from '../src/plugins/installedRegistry.js';
 import { extractTemplateDeclarations } from '../src/plugins/manifestLoader.js';
 import type { PluginCatalog } from '../src/plugins/manifestLoader.js';
 import { loadPluginTemplates, registerInstalledPluginTemplates } from '../src/plugins/pluginTemplates.js';
@@ -109,9 +113,9 @@ describe('loadPluginTemplates — the strict install gate', () => {
     const result = await loadPluginTemplates(PLUGIN_ID, root, ['templates/bad.json']);
     assert.equal(result.manifests.length, 0);
     assert.equal(result.errors.length, 1);
-    assert.ok(result.errors[0]!.includes('template_concrete_ref_in_strict_mode'), result.errors[0]);
+    assert.ok(result.errors[0]!.includes('template_concrete_ref_in_strict_mode'), result.errors[0]!);
     // the now-unused declared slot is flagged too (bidirectional coverage)
-    assert.ok(result.errors[0]!.includes('template_unused_slot'), result.errors[0]);
+    assert.ok(result.errors[0]!.includes('template_unused_slot'), result.errors[0]!);
   });
 
   it("rejects ids that are not namespaced 'plugin:<pluginId>:<name>' (no shadowing of bundled/user ids)", async () => {
@@ -132,13 +136,13 @@ describe('loadPluginTemplates — the strict install gate', () => {
     await writeFile(path.join(root, '..', 'outside.json'), JSON.stringify(strictManifest()), 'utf8');
     const traversal = await loadPluginTemplates(PLUGIN_ID, root, ['../outside.json']);
     assert.equal(traversal.manifests.length, 0);
-    assert.ok(traversal.errors[0]!.includes('outside the package root'), traversal.errors[0]);
+    assert.ok(traversal.errors[0]!.includes('outside the package root'), traversal.errors[0]!);
 
     // A confined-LOOKING declared path whose file is a symlink pointing outside.
     await symlink(path.join(root, '..', 'outside.json'), path.join(root, 'templates', 'sneaky.json'));
     const sneaky = await loadPluginTemplates(PLUGIN_ID, root, ['templates/sneaky.json']);
     assert.equal(sneaky.manifests.length, 0);
-    assert.ok(sneaky.errors[0]!.includes('outside the package root'), sneaky.errors[0]);
+    assert.ok(sneaky.errors[0]!.includes('outside the package root'), sneaky.errors[0]!);
   });
 
   it('rejects non-.json declarations, unreadable files, invalid JSON, and duplicate ids', async () => {
@@ -169,7 +173,7 @@ describe('loadPluginTemplates — the strict install gate', () => {
     const root = await makePackage({ 'templates/cron.json': JSON.stringify(manifest) });
     const result = await loadPluginTemplates(PLUGIN_ID, root, ['templates/cron.json']);
     assert.equal(result.manifests.length, 0);
-    assert.ok(result.errors[0]!.includes('invalid cron expression'), result.errors[0]);
+    assert.ok(result.errors[0]!.includes('invalid cron expression'), result.errors[0]!);
   });
 });
 
@@ -181,6 +185,8 @@ function makePlugin(id: string): Plugin {
   return {
     id,
     kind: 'tool',
+    multi_instance: false,
+    privacy_class: 'default',
     name: id,
     version: '0.1.0',
     latest_version: '0.1.0',
@@ -227,13 +233,19 @@ function makeRegistry(): InstalledRegistry {
   const map = new Map<string, InstalledAgent>();
   return {
     list: () => Array.from(map.values()),
-    get: (id) => map.get(id),
-    has: (id) => map.has(id),
-    register: async (entry) => {
+    get: (id: string) => map.get(id),
+    has: (id: string) => map.has(id),
+    register: async (entry: InstalledAgent) => {
       map.set(entry.id, entry);
     },
-    remove: async (id) => {
+    remove: async (id: string) => {
       map.delete(id);
+    },
+    markActivationBlocked: async (id: string, error: string) => {
+      const current = map.get(id);
+      if (current) {
+        map.set(id, blockActivation(current, error, new Date().toISOString()));
+      }
     },
     markActivationFailed: async () => undefined,
     markActivationSucceeded: async () => undefined,

--- a/middleware/test/registryInstallMerge.test.ts
+++ b/middleware/test/registryInstallMerge.test.ts
@@ -10,7 +10,7 @@ import { createStoreRouter } from '../src/routes/store.js';
 import { createRegistryInstallRouter } from '../src/routes/registryInstall.js';
 import type { Plugin } from '../src/api/admin-v1.js';
 import type { PluginCatalog } from '../src/plugins/manifestLoader.js';
-import type { InstalledRegistry } from '../src/plugins/installedRegistry.js';
+import { InMemoryInstalledRegistry, type InstalledRegistry } from '../src/plugins/installedRegistry.js';
 import type {
   PackageUploadService,
   IngestInput,
@@ -110,6 +110,8 @@ function fakeCatalog(plugins: Plugin[]): PluginCatalog {
 }
 
 const fakeRegistry = {
+  // Empty fixture: every id is absent, so blocking is a no-op.
+  markActivationBlocked: async () => undefined,
   has: () => false,
   get: () => undefined,
   // `list()` is not optional on InstalledRegistry — the `as unknown as` cast
@@ -358,21 +360,17 @@ describe('store router · setup_guide flows from the registry manifest_summary',
 // --- C6: update detection --------------------------------------------------
 
 function fakeInstalled(map: Record<string, string>): InstalledRegistry {
-  return {
-    has: (id: string) => id in map,
-    get: (id: string) =>
-      id in map ? { id, installed_version: map[id]! } : undefined,
-    // See the note on `fakeRegistry` above: `list()` is required by the
-    // interface, and the store's already-provided check (#671) calls it.
-    // These entries are `status: 'active'` so the projection matches what a
-    // real registry would report for an installed plugin.
-    list: () =>
-      Object.entries(map).map(([id, version]) => ({
-        id,
-        installed_version: version,
-        status: 'active',
-      })),
-  } as unknown as InstalledRegistry;
+  const registry = new InMemoryInstalledRegistry();
+  for (const [id, installed_version] of Object.entries(map)) {
+    void registry.register({
+      id,
+      installed_version,
+      installed_at: '2026-09-10T00:00:00Z',
+      status: 'active',
+      config: {},
+    });
+  }
+  return registry;
 }
 
 function indexWith(id: string, latest: string): string {

--- a/middleware/test/registrySetupProfile.test.ts
+++ b/middleware/test/registrySetupProfile.test.ts
@@ -74,6 +74,8 @@ const emptyCatalog = {
 } as unknown as PluginCatalog;
 
 const fakeRegistry = {
+  // Empty fixture: every id is absent, so blocking is a no-op.
+  markActivationBlocked: async () => undefined,
   has: () => false,
   get: () => undefined,
 } as unknown as InstalledRegistry;

--- a/middleware/test/teamsBotsConfigSync.test.ts
+++ b/middleware/test/teamsBotsConfigSync.test.ts
@@ -382,6 +382,7 @@ describe('syncTeamsBotConfig', () => {
     // widest interleaving window a real, async registry could open.
     const slow: InstalledRegistry = {
       ...registry,
+      markActivationBlocked: (id, error) => registry.markActivationBlocked(id, error),
       get: (id) => registry.get(id),
       updateConfig: async (id, config) => {
         await new Promise((resolve) => setTimeout(resolve, 5));

--- a/middleware/test/toolPluginRuntimeDuplicateProvider.test.ts
+++ b/middleware/test/toolPluginRuntimeDuplicateProvider.test.ts
@@ -1,0 +1,346 @@
+import { strict as assert } from 'node:assert';
+import { mkdtemp, mkdir, rm, utimes, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, type TestContext } from 'node:test';
+
+import { ServiceRegistry } from '../src/platform/serviceRegistry.js';
+import { UiRouteCatalog } from '../src/platform/uiRouteCatalog.js';
+import {
+  retryErroredPlugins,
+  type RetryErroredPluginsDeps,
+} from '../src/plugins/bootstrap.js';
+import {
+  CIRCUIT_BREAKER_THRESHOLD,
+  InMemoryInstalledRegistry,
+  type InstalledRegistry,
+} from '../src/plugins/installedRegistry.js';
+import {
+  adaptManifestV1,
+  type PluginCatalog,
+  type PluginCatalogEntry,
+} from '../src/plugins/manifestLoader.js';
+import {
+  ToolPluginRuntime,
+  type ToolPluginRuntimeDeps,
+} from '../src/plugins/toolPluginRuntime.js';
+import { newTestRouteRegistry } from './_helpers/routeRegistry.js';
+
+const OLDER = '@test/older-provider';
+const YOUNGER = '@test/younger-provider';
+const CONSUMER = '@test/consumer';
+const DUPLICATE_MESSAGE =
+  `capability 'fooClient@1' is also provided by '${OLDER}' — uninstall one`;
+
+type FailureCall = Parameters<InstalledRegistry['markActivationFailed']>;
+type BlockCall = Parameters<InstalledRegistry['markActivationBlocked']>;
+
+class RecordingInstalledRegistry extends InMemoryInstalledRegistry {
+  readonly failureCalls: FailureCall[] = [];
+  readonly blockCalls: BlockCall[] = [];
+
+  constructor(private readonly writeFailure?: unknown) {
+    super();
+  }
+
+  override async markActivationFailed(...args: FailureCall): Promise<void> {
+    this.failureCalls.push(args);
+    if (this.writeFailure !== undefined) throw this.writeFailure;
+    await super.markActivationFailed(...args);
+  }
+
+  override async markActivationBlocked(...args: BlockCall): Promise<void> {
+    this.blockCalls.push(args);
+    if (this.writeFailure !== undefined) throw this.writeFailure;
+    await super.markActivationBlocked(...args);
+  }
+}
+
+interface RuntimeHarness {
+  readonly runtime: ToolPluginRuntime;
+  readonly registry: RecordingInstalledRegistry;
+  readonly serviceRegistry: ServiceRegistry;
+  readonly activated: string[];
+  readonly logs: string[];
+  readonly retryDeps: RetryErroredPluginsDeps;
+}
+
+/**
+ * OM-87 / #1053 — reuse the on-disk package + adapted manifest harness from
+ * toolPluginRuntimeHandoff.pg.test.ts. A mocked activate() would only prove
+ * selection: real providers and a real consumer prove that boot still wires
+ * the surviving service before the consumer reads it.
+ */
+async function makeRuntime(
+  t: TestContext,
+  options: {
+    readonly writeFailure?: unknown;
+    readonly previousFailureCount?: number;
+    readonly pluginIds?: readonly string[];
+    readonly activationError?: string;
+  } = {},
+): Promise<RuntimeHarness> {
+  const root = await mkdtemp(join(tmpdir(), 'om87-runtime-'));
+  t.after(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+  const registry = new RecordingInstalledRegistry(options.writeFailure);
+  const entries = new Map<string, PluginCatalogEntry>();
+  const packages = new Map<string, { readonly id: string; readonly path: string }>();
+  // Put both the consumer and the younger provider first. Package-store
+  // enumeration must not overrule installation age or the dependency edge.
+  for (const id of options.pluginIds ?? [CONSUMER, YOUNGER, OLDER]) {
+    const packagePath = join(root, id.slice('@test/'.length));
+    await mkdir(packagePath);
+    const manifest = {
+      schema_version: '1',
+      identity: {
+        id,
+        name: id,
+        version: '1.0.0',
+        kind: 'tool',
+        domain: 'test.duplicate',
+      },
+      lifecycle: { entry: 'plugin.ts' },
+      provides: [id === CONSUMER ? 'consumerResult@1' : 'fooClient@1'],
+      requires: id === CONSUMER ? ['fooClient@^1'] : [],
+    };
+    const plugin = adaptManifestV1(manifest);
+    assert.ok(plugin, 'fixture manifest must adapt');
+    entries.set(id, {
+      plugin,
+      manifest,
+      source_path: packagePath,
+      source_kind: 'manifest-v1',
+      origin: 'installed',
+    });
+    packages.set(id, { id, path: packagePath });
+    const body = id === CONSUMER
+      ? `const provider = ctx.services.get<{ providerId: string }>('fooClient');
+         if (!provider) throw new Error('fooClient was not activated first');
+         const dispose = ctx.services.provide('consumerResult', provider);`
+      : `const dispose = ctx.services.provide('fooClient', { providerId: '${id}' });`;
+    const activationBody = options.activationError
+      ? `throw new Error(${JSON.stringify(options.activationError)});`
+      : `${body}
+         return { close: async (): Promise<void> => { dispose(); } };`;
+    await writeFile(
+      join(packagePath, 'plugin.ts'),
+      `import type { PluginContext } from '@omadia/plugin-api';
+       export async function activate(ctx: PluginContext): Promise<{ close(): Promise<void> }> {
+         ${activationBody}
+       }
+      `,
+      'utf8',
+    );
+    await registry.register({
+      id,
+      installed_version: '1.0.0',
+      installed_at: id === OLDER ? '2026-08-01T00:00:00Z' : '2026-09-01T00:00:00Z',
+      status: 'active',
+      config: {},
+      ...(id === YOUNGER ? {
+        activation_failure_count: options.previousFailureCount ?? 0,
+        // Prove that the duplicate path clears stale requires metadata, so
+        // bootstrap cannot auto-retry this conflict as a repaired dependency.
+        unresolved_requires: ['obsoleteClient@1'],
+      } : {}),
+    });
+  }
+
+  const catalog = {
+    get: (id: string): PluginCatalogEntry | undefined => entries.get(id),
+    list: (): PluginCatalogEntry[] => [...entries.values()],
+  } as unknown as PluginCatalog;
+  const serviceRegistry = new ServiceRegistry();
+  const activated: string[] = [];
+  const logs: string[] = [];
+  const stub = (): (() => void) => (): void => {};
+  const deps = {
+    catalog,
+    registry,
+    vault: {
+      get: async (): Promise<undefined> => undefined,
+      listKeys: async (): Promise<string[]> => [],
+    },
+    uploadedStore: {
+      get: (id: string) => packages.get(id),
+      list: () => [...packages.values()],
+    },
+    serviceRegistry,
+    nativeToolRegistry: { register: stub, registerHandler: stub },
+    pluginRouteRegistry: newTestRouteRegistry(),
+    notificationRouter: { dispatch: (): void => {}, registerChannel: stub },
+    uiRouteCatalog: new UiRouteCatalog(),
+    jobScheduler: { register: stub, stopForPlugin: (): void => {} },
+    onActivated: (entry: PluginCatalogEntry): void => {
+      activated.push(entry.plugin.id);
+    },
+    log: (msg: string): void => {
+      logs.push(msg);
+    },
+  } as unknown as ToolPluginRuntimeDeps;
+  return {
+    runtime: new ToolPluginRuntime(deps),
+    registry,
+    serviceRegistry,
+    activated,
+    logs,
+    retryDeps: { catalog, registry, uploadedStore: deps.uploadedStore, log: deps.log },
+  };
+}
+
+function assertSurvivingActivation(harness: RuntimeHarness): void {
+  assert.deepEqual(harness.activated, [OLDER, CONSUMER]);
+  assert.deepEqual(harness.serviceRegistry.get('fooClient'), { providerId: OLDER });
+  assert.deepEqual(harness.serviceRegistry.get('consumerResult'), { providerId: OLDER });
+  assert.deepEqual(harness.registry.blockCalls, [[YOUNGER, DUPLICATE_MESSAGE]],
+    'duplicate failure must use the terminal path without a requires-array');
+  assert.deepEqual(harness.registry.failureCalls, [],
+    'deterministic conflicts must not consume transient retries');
+  assert.deepEqual(
+    harness.logs.filter((line) => line.includes('not activated')),
+    [`[tool-runtime] ${YOUNGER} not activated — ${DUPLICATE_MESSAGE}`],
+  );
+}
+
+describe('ToolPluginRuntime.activateAllInstalled — duplicate providers (OM-87)', () => {
+  it('errors the younger provider on the first boot while the older provider and consumer activate', async (t) => {
+    const harness = await makeRuntime(t);
+    await assert.doesNotReject(harness.runtime.activateAllInstalled());
+
+    assertSurvivingActivation(harness);
+    const younger = harness.registry.get(YOUNGER);
+    assert.ok(younger);
+    assert.equal(younger.last_activation_error, DUPLICATE_MESSAGE);
+    assert.equal(younger.activation_failure_count, CIRCUIT_BREAKER_THRESHOLD);
+    assert.equal(younger.unresolved_requires, undefined);
+    assert.equal(Object.hasOwn(younger, 'unresolved_requires'), false);
+    assert.equal(younger.status, 'errored');
+    assert.ok(younger.last_activation_error_at);
+    assert.equal(harness.registry.get(OLDER)?.status, 'active');
+    assert.ok(harness.registry.get(OLDER)?.last_activated_at);
+  });
+
+  it('immediately blocks a duplicate that already has transient failures', async (t) => {
+    const harness = await makeRuntime(t, {
+      previousFailureCount: CIRCUIT_BREAKER_THRESHOLD - 1,
+    });
+    await assert.doesNotReject(harness.runtime.activateAllInstalled());
+
+    assertSurvivingActivation(harness);
+    assert.equal(harness.registry.get(YOUNGER)?.status, 'errored');
+    assert.equal(harness.registry.get(YOUNGER)?.activation_failure_count, CIRCUIT_BREAKER_THRESHOLD);
+    assert.equal(harness.registry.get(YOUNGER)?.unresolved_requires, undefined);
+  });
+
+  it('re-blocks a duplicate after a file-mtime reset and leaves it errored on the next retry pass', async (t) => {
+    const harness = await makeRuntime(t);
+    await harness.runtime.activateAllInstalled();
+    const younger = harness.registry.get(YOUNGER);
+    assert.ok(younger);
+    assert.equal(younger.status, 'errored');
+
+    // No pending requires means the surviving provider cannot auto-reset a
+    // deterministic provides conflict as if it were a repaired dependency.
+    await retryErroredPlugins(harness.retryDeps);
+    assert.equal(harness.registry.get(YOUNGER)?.status, 'errored');
+
+    // Age the original error and manifest to deterministic dates; the real
+    // fs.stat path must observe a manifest touch later than that first error.
+    await harness.registry.register({ ...younger, last_activation_error_at: '2000-01-01T00:00:00.000Z' });
+    const pkg = harness.retryDeps.uploadedStore?.get(YOUNGER);
+    assert.ok(pkg);
+    const manifestPath = join(pkg.path, 'manifest.yaml');
+    await writeFile(manifestPath, 'schema_version: "1"\n', 'utf8');
+    const mtime = new Date('2001-01-01T00:00:00.000Z');
+    await utimes(manifestPath, mtime, mtime);
+
+    await retryErroredPlugins(harness.retryDeps);
+    assert.equal(harness.registry.get(YOUNGER)?.status, 'active');
+    assert.equal(harness.registry.get(YOUNGER)?.activation_failure_count, undefined);
+    assert.equal(harness.registry.get(YOUNGER)?.last_activation_error_at, undefined);
+
+    await assert.doesNotReject(harness.runtime.activateAllInstalled());
+    const blockedAgain = harness.registry.get(YOUNGER);
+    assert.ok(blockedAgain);
+    assert.equal(blockedAgain.status, 'errored');
+    assert.equal(blockedAgain.activation_failure_count, CIRCUIT_BREAKER_THRESHOLD);
+    assert.equal(blockedAgain.unresolved_requires, undefined);
+    assert.equal(blockedAgain.last_activation_error, DUPLICATE_MESSAGE);
+    assert.ok(blockedAgain.last_activation_error_at && blockedAgain.last_activation_error_at > mtime.toISOString());
+    assert.deepEqual(harness.registry.blockCalls, [
+      [YOUNGER, DUPLICATE_MESSAGE],
+      [YOUNGER, DUPLICATE_MESSAGE],
+    ]);
+    assert.deepEqual(harness.registry.failureCalls, []);
+    assert.equal(harness.registry.get(OLDER)?.status, 'active');
+    assert.deepEqual(harness.activated, [OLDER, CONSUMER]);
+
+    await retryErroredPlugins(harness.retryDeps);
+    assert.deepEqual(harness.registry.get(YOUNGER), blockedAgain,
+      'the refreshed error timestamp prevents another reset for the same manifest touch');
+  });
+
+  it('keeps ordinary activate() throws on the counted circuit-breaker path', async (t) => {
+    const activationError = 'ECONNREFUSED: provider dependency unavailable';
+    const harness = await makeRuntime(t, { pluginIds: [OLDER], activationError });
+
+    for (let attempt = 1; attempt <= CIRCUIT_BREAKER_THRESHOLD; attempt += 1) {
+      await assert.doesNotReject(harness.runtime.activateAllInstalled());
+      const entry = harness.registry.get(OLDER);
+      assert.ok(entry);
+      assert.equal(entry.status, attempt < CIRCUIT_BREAKER_THRESHOLD ? 'active' : 'errored');
+      assert.equal(entry.activation_failure_count, attempt);
+      assert.equal(entry.last_activation_error, activationError);
+      assert.equal(entry.unresolved_requires, undefined);
+      assert.equal(harness.registry.failureCalls.length, attempt);
+      assert.deepEqual(harness.registry.failureCalls.at(-1), [OLDER, activationError]);
+      assert.deepEqual(harness.registry.blockCalls, []);
+    }
+
+    await harness.runtime.activateAllInstalled();
+    assert.equal(harness.registry.failureCalls.length, CIRCUIT_BREAKER_THRESHOLD,
+      'errored plugins are skipped until the retry policy resets them');
+    assert.deepEqual(harness.activated, []);
+  });
+
+  it('keeps unresolved requires persisted on the counted circuit-breaker path', async (t) => {
+    const harness = await makeRuntime(t, { pluginIds: [CONSUMER] });
+    const requires = ['fooClient@^1'];
+    const message = 'unresolved capability requires: fooClient@^1';
+
+    for (let attempt = 1; attempt <= CIRCUIT_BREAKER_THRESHOLD; attempt += 1) {
+      await assert.doesNotReject(harness.runtime.activateAllInstalled());
+      const entry = harness.registry.get(CONSUMER);
+      assert.ok(entry);
+      assert.equal(entry.status, attempt < CIRCUIT_BREAKER_THRESHOLD ? 'active' : 'errored');
+      assert.equal(entry.activation_failure_count, attempt);
+      assert.equal(entry.last_activation_error, message);
+      assert.deepEqual(entry.unresolved_requires, requires);
+      assert.equal(harness.registry.failureCalls.length, attempt);
+      assert.deepEqual(harness.registry.failureCalls.at(-1), [CONSUMER, message, requires]);
+      assert.deepEqual(harness.registry.blockCalls, []);
+    }
+
+    await harness.runtime.activateAllInstalled();
+    assert.equal(harness.registry.failureCalls.length, CIRCUIT_BREAKER_THRESHOLD);
+    assert.deepEqual(harness.registry.get(CONSUMER)?.unresolved_requires, requires);
+    assert.deepEqual(harness.activated, []);
+  });
+
+  for (const { label, failure } of [
+    { label: 'Error', failure: new Error('registry unavailable') },
+    { label: 'non-Error', failure: 'registry unavailable' },
+  ]) {
+    it(`continues activation and logs a registry-write failure (${label})`, async (t) => {
+      const harness = await makeRuntime(t, { writeFailure: failure });
+      await assert.doesNotReject(harness.runtime.activateAllInstalled());
+
+      assertSurvivingActivation(harness);
+      assert.ok(harness.logs.includes(
+        `[tool-runtime] registry markActivationBlocked FAILED for ${YOUNGER}: registry unavailable`,
+      ));
+    });
+  }
+});


### PR DESCRIPTION
Beta round 5 (Silvio Lange, TE Printline, 2026-09-10) — **Wave 1 boot robustness**. Follows the W0 hotfix (#1061). A plugin conflict must never take the kernel down again, and the startup log must be readable when it matters.

## OM-87 — duplicate capability provider killed the boot
- `capabilityResolver.ts` / `toolPluginRuntime.ts`: `onDuplicate: 'throw' | 'errored'`. On the boot path the **younger** provider is dropped into `duplicateProviders` and marked `errored`, the older one activates, the boot survives — the same shape as an unsatisfied `requires`.
- `bootstrap.ts`: the generic `findActiveProviderCollision` is documented as the safety net, the KG/memoryStore skip-lists as opt-in policy (comment-only; behaviour unchanged).
- `installedRegistry.ts` / `fileInstalledRegistry.ts`: `markActivationBlocked` → `errored` on first boot (a deterministic conflict is not a retryable failure), never writes `unresolved_requires`.

## OM-88 — 90 s wait on a kernel that had already died
- `desktop/src/supervisor.ts`: `waitForHttp` races the child's exit; a crash surfaces in ~180 ms instead of 90 s, with the child's last fatal line as the reason. Generation-safe; listener released in `finally`.

## OM-89 — `permissions.filesystem` unknown to the core (48 warnings/boot)
- `manifestLoader.ts` / `platform/pluginContext.ts`: key recognised. **Latent bug found on the way:** `scratchEnabled` was read top-level while manifests declare it nested, so `ctx.scratch` never worked (scratch test: 7 failing before, 25 green after). Unknown-key warnings are aggregated once per catalog build.

## OM-93 — catalog warned about a missing optional directory
- Missing *optional* manifest dir → `debug`; an explicit `PLUGIN_MANIFEST_DIR` that is missing still warns; non-ENOENT still throws.

## OM-95 — orphaned plugin binding logged three lines a minute
- `harness-orchestrator/registry/{index,configStore}.ts`, `installService.ts`: quarantine logs only on state change; uninstall purges `agent_plugins`; reactivation deliberately does not.

## Verification
- middleware `tsc --noEmit`, `npm run lint`, plugin-api `api:check` snapshot: clean.
- middleware: 389/389 across the 32 touched suites; desktop typecheck + `typecheck:test` clean, 243/243 tests.
- No `web-ui/` changes (i18n rule N/A).

## Deliberately left open
- The four `registry.remove` sites in `bootstrap.ts` do not purge bindings yet (needs a `BootstrapDeps.onPluginRemoved` hook deferred until the orchestrator store exists) — documented in code on `purgePluginAgentBindings`. The log noise is gone; the leak is a follow-up.
- Low: `quarantineUnsatisfiablePlugins` records tracking state before `validateSnapshot`; a throw there could suppress a later first-time log (log-only).

Related: Runde-5-Befunde OM-87, OM-88, OM-89, OM-93, OM-95.

https://claude.ai/code/session_01J7sBWSEtQ4RnWAHxoD3Y2s

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/1063"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791640590&installation_model_id=428086&pr_number=1063&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F1063&signature=6d5925597502ac9259fdb63cf9c1ebf5ffcbe89103acb2f5b8e1ce5576901b81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->